### PR TITLE
`tribble` now handles columns with a class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.o
 src/*.o-*
+src-i386/
+src-x64/
 *.so
 *.dll
 .RData

--- a/R/tribble.R
+++ b/R/tribble.R
@@ -140,7 +140,7 @@ turn_matrix_into_column_list <- function(frame_mat) {
     if (some(col, needs_list_col) || !inherits(col, "list")) {
       frame_col[[i]] <- col
     } else {
-      frame_col[[i]] <- rlang::invoke(c, col)
+      frame_col[[i]] <- invoke(c, col)
     }
   }
   return(frame_col)

--- a/R/tribble.R
+++ b/R/tribble.R
@@ -137,12 +137,10 @@ turn_matrix_into_column_list <- function(frame_mat) {
   # if a frame_mat's col is a list column, keep it unchanged (does not unlist)
   for (i in seq_len(ncol(frame_mat))) {
     col <- frame_mat[, i]
-    if (some(col, needs_list_col)) {
+    if (some(col, needs_list_col) || !inherits(col, "list")) {
       frame_col[[i]] <- col
-    } else if (inherits(col, "list")){
+    } else {
       frame_col[[i]] <- rlang::invoke(c, col)
-    } else{
-      frame_col[[i]] <- col
     }
   }
   return(frame_col)

--- a/R/tribble.R
+++ b/R/tribble.R
@@ -139,8 +139,10 @@ turn_matrix_into_column_list <- function(frame_mat) {
     col <- frame_mat[, i]
     if (some(col, needs_list_col)) {
       frame_col[[i]] <- col
-    } else {
-      frame_col[[i]] <- unlist(col)
+    } else if (inherits(col, "list")){
+      frame_col[[i]] <- rlang::invoke(c, col)
+    } else{
+      frame_col[[i]] <- col
     }
   }
   return(frame_col)

--- a/tests/testthat/test-tribble.R
+++ b/tests/testthat/test-tribble.R
@@ -46,6 +46,23 @@ test_that("tribble() constructs 'tibble' as expected", {
 
 })
 
+test_that("tribble() handles columns with a class (#161)", {
+  sys_date <- Sys.Date()
+  sys_time <- Sys.time()
+  date_time_col <- tribble(
+    ~dt, ~dttm,
+    sys_date, sys_time,
+    as.Date("2003-01-02"), as.POSIXct("2004-04-05 13:45:17", tz = "UTC")
+  )
+
+  date_time_col_expectation <- tibble(
+    dt = c(sys_date, as.Date("2003-01-02")),
+    dttm = c(sys_time, as.POSIXct("2004-04-05 13:45:17", tz = "UTC"))
+  )
+
+  expect_equal(date_time_col, date_time_col_expectation)
+})
+
 test_that("tribble() creates lists for non-atomic inputs (#7)", {
   expect_identical(
     tribble(~a, ~b, NA, "A", letters, LETTERS[-1L]),


### PR DESCRIPTION
Fixes #161, and allows for syntax such as:

    tribble(~a,
            Sys.Date()
           )

Also updated NEWS, DESCRIPTION and
test-tribble accordingly.