### PR TITLE
Use quos() instead of dots_quos()

### DIFF
--- a/R/lst.R
+++ b/R/lst.R
@@ -13,7 +13,7 @@
 #' @export
 #' @rdname tibble
 lst <- function(...) {
-  xs <- dots_quos(..., .named = 500L)
+  xs <- quos(..., .named = 500L)
 
   n <- length(xs)
   if (n == 0) {


### PR DESCRIPTION
That function has been removed in rlang 0.1