### PR TITLE
rownames to column numeric option

### DIFF
--- a/R/rownames.R
+++ b/R/rownames.R
@@ -46,20 +46,27 @@ remove_rownames <- function(df) {
 
 #' @export
 #' @rdname rownames
-rownames_to_column <- function(df, var = "rowname") {
+rownames_to_column <- function(df, var = "rowname", to_numeric = TRUE) {
   stopifnot(is.data.frame(df))
-
+  
   if (has_name(df, var))
     stopc("There is a column named ", var, " already!")
-
+  
   rn <- tibble(rownames(df))
   names(rn) <- var
-
+  
+  if (to_numeric == TRUE){
+    if(mean(grepl('[0-9]*', rn[[var]])) == 1){
+      rn[[var]] <- as.numeric(rn[[var]])
+    } else {
+      stopc("Row names must be valid numbers to be changed to numeric!"
+    }
+  
   attribs <- attributes(df)
-
+  
   new_df <- c(rn, df)
   attribs[["names"]] <- names(new_df)
-
+  
   attributes(new_df) <- attribs[names(attribs) != "row.names"]
   attr(new_df, "row.names") <- .set_row_names(nrow(df))
   new_df


### PR DESCRIPTION
Hi, this is my first attempt at this so apologies if I'm not doing it right!

I use the `rownames_to_column` function on a very regular basis simply to add a numerical id field to my dataframe. It drives me slightly crazy that this is added to the dataframe as a character column.

To address this I altered the function to add an option for `to_numeric` which defaults to `FALSE` but if it's set to `TRUE` then it checks whether the row names are all numeric then converts if so. 