### PR TITLE
ignore options(max.print)

### DIFF
--- a/R/utils-format.r
+++ b/R/utils-format.r
@@ -149,6 +149,8 @@ print_summary <- function(x) {
 
 print_table <- function(x) {
   if (!is.null(x$table)) {
+    opt <- options(max.print = prod(dim(x$table)))
+    on.exit(options(max.print = opt$max.print), add = TRUE)
     print(x$table)
   }
 }

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -73,3 +73,10 @@ test_that("tibble_glimpse_width ignores Inf tibble.width", {
     expect_equal(tibble_glimpse_width(NULL), 20)
   )
 })
+
+test_that("print.tbl_df ignores max.print option", {
+  iris2 <- as_tibble(iris)
+  expect_output(
+    withr::with_options(list(max.print = 3), print(iris2)),
+    capture_output(print(iris2)), fixed = TRUE)
+})


### PR DESCRIPTION
Fixes #194.

Hows this?

Setting it higher in the call stack (`print.trunc_mat` or `print.tbl_df`) makes it take effect for the printing of the df summary and extra colnames, but it looks like those strings are collapsed before printing, so not this is not necessary there. 