### PR TITLE
Derive classes and names from `x` not `df`

### DIFF
--- a/R/glimpse.R
+++ b/R/glimpse.R
@@ -43,8 +43,8 @@ glimpse.tbl <- function(x, width = NULL, ...) {
   rows <- as.integer(width / 3)
   df <- as.data.frame(head(x, rows))
 
-  var_types <- vapply(df, type_sum, character(1))
-  var_names <- paste0("$ ", format(names(df)), " <", var_types, "> ")
+  var_types <- vapply(x, type_sum, character(1))
+  var_names <- paste0("$ ", format(names(x)), " <", var_types, "> ")
 
   data_width <- width - nchar(var_names) - 2
 

--- a/tests/testthat/test-type_sum.R
+++ b/tests/testthat/test-type_sum.R
@@ -1,0 +1,17 @@
+context("type_sum")
+
+SomeClass <- function (x) {
+  structure(x, class = "SomeClass")
+}
+
+type_sum.SomeClass <- function (x, ...) {
+  "SC"
+}
+
+test_that("works with glimpse", {
+
+  foo <- SomeClass(2011:2013)
+  expect_equal(type_sum(foo), "SC")
+  expect_output(glimpse(tibble(foo)), "foo <SC>")
+
+})

--- a/tests/testthat/test-type_sum.R
+++ b/tests/testthat/test-type_sum.R
@@ -4,9 +4,16 @@ SomeClass <- function (x) {
   structure(x, class = "SomeClass")
 }
 
-type_sum.SomeClass <- function (x, ...) {
-  "SC"
-}
+# Simply defining type_sum.SomeClass here
+# (or inside the following test_that block)
+# doesn't seem to work.
+#
+# So, let's assign it to .GlobalEnv and then
+# politely destroy it when we're done testing.
+#
+assign("type_sum.SomeClass",
+       function (x, ...) { "SC" },
+       .GlobalEnv)
 
 test_that("works with glimpse", {
 
@@ -14,4 +21,13 @@ test_that("works with glimpse", {
   expect_equal(type_sum(foo), "SC")
   expect_output(glimpse(tibble(foo)), "foo <SC>")
 
+})
+
+rm("type_sum.SomeClass",
+   envir = .GlobalEnv)
+
+test_that("teardown succeeded", {
+  expect_error(
+    get("type_sum.SomeClass"),
+    "object 'type_sum.SomeClass' not found")
 })


### PR DESCRIPTION
In `glimpse.tbl`, use of `as.data.frame` may drop classes from `x` when creating `df`. See #185
for reprex.

Fixes #185.