### PR TITLE
Fix returned number of rows while subsetting zero columns.

### DIFF
--- a/R/tbl-df.r
+++ b/R/tbl-df.r
@@ -69,7 +69,7 @@ print.tbl_df <- function(x, ..., n = NULL, width = NULL, n_extra = NULL) {
   # Next, subset rows
   if (!missing(i)) {
     if (length(x) == 0) {
-      nr <- length(attr(x, "row.names")[i])
+      nr <- length(seq_len(nr)[i])
     } else {
       x <- map(x, `[`, i)
       nr <- length(x[[1]])

--- a/R/tbl-df.r
+++ b/R/tbl-df.r
@@ -63,19 +63,21 @@ print.tbl_df <- function(x, ..., n = NULL, width = NULL, n_extra = NULL) {
   # First, subset columns
   if (!missing(j)) {
     j <- check_names_df(j, x)
-    x <- .subset(x, j)
+    result <- .subset(x, j)
+  } else {
+    result <- x
   }
 
   # Next, subset rows
   if (!missing(i)) {
-    if (length(x) == 0) {
-      nr <- length(seq_len(nr)[i])
+    if (length(result) == 0) {
+      nr <- length(attr(x, "row.names")[i])
     } else {
-      x <- map(x, `[`, i)
-      nr <- length(x[[1]])
+      result <- map(result, `[`, i)
+      nr <- length(result[[1]])
     }
   }
 
-  attr(x, "row.names") <- .set_row_names(nr)
-  as_tibble.data.frame(x, validate = FALSE)
+  attr(result, "row.names") <- .set_row_names(nr)
+  as_tibble.data.frame(result, validate = FALSE)
 }

--- a/tests/testthat/test-tbl-df.R
+++ b/tests/testthat/test-tbl-df.R
@@ -36,6 +36,22 @@ test_that("[ with 0 cols creates correct row names (#656)", {
   expect_identical(zero_row, as_tibble(iris)[0])
 })
 
+test_that("[ with 0 cols returns correct number of rows", {
+  iris_tbl <- as_tibble(iris)
+  nrow_iris <- nrow(iris_tbl)
+
+  expect_is(iris_tbl, "tbl_df")
+  expect_equal(nrow(iris_tbl[, 0]), nrow_iris)
+
+  expect_equal(nrow(iris_tbl[, 0][1:10, ]), 10)
+  expect_equal(nrow(iris_tbl[1:10, ][, 0]), 10)
+  expect_equal(nrow(iris_tbl[1:10, 0]), 10)
+
+  expect_equal(nrow(iris_tbl[, 0][-(1:10), ]), nrow_iris - 10)
+  expect_equal(nrow(iris_tbl[-(1:10), ][, 0]), nrow_iris - 10)
+  expect_equal(nrow(iris_tbl[-(1:10), 0]), nrow_iris - 10)
+})
+
 test_that("[.tbl_df is careful about names (#1245)",{
   z_msg <- "Unknown column: 'z'"
 

--- a/tests/testthat/test-tbl-df.R
+++ b/tests/testthat/test-tbl-df.R
@@ -40,15 +40,19 @@ test_that("[ with 0 cols returns correct number of rows", {
   iris_tbl <- as_tibble(iris)
   nrow_iris <- nrow(iris_tbl)
 
-  expect_is(iris_tbl, "tbl_df")
+  expect_equal(nrow(iris_tbl[0]), nrow_iris)
   expect_equal(nrow(iris_tbl[, 0]), nrow_iris)
 
   expect_equal(nrow(iris_tbl[, 0][1:10, ]), 10)
+  expect_equal(nrow(iris_tbl[0][1:10, ]), 10)
   expect_equal(nrow(iris_tbl[1:10, ][, 0]), 10)
+  expect_equal(nrow(iris_tbl[1:10, ][0]), 10)
   expect_equal(nrow(iris_tbl[1:10, 0]), 10)
 
   expect_equal(nrow(iris_tbl[, 0][-(1:10), ]), nrow_iris - 10)
+  expect_equal(nrow(iris_tbl[0][-(1:10), ]), nrow_iris - 10)
   expect_equal(nrow(iris_tbl[-(1:10), ][, 0]), nrow_iris - 10)
+  expect_equal(nrow(iris_tbl[-(1:10), ][0]), nrow_iris - 10)
   expect_equal(nrow(iris_tbl[-(1:10), 0]), nrow_iris - 10)
 })
 


### PR DESCRIPTION
Hello.
Recently I experienced an odd behaviour of `[.tbl_df`:

    iris_tbl <- tibble::as_tibble(iris)
    nrow_iris <- nrow(iris_tbl)
    
    nrow(iris_tbl[, 0]) # equals to nrow_iris

    nrow(iris_tbl[, 0][1:10, ]) # equals to 10
    nrow(iris_tbl[1:10, ][, 0]) # equals to 10
    nrow(iris_tbl[1:10, 0]) # expected to be equal to 10 but it's 0
    
    nrow(iris_tbl[, 0][-(1:10), ]) # equals to nrow_iris - 10
    nrow(iris_tbl[-(1:10), ][, 0]) # equals to nrow_iris - 10
    nrow(iris_tbl[-(1:10), 0]) # expected to be equal to nrow_iris - 10 but it's 0

I think that the two unexpected cases weren't designed to behave like this.
I think the problem is in the command `nr <- length(attr(x, "row.names")[i])` of `[.tbl_df` which computes the resulting number of rows in case of zero columns by applying R's standard subsetting mechanism to some vector of appropriate length. But in case of zero columns `attr(x, "row.names")` equals to NULL at that point of function evaluation and the resulting `nr` equals to 0 regardless of `i`. Changing `attr(x, "row.names")` to `seq_len(nr)` resolves the issue.
Also added some tests for checking number of rows in case of zero columns.