### PR TITLE
Preserve rownames with as_tibble.matrix

### DIFF
--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -100,7 +100,13 @@ list_to_tibble <- function(x, validate, rownames = NULL) {
 #' @export
 #' @rdname as_tibble
 as_tibble.matrix <- function(x, ...) {
-  matrixToDataFrame(x)
+  rownames <- dimnames(x)[[1]]
+
+  x <- matrixToDataFrame(x)
+
+  if (!is.null(rownames)) attr(x, "row.names") <- rownames
+
+  x
 }
 
 #' @export

--- a/tests/testthat/test-matrix.R
+++ b/tests/testthat/test-matrix.R
@@ -15,6 +15,14 @@ test_that("preserves col names", {
   expect_equal(names(out), c("a", "b"))
 })
 
+test_that("preserves row names", {
+  x <- matrix(1:4, nrow = 2)
+  rownames(x) <- c("a", "b")
+
+  out <- as_tibble(x)
+  expect_equal(rownames(out), c("a", "b"))
+})
+
 test_that("creates col names", {
   x <- matrix(1:4, nrow = 2)
 


### PR DESCRIPTION
Fixes #288.