### PR TITLE
Tribble conversion functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.o
 src/*.o-*
+src-i386/
+src-x64/
 *.so
 *.dll
 .RData

--- a/R/tribble.R
+++ b/R/tribble.R
@@ -161,8 +161,8 @@ call_contains_dot <- function(cur_call) {
 }
 
 extract_quosure <- function(el) {
-  candidate <- el[[2]]
-  if (!is.call(el[[3]]) && !identical(el[[3]], quote(.))) {
+  col_quosure <- expr_interp(el[-2])
+  if (!is.call(col_quosure[[2]]) && !identical(col_quosure[[2]], quote(.))) {
     stopc("conversion expressions should be specified as e.g. colA~factor(.)")
   }
   if (!is.character(el[[2]]) && !is_symbol(el[[2]])) {
@@ -171,16 +171,15 @@ extract_quosure <- function(el) {
               deparse(el))
     )
   }
-  col_quosure <- expr_interp(el[-2])
   if ((length(col_quosure[[2]]) == 1L &&
-      !identical(col_quosure[[2]], quote(.))) ||
+       !identical(col_quosure[[2]], quote(.))) ||
       (length(col_quosure[[2]]) > 1L &&
-      !call_contains_dot(col_quosure[[2]]))) {
+       !call_contains_dot(col_quosure[[2]]))) {
     stopc(
       sprintf(
         "conversion expression '%s' does not contain a `.` placeholder for data",
-              deparse(el))
-      )
+        deparse(el))
+    )
   }
   list(col_name = as.character(el[[2]]), col_quosure = col_quosure)
 }

--- a/R/tribble.R
+++ b/R/tribble.R
@@ -167,7 +167,7 @@ extract_quosure <- function(el) {
   }
   if (!is.character(el[[2]]) && !is_symbol(el[[2]])) {
     stopc(
-      sprintf("column name for '%s' should be a character or bare name",
+      sprintf("column name for '%s' should be a symbol or character",
               deparse(el))
     )
   }

--- a/R/tribble.R
+++ b/R/tribble.R
@@ -172,8 +172,9 @@ extract_quosure <- function(el) {
     )
   }
   col_quosure <- expr_interp(el[-2])
-  if (length(col_quosure[[2]]) == 1L ||
-      (!identical(col_quosure[[2]], quote(.)) &&
+  if ((length(col_quosure[[2]]) == 1L &&
+      !identical(col_quosure[[2]], quote(.))) ||
+      (length(col_quosure[[2]]) > 1L &&
       !call_contains_dot(col_quosure[[2]]))) {
     stopc(
       sprintf(

--- a/R/tribble.R
+++ b/R/tribble.R
@@ -171,16 +171,17 @@ extract_quosure <- function(el) {
               deparse(el))
     )
   }
-  if (length(el[[3]]) == 1L ||
-      (!identical(el[[3]], quote(.)) &&
-      !call_contains_dot(el[[3]]))) {
+  col_quosure <- expr_interp(el[-2])
+  if (length(col_quosure[[2]]) == 1L ||
+      (!identical(col_quosure[[2]], quote(.)) &&
+      !call_contains_dot(col_quosure[[2]]))) {
     stopc(
       sprintf(
         "conversion expression '%s' does not contain a `.` placeholder for data",
               deparse(el))
       )
   }
-  list(col_name = as.character(el[[2]]), col_quosure = expr_interp(el[-2]))
+  list(col_name = as.character(el[[2]]), col_quosure = col_quosure)
 }
 
 validate_rectangular_shape <- function(frame_names, frame_rest) {

--- a/R/tribble.R
+++ b/R/tribble.R
@@ -11,7 +11,7 @@
 #'   Variable names should be formulas, and may only appear before the data.
 #'   If a function needs to be applied to the data for a column (e.g. `factor`),
 #'   this should apear after the `~`, e.g. factor(column_A). Other arguments
-#'   cab be provided as needed.
+#'   can be provided as needed.
 #' @return A [tibble].
 #' @export
 #' @examples

--- a/R/tribble.R
+++ b/R/tribble.R
@@ -250,7 +250,7 @@ apply_quosures_to_frame_data <- function(data, quosures) {
         stopc(
           sprintf(
             "conversion '%s%s' returns %d items; expecting %d.",
-            deparse(as_symbol(names(data)[i]), backtick = TRUE),
+            deparse(as.symbol(names(data)[i]), backtick = TRUE),
             deparse(cur_quosure),
             length(res),
             length(data[[i]])

--- a/man/tribble.Rd
+++ b/man/tribble.Rd
@@ -10,9 +10,17 @@ tribble(...)
 \arguments{
 \item{...}{Arguments specifying the structure of a \code{tibble}.
 Variable names should be formulas, and may only appear before the data.
+
 If a function needs to be applied to the data for a column (e.g. \code{factor}),
-this should apear after the \code{~}, e.g. factor(column_A). Other arguments
-cab be provided as needed.}
+this should apear after the \code{~}, with the column name before,
+e.g. \code{colA~factor(.)}. \code{.} should be used as a placeholder for the data.
+Other arguments can be provided as needed, e.g.
+\code{colA~factor(., levels = C("A", "B")}.
+
+As with \link{tibble}, functions can refer back to earlier columns in the
+data. Conversions can include any valid expression, and are evaluated using
+\code{\link[rlang]{eval_tidy}} and so support splicing with
+\code{\link[rlang]{!!}}.}
 }
 \value{
 A \link{tibble}.
@@ -34,12 +42,27 @@ tribble(
   "c",   3
 )
 
-# Conversion functions can be supplied, including additional
+# Conversion expressions can be supplied, including additional
 # paremeters if needed.
 tribble(
-  ~colA, ~factor(colB, levels = c("B", "A")),
+  ~colA, colB~factor(., levels = c("B", "A")),
   "X",   "A",
-  "Y",   "B")
+  "Y",   "B"
+)
+
+# More complex conversion expressions are also possible
+
+ tribble(
+   colA~as.numeric(Sys.Date() - as.Date(.), unit = "days"),
+   "2015-01-02",
+   "2016-03-04"
+)
+
+# Conversion expressions must always include the placeholder `.`
+
+\dontrun{
+tribble(colA~factor(), 1)
+}
 
 # tribble will create a list column if the value in any cell is
 # not a scalar

--- a/man/tribble.Rd
+++ b/man/tribble.Rd
@@ -9,7 +9,10 @@ tribble(...)
 }
 \arguments{
 \item{...}{Arguments specifying the structure of a \code{tibble}.
-Variable names should be formulas, and may only appear before the data.}
+Variable names should be formulas, and may only appear before the data.
+If a function needs to be applied to the data for a column (e.g. \code{factor}),
+this should apear after the \code{~}, e.g. factor(column_A). Other arguments
+cab be provided as needed.}
 }
 \value{
 A \link{tibble}.
@@ -30,6 +33,13 @@ tribble(
   "b",   2,
   "c",   3
 )
+
+# Conversion functions can be supplied, including additional
+# paremeters if needed.
+tribble(
+  ~colA, ~factor(colB, levels = c("B", "A")),
+  "X",   "A",
+  "Y",   "B")
 
 # tribble will create a list column if the value in any cell is
 # not a scalar

--- a/tests/testthat/test-tribble.R
+++ b/tests/testthat/test-tribble.R
@@ -62,6 +62,8 @@ test_that("tribble() errs appropriately on bad calls", {
 
   # invalid colname syntax
   expect_error(tribble(a~b), "specified as e.g. colA~factor(.)")
+  expect_error(tribble(~a + b), "expected a symbol")
+  expect_error(tribble(a + b~factor(.), "should be a symbol"))
 
   # tribble() must be passed colnames
   expect_error(tribble(
@@ -78,6 +80,12 @@ test_that("tribble() errs appropriately on bad calls", {
 
   # tribble() expects . placeholder for conversion functions
   expect_error(tribble(colA~factor()), "`.` placeholder")
+  expect_error(
+    tribble(colA~Sys.Date - as.Date(), "2013-04-05"), "`.` placeholder"
+  )
+
+  # Conversion functions must return same length as data
+  expect_error(tribble(colA~mean(.), 1, 4), "items; expecting 2")
 })
 
 test_that("tribble supports conversion functions #149", {

--- a/tests/testthat/test-tribble.R
+++ b/tests/testthat/test-tribble.R
@@ -79,15 +79,17 @@ test_that("tribble() errs appropriately on bad calls", {
 })
 
 test_that("tribble supports conversion functions #149", {
+  sys_date <- Sys.Date()
   conversion <- tribble(
-    ~factor(colA), ~factor(colB, levels = c("B", "A")),
-    3, "A",
-    4, "B"
+    ~factor(colA), ~factor(colB, levels = c("B", "A")), ~asin(sqrt(arcsin_sqrt_prop)),
+    3, "A", 0.4,
+    4, "B", 0.3
   )
 
   conversion_expectation <- tibble(
     colA = factor(3:4),
-    colB = factor(c("A", "B"), levels = c("B", "A"))
+    colB = factor(c("A", "B"), levels = c("B", "A")),
+    arcsin_sqrt_prop = asin(sqrt(c(0.4, 0.3)))
   )
 
   expect_equal(conversion, conversion_expectation)

--- a/tests/testthat/test-tribble.R
+++ b/tests/testthat/test-tribble.R
@@ -61,7 +61,7 @@ test_that("tribble() creates lists for non-atomic inputs (#7)", {
 test_that("tribble() errs appropriately on bad calls", {
 
   # invalid colname syntax
-  expect_error(tribble(a~b), "single argument")
+  expect_error(tribble(a~b), "specified as e.g. colA~factor(.)")
 
   # tribble() must be passed colnames
   expect_error(tribble(
@@ -76,12 +76,13 @@ test_that("tribble() errs appropriately on bad calls", {
     3, 4, 5
   ))
 
+  # tribble() expects . placeholder for conversion functions
+  expect_error(tribble(colA~factor()), "`.` placeholder")
 })
 
 test_that("tribble supports conversion functions #149", {
-  sys_date <- Sys.Date()
   conversion <- tribble(
-    ~factor(colA), ~factor(colB, levels = c("B", "A")), ~asin(sqrt(arcsin_sqrt_prop)),
+    colA~factor(.), colB~factor(., levels = c("B", "A")), colC~asin(sqrt(.)),
     3, "A", 0.4,
     4, "B", 0.3
   )
@@ -89,7 +90,7 @@ test_that("tribble supports conversion functions #149", {
   conversion_expectation <- tibble(
     colA = factor(3:4),
     colB = factor(c("A", "B"), levels = c("B", "A")),
-    arcsin_sqrt_prop = asin(sqrt(c(0.4, 0.3)))
+    colC = asin(sqrt(c(0.4, 0.3)))
   )
 
   expect_equal(conversion, conversion_expectation)

--- a/tests/testthat/test-tribble.R
+++ b/tests/testthat/test-tribble.R
@@ -63,9 +63,6 @@ test_that("tribble() errs appropriately on bad calls", {
   # invalid colname syntax
   expect_error(tribble(a~b), "single argument")
 
-  # invalid colname syntax
-  expect_error(tribble(~a + b), "symbol or string")
-
   # tribble() must be passed colnames
   expect_error(tribble(
     "a", "b",
@@ -79,6 +76,21 @@ test_that("tribble() errs appropriately on bad calls", {
     3, 4, 5
   ))
 
+})
+
+test_that("tribble supports conversion functions #149", {
+  conversion <- tribble(
+    ~factor(colA), ~factor(colB, levels = c("B", "A")),
+    3, "A",
+    4, "B"
+  )
+
+  conversion_expectation <- tibble(
+    colA = factor(3:4),
+    colB = factor(c("A", "B"), levels = c("B", "A"))
+  )
+
+  expect_equal(conversion, conversion_expectation)
 })
 
 test_that("tribble can have list columns", {


### PR DESCRIPTION
Fixes #149 and allows the following syntax:

    library(lubridate)
    library(tibble)
    tribble(
      ~factor(a), ~hms(b),
      "A",        "0:1:1",
      "B",        "5:4:3"
    )
    # # A tibble: 2 × 2
    #        a            b
    #   <fctr> <S4: Period>
    # 1      A        1M 1S
    # 2      B     5H 4M 3S