### PR TITLE
Unicode multiplication sign ==> x

### DIFF
--- a/R/type-sum.r
+++ b/R/type-sum.r
@@ -106,9 +106,7 @@ dim_desc <- function(x) {
   dim <- dim(x) %||% length(x)
   format_dim <- vapply(dim, big_mark, character(1))
   format_dim[is.na(dim)] <- "??"
-  mult <- " \u00d7 " # unicode multiplication sign
-  if(enc2native(mult) != mult) mult <- " x " # lowercase x
-  paste0(format_dim, collapse = mult)
+  paste0(format_dim, collapse = mult_sign())
 }
 
 size_sum <- function(x) {

--- a/R/type-sum.r
+++ b/R/type-sum.r
@@ -106,7 +106,7 @@ dim_desc <- function(x) {
   dim <- dim(x) %||% length(x)
   format_dim <- vapply(dim, big_mark, character(1))
   format_dim[is.na(dim)] <- "??"
-  paste0(format_dim, collapse = " \u00d7 ")
+  paste0(format_dim, collapse = " x ")
 }
 
 size_sum <- function(x) {

--- a/R/type-sum.r
+++ b/R/type-sum.r
@@ -106,7 +106,9 @@ dim_desc <- function(x) {
   dim <- dim(x) %||% length(x)
   format_dim <- vapply(dim, big_mark, character(1))
   format_dim[is.na(dim)] <- "??"
-  paste0(format_dim, collapse = " x ")
+  mult <- " \u00d7 " # unicode multiplication sign
+  if(enc2native(mult) != mult) mult <- " x " # lowercase x
+  paste0(format_dim, collapse = mult)
 }
 
 size_sum <- function(x) {

--- a/R/utils-format.r
+++ b/R/utils-format.r
@@ -302,9 +302,13 @@ mult_sign <- function(with_spaces = TRUE) {
   # unicode multiplication sign
   mult <- "\u00d7"
   # if unicode doesn't render, use lowercase x
-  if(enc2native(mult) != mult) mult <- "x"
+  if (enc2native(mult) != mult) {
+    mult <- "x"
+  }
   # whitespace on either side?
-  if(with_spaces) mult <- paste0(" ", mult, " ")
+  if (with_spaces) {
+    mult <- paste0(" ", mult, " ")
+  }
 
   mult
 }

--- a/R/utils-format.r
+++ b/R/utils-format.r
@@ -298,6 +298,17 @@ pluralise <- function(message, objects) {
   message
 }
 
+mult_sign <- function(with_spaces = TRUE) {
+  # unicode multiplication sign
+  mult <- "\u00d7"
+  # if unicode doesn't render, use lowercase x
+  if(enc2native(mult) != mult) mult <- "x"
+  # whitespace on either side?
+  if(with_spaces) mult <- paste0(" ", mult, " ")
+
+  mult
+}
+
 format_n <- function(x) collapse(quote_n(x))
 
 quote_n <- function(x) UseMethod("quote_n")


### PR DESCRIPTION
Is it possible to replace `U+00D7` with `x` (lowercase letter x) in the standard tibble output? We use tbls in many of our courses on DataCamp, but unfortunately the unicode doesn't render properly so the output looks like this :(

![screenshot 2016-11-15 19 16 08](https://cloud.githubusercontent.com/assets/4229089/20330071/3e401942-ab6a-11e6-91ee-a48db95de0a1.png)