### PR TITLE
Escape factor levels

### DIFF
--- a/R/utils-format.r
+++ b/R/utils-format.r
@@ -81,15 +81,19 @@ shrink_mat <- function(df, width, rows, n, star) {
 
   # List columns need special treatment because format() can't be trusted
   is_list <- map_lgl(df, is.list)
-  # Character columns need special treatment because of NA and escapes
-  is_character <- map_lgl(df, is.character)
 
   df[is_list] <- map(df[is_list], function(x) {
     summary <- obj_sum(x)
     paste0("<", summary, ">")
   })
 
+  # Character columns need special treatment because of NA and escapes
+  is_character <- map_lgl(df, is.character)
   df[is_character] <- map(df[is_character], format_character)
+
+  # Factor columns need special treatment because of NA and escapes
+  is_factor <- map_lgl(df, is.factor)
+  df[is_factor] <- map(df[is_factor], format_factor)
 
   mat <- format(df, justify = "left")
   values <- c(format(rownames(mat))[[1]], unlist(mat[1, ]))
@@ -289,6 +293,10 @@ wrap <- function(..., indent = 0, prefix = "", width) {
 }
 
 
+
+format_factor <- function(x) {
+  format_character(as.character(x))
+}
 
 format_character <- function(x) {
   res <- quote_escaped(x)

--- a/tests/testthat/output/trunc_mat/all--300.txt
+++ b/tests/testthat/output/trunc_mat/all--300.txt
@@ -3,4 +3,4 @@
   <dbl> <int> <lgl> <chr> <fctr>     <date>              <dttm>    <list>     <list>
 1   1.0     1  TRUE     a      a 2015-12-10 2015-12-09 10:51:35 <int [1]> <list [2]>
 2   2.5     2 FALSE     b      b 2015-12-11 2015-12-09 10:51:36 <int [1]> <list [1]>
-3    NA    NA    NA  <NA>     NA         NA                  NA <int [1]> <list [1]>
+3    NA    NA    NA  <NA>   <NA>         NA                  NA <int [1]> <list [1]>

--- a/tests/testthat/output/trunc_mat/all-knit-120.txt
+++ b/tests/testthat/output/trunc_mat/all-knit-120.txt
@@ -7,6 +7,6 @@ A tibble: 3 x 9
 |<dbl> |<int> |<lgl> |<chr> |<fctr> |<date>     |<dttm>              |<list>    |<list>     |
 |1.0   |1     |TRUE  |a     |a      |2015-12-10 |2015-12-09 10:51:35 |<int [1]> |<list [2]> |
 |2.5   |2     |FALSE |b     |b      |2015-12-11 |2015-12-09 10:51:36 |<int [1]> |<list [1]> |
-|NA    |NA    |NA    |<NA>  |NA     |NA         |NA                  |<int [1]> |<list [1]> |
+|NA    |NA    |NA    |<NA>  |<NA>   |NA         |NA                  |<int [1]> |<list [1]> |
 
 

--- a/tests/testthat/output/trunc_mat/all-knit-60.txt
+++ b/tests/testthat/output/trunc_mat/all-knit-60.txt
@@ -7,6 +7,6 @@ A tibble: 3 x 9
 |<dbl> |<int> |<lgl> |<chr> |<fctr> |<date>     |
 |1.0   |1     |TRUE  |a     |a      |2015-12-10 |
 |2.5   |2     |FALSE |b     |b      |2015-12-11 |
-|NA    |NA    |NA    |<NA>  |NA     |NA         |
+|NA    |NA    |NA    |<NA>  |<NA>   |NA         |
 
 (with 3 more variables: g <dttm>, h <list>, i <list>)

--- a/tests/testthat/output/trunc_mat/newline.txt
+++ b/tests/testthat/output/trunc_mat/newline.txt
@@ -1,5 +1,5 @@
-# A tibble: 2 x 1
-   `\n`
-  <chr>
-1  "\n"
-2  "\""
+# A tibble: 2 x 2
+   `\n`   `\r`
+  <chr> <fctr>
+1  "\n"   "\n"
+2  "\""   "\""

--- a/tests/testthat/test-trunc-mat.R
+++ b/tests/testthat/test-trunc-mat.R
@@ -80,7 +80,7 @@ test_that("trunc_mat output matches known output", {
     "trunc_mat/all-1-30-0.txt")
 
   expect_output_file_rel(
-    print(trunc_mat(tibble(`\n` = c("\n", '"')))),
+    print(trunc_mat(tibble(`\n` = c("\n", '"'), `\r` = factor(`\n`)))),
     "trunc_mat/newline.txt")
 
   expect_output_file_rel(


### PR DESCRIPTION
Closes #277.

@hadley: Until now, `NA` in factors are printed as `NA`, not as `<NA>` like in character variables. Was this on purpose?