### PR TITLE
add rowname to column as numeric func

### DIFF
--- a/R/rownames.R
+++ b/R/rownames.R
@@ -50,10 +50,10 @@ remove_rownames <- function(df) {
 #' @rdname rownames
 rownames_to_column <- function(df, var = "rowname") {
   stopifnot(is.data.frame(df))
-  
+
   if (has_name(df, var))
     stopc("There is a column named ", var, " already!")
-  
+
   new_df <- add_column(df, !!(var) := rownames(df), .before = 1)
   new_df
 }
@@ -62,7 +62,7 @@ rownames_to_column <- function(df, var = "rowname") {
 #' @rdname rownames
 rowid_to_column <- function(df, var = "rowid") {
   stopifnot(is.data.frame(df))
-  
+
   if (has_name(df, var))
     stopc("There is a column named ", var, " already!")
 

--- a/R/rownames.R
+++ b/R/rownames.R
@@ -65,6 +65,31 @@ rownames_to_column <- function(df, var = "rowname") {
   new_df
 }
 
+rownames_to_column_numeric <- function(df, var = "rowname") {
+  stopifnot(is.data.frame(df))
+
+  if (has_name(df, var))
+    stopc("There is a column named ", var, " already!")
+
+  rn <- tibble(rownames(df))
+  names(rn) <- var
+
+  if(mean(grepl('[0-9]*', rn[[var]])) == 1){
+    rn[[var]] <- as.numeric(rn[[var]])
+  } else {
+    stopc("Row names must be valid numbers to be changed to numeric!")
+}
+
+  attribs <- attributes(df)
+
+  new_df <- c(rn, df)
+  attribs[["names"]] <- names(new_df)
+
+  attributes(new_df) <- attribs[names(attribs) != "row.names"]
+  attr(new_df, "row.names") <- .set_row_names(nrow(df))
+  new_df
+}
+
 #' @rdname rownames
 #' @export
 column_to_rownames <- function(df, var = "rowname") {

--- a/R/rownames.R
+++ b/R/rownames.R
@@ -9,7 +9,9 @@
 #' functions allow to you detect if a data frame has row names
 #' (`has_rownames()`), remove them (`remove_rownames()`), or convert
 #' them back-and-forth between an explicit column (`rownames_to_column()`
-#' and `column_to_rownames()`).
+#' and `column_to_rownames()`). Also included is a `rowid_to_column` which 
+#' adds a column at the start of the dataframe of ascending sequential row
+#' ids starting at 1.
 #'
 #' In the printed output, the presence of row names is indicated by a star just
 #' above the row numbers.

--- a/R/rownames.R
+++ b/R/rownames.R
@@ -50,20 +50,11 @@ remove_rownames <- function(df) {
 #' @rdname rownames
 rownames_to_column <- function(df, var = "rowname") {
   stopifnot(is.data.frame(df))
-
+  
   if (has_name(df, var))
     stopc("There is a column named ", var, " already!")
-
-  rn <- tibble(rownames(df))
-  names(rn) <- var
-
-  attribs <- attributes(df)
-
-  new_df <- c(rn, df)
-  attribs[["names"]] <- names(new_df)
-
-  attributes(new_df) <- attribs[names(attribs) != "row.names"]
-  attr(new_df, "row.names") <- .set_row_names(nrow(df))
+  
+  new_df <- add_column(df, !!(var) := rownames(df), .before = 1)
   new_df
 }
 
@@ -75,9 +66,7 @@ rowid_to_column <- function(df, var = "rowid") {
   if (has_name(df, var))
     stopc("There is a column named ", var, " already!")
 
-  rn <- tibble(seq_len(nrow(df)))
-  names(rn) <- var
-  new_df <- cbind(rn, df)
+  new_df <- add_column(df, !!(var) := seq_len(nrow(df)), .before = 1)
   new_df
 }
 

--- a/R/rownames.R
+++ b/R/rownames.R
@@ -9,7 +9,7 @@
 #' functions allow to you detect if a data frame has row names
 #' (`has_rownames()`), remove them (`remove_rownames()`), or convert
 #' them back-and-forth between an explicit column (`rownames_to_column()`
-#' and `column_to_rownames()`). Also included is a `rowid_to_column` which 
+#' and `column_to_rownames()`). Also included is `rowid_to_column()` which 
 #' adds a column at the start of the dataframe of ascending sequential row
 #' ids starting at 1.
 #'
@@ -74,11 +74,8 @@ rowid_to_column <- function(df, var = "rowid") {
   
   if (has_name(df, var))
     stopc("There is a column named ", var, " already!")
-  
-  if(nrow(df) == 0)
-    stopc('Data frame must have 1 or more rows')
-  
-  rn <- tibble(seq(1, nrow(df)))
+
+  rn <- tibble(seq_len(nrow(df)))
   names(rn) <- var
   new_df <- cbind(rn, df)
   new_df

--- a/R/rownames.R
+++ b/R/rownames.R
@@ -65,28 +65,20 @@ rownames_to_column <- function(df, var = "rowname") {
   new_df
 }
 
-rownames_to_column_numeric <- function(df, var = "rowname") {
+#' @export
+#' @rdname rownames
+rowid_to_column <- function(df, var = "rowid") {
   stopifnot(is.data.frame(df))
-
+  
   if (has_name(df, var))
     stopc("There is a column named ", var, " already!")
-
-  rn <- tibble(rownames(df))
+  
+  if(nrow(df) == 0)
+    stopc('Data frame must have 1 or more rows')
+  
+  rn <- tibble(seq(1, nrow(df)))
   names(rn) <- var
-
-  if(mean(grepl('[0-9]*', rn[[var]])) == 1){
-    rn[[var]] <- as.numeric(rn[[var]])
-  } else {
-    stopc("Row names must be valid numbers to be changed to numeric!")
-}
-
-  attribs <- attributes(df)
-
-  new_df <- c(rn, df)
-  attribs[["names"]] <- names(new_df)
-
-  attributes(new_df) <- attribs[names(attribs) != "row.names"]
-  attr(new_df, "row.names") <- .set_row_names(nrow(df))
+  new_df <- cbind(rn, df)
   new_df
 }
 

--- a/R/rownames.R
+++ b/R/rownames.R
@@ -9,9 +9,10 @@
 #' functions allow to you detect if a data frame has row names
 #' (`has_rownames()`), remove them (`remove_rownames()`), or convert
 #' them back-and-forth between an explicit column (`rownames_to_column()`
-#' and `column_to_rownames()`). Also included is `rowid_to_column()` which 
+#' and `column_to_rownames()`). 
+#' Also included is `rowid_to_column()` which 
 #' adds a column at the start of the dataframe of ascending sequential row
-#' ids starting at 1.
+#' ids starting at 1. Note that this will remove any existing row names.
 #'
 #' In the printed output, the presence of row names is indicated by a star just
 #' above the row numbers.

--- a/tests/testthat/test-rownames.R
+++ b/tests/testthat/test-rownames.R
@@ -26,6 +26,13 @@ test_that("rownames_to_column keeps the tbl classes (#882)", {
                paste("There is a column named wt already!")  )
 })
 
+test_that("rowid_to_column adds row names and errors if col name reused", {
+  res <- rowid_to_column( mtcars)
+  expect_true(ncol(res)==12)
+  expect_error(rowid_to_column( mtcars, var = 'mpg'),
+               paste("There is a column named mpg already!") )
+})
+
 test_that("column_to_rownames returns tbl", {
   var <- "car"
   mtcars1 <- as_tibble(mtcars)

--- a/tests/testthat/test-rownames.R
+++ b/tests/testthat/test-rownames.R
@@ -14,23 +14,29 @@ test_that("setting row names on a tibble raises a warning", {
 })
 
 test_that("rownames_to_column keeps the tbl classes (#882)", {
-  res <- rownames_to_column( mtcars, "Make&Model" )
+  res <- rownames_to_column(mtcars, "Make&Model")
   expect_false(has_rownames(res))
-  expect_equal( class(res), class(mtcars) )
+  expect_equal(class(res), class(mtcars))
   expect_error(rownames_to_column( mtcars, "wt"),
-               paste("There is a column named wt already!")  )
-  res1 <- rownames_to_column( as_tibble(mtcars), "Make&Model" )
+               paste("There is a column named wt already!"))
+  res1 <- rownames_to_column(as_tibble(mtcars), "Make&Model")
   expect_false(has_rownames(res1))
-  expect_equal( class(res1), class(as_tibble(mtcars)) )
+  expect_equal(class(res1), class(as_tibble(mtcars)))
   expect_error(rownames_to_column( mtcars, "wt"),
-               paste("There is a column named wt already!")  )
+               paste("There is a column named wt already!"))
 })
 
-test_that("rowid_to_column adds row names and errors if col name reused", {
-  res <- rowid_to_column( mtcars)
-  expect_true(ncol(res) == ncol(mtcars) + 1)
-  expect_error(rowid_to_column( mtcars, var = 'mpg'),
-               paste("There is a column named mpg already!") )
+test_that("rowid_to_column keeps the tbl classes", {
+  res <- rowid_to_column(mtcars)
+  expect_false(has_rownames(res))
+  expect_equal(class(res), class(mtcars))
+  expect_error(rowid_to_column( mtcars, "wt"),
+               paste("There is a column named wt already!"))
+  res1 <- rowid_to_column(as_tibble(mtcars))
+  expect_false(has_rownames(res1))
+  expect_equal(class(res1), class(as_tibble(mtcars)))
+  expect_error(rowid_to_column( mtcars, "wt"),
+               paste("There is a column named wt already!"))
 })
 
 test_that("column_to_rownames returns tbl", {

--- a/tests/testthat/test-rownames.R
+++ b/tests/testthat/test-rownames.R
@@ -28,7 +28,7 @@ test_that("rownames_to_column keeps the tbl classes (#882)", {
 
 test_that("rowid_to_column adds row names and errors if col name reused", {
   res <- rowid_to_column( mtcars)
-  expect_true(ncol(res)==12)
+  expect_true(ncol(res) == ncol(mtcars) + 1)
   expect_error(rowid_to_column( mtcars, var = 'mpg'),
                paste("There is a column named mpg already!") )
 })


### PR DESCRIPTION
Adds a separate function called `rownames_to_column_numeric` which outputs the rownames as numeric where they are legitimate numbers. 

Function could conceivably be called something slightly less verbose (but less accurate) such as `rownum_to_column`.