### PR TITLE
change depends to 3.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Authors@R: c(
 URL: https://github.com/tidyverse/tibble
 BugReports: https://github.com/tidyverse/tibble/issues
 Depends:
-    R (>= 3.1.2)
+    R (>= 3.1.0)
 Imports:
     methods,
     assertthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Authors@R: c(
 URL: https://github.com/tidyverse/tibble
 BugReports: https://github.com/tidyverse/tibble/issues
 Depends:
-    R (>= 3.1.0)
+    R (>= 3.0.0)
 Imports:
     methods,
     assertthat,

--- a/README.Rmd
+++ b/README.Rmd
@@ -72,7 +72,7 @@ flights
 Tibbles are strict about subsetting. If you try to access a variable that does not exist via `$`, you'll get a warning:
 
 ```{r, error = TRUE}
-flights$yea
+flights$year
 ```
 
 Tibbles also clearly delineate `[` and `[[`: `[` always returns another tibble, `[[` always returns a vector. No more `drop = FALSE`!


### PR DESCRIPTION
Tried basic `tibble` functionality with `3.1.0` and could not spot any issues. Also tried with `3.0.0` but it depends on `lazyeval` which requires `3.1.0` since it depends on this addition https://github.com/wch/r-source/commit/2e5fdefa0ef62f83ef5669242f71597d60945bf5 and therefore, supporting `3.0.0` would require additional work in `lazyeval`.

**NOTE**: Dependent on https://github.com/hadley/lazyeval/pull/87

Fixes #189.