### PR TITLE
Remove cbind() dependency from add_column().

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 ### tibble 1.3.4.9001 (2017-08-25)
 
+- Prevent `add_column()` from dropping classes and attributes by removing the use of `cbind()`. Additionally this ensures that `add_column()` can be used with grouped data frames (#303, @DavisVaughan).
+
 - Integrate pillar (#294).
 
 

--- a/R/add.R
+++ b/R/add.R
@@ -137,27 +137,21 @@ add_column <- function(.data, ..., .before = NULL, .after = NULL) {
 
   pos <- pos_from_before_after_names(.before, .after, colnames(.data))
 
-  # The positions for the new columns
   end_pos <- ncol(.data) + seq_len(ncol(df))
 
   if (pos <= 0L) {
-    #out <- cbind(df, .data)
-    # Add to end, then rearrange to the beginning
-    .data[, end_pos] <- df
-    .data <- .data[, c(end_pos, seq_len(ncol(.data))[-end_pos])]
+    indexes_orig <- seq_len(ncol(.data))
+    .data[end_pos] <- df
+    .data <- .data[c(end_pos, indexes_orig)]
   } else if (pos >= ncol(.data)) {
-    #out <- cbind(.data, df)
-    # Add to end
-    .data[, end_pos] <- df
+    .data[end_pos] <- df
   } else {
-    indexes <- seq_len(pos)
-    #out <- cbind(.data[indexes], df, .data[-indexes])
-    # Add to end then position correctly
-    .data[, end_pos] <- df
-    .data <- .data[, c(indexes, end_pos, (length(indexes)+1):(length(.data)-1))]
+    indexes_before <- seq_len(pos)
+    indexes_after <- (length(indexes_before)+1):ncol(.data)
+    .data[end_pos] <- df
+    .data <- .data[c(indexes_before, end_pos, indexes_after)]
   }
 
-  #out <- set_class(remove_rownames(out), class(.data))
   .data
 }
 

--- a/R/add.R
+++ b/R/add.R
@@ -140,19 +140,17 @@ add_column <- function(.data, ..., .before = NULL, .after = NULL) {
   end_pos <- ncol(.data) + seq_len(ncol(df))
 
   if (pos <= 0L) {
-    indexes_orig <- seq_len(ncol(.data))
-    .data[end_pos] <- df
-    .data <- .data[c(end_pos, indexes_orig)]
-  } else if (pos >= ncol(.data)) {
-    .data[end_pos] <- df
+    indexes <- c(end_pos, seq_len(ncol(.data)))
+  } else if (pos > ncol(.data)) {
+    indexes <- seq_len(ncol(.data) + ncol(df))
   } else {
     indexes_before <- seq_len(pos)
-    indexes_after <- (length(indexes_before)+1):ncol(.data)
-    .data[end_pos] <- df
-    .data <- .data[c(indexes_before, end_pos, indexes_after)]
+    indexes_after <- rlang::seq2(length(indexes_before) + 1, ncol(.data))
+    indexes <- c(indexes_before, end_pos, indexes_after)
   }
 
-  .data
+  .data[end_pos] <- df
+  .data[indexes]
 }
 
 

--- a/R/add.R
+++ b/R/add.R
@@ -139,15 +139,9 @@ add_column <- function(.data, ..., .before = NULL, .after = NULL) {
 
   end_pos <- ncol(.data) + seq_len(ncol(df))
 
-  if (pos <= 0L) {
-    indexes <- c(end_pos, seq_len(ncol(.data)))
-  } else if (pos > ncol(.data)) {
-    indexes <- seq_len(ncol(.data) + ncol(df))
-  } else {
-    indexes_before <- seq_len(pos)
-    indexes_after <- rlang::seq2(length(indexes_before) + 1, ncol(.data))
-    indexes <- c(indexes_before, end_pos, indexes_after)
-  }
+  indexes_before <- rlang::seq2(1L, pos)
+  indexes_after <- rlang::seq2(pos + 1L, ncol(.data))
+  indexes <- c(indexes_before, end_pos, indexes_after)
 
   .data[end_pos] <- df
   .data[indexes]
@@ -168,13 +162,17 @@ pos_from_before_after <- function(before, after, len) {
     if (is_null(after)) {
       len
     } else {
-      after
+      limit_pos_range(after, len)
     }
   } else {
     if (is_null(after)) {
-      before - 1L
+      limit_pos_range(before - 1L, len)
     } else {
       stopc("Can't specify both `.before` and `.after`")
     }
   }
+}
+
+limit_pos_range <- function(pos, len) {
+  max(c(0, min(c(len, pos))))
 }

--- a/R/add.R
+++ b/R/add.R
@@ -137,16 +137,28 @@ add_column <- function(.data, ..., .before = NULL, .after = NULL) {
 
   pos <- pos_from_before_after_names(.before, .after, colnames(.data))
 
+  # The positions for the new columns
+  end_pos <- ncol(.data) + seq_len(ncol(df))
+
   if (pos <= 0L) {
-    out <- cbind(df, .data)
+    #out <- cbind(df, .data)
+    # Add to end, then rearrange to the beginning
+    .data[, end_pos] <- df
+    .data <- .data[, c(end_pos, seq_len(ncol(.data))[-end_pos])]
   } else if (pos >= ncol(.data)) {
-    out <- cbind(.data, df)
+    #out <- cbind(.data, df)
+    # Add to end
+    .data[, end_pos] <- df
   } else {
     indexes <- seq_len(pos)
-    out <- cbind(.data[indexes], df, .data[-indexes])
+    #out <- cbind(.data[indexes], df, .data[-indexes])
+    # Add to end then position correctly
+    .data[, end_pos] <- df
+    .data <- .data[, c(indexes, end_pos, (length(indexes)+1):(length(.data)-1))]
   }
 
-  set_class(remove_rownames(out), class(.data))
+  #out <- set_class(remove_rownames(out), class(.data))
+  .data
 }
 
 

--- a/R/add.R
+++ b/R/add.R
@@ -174,5 +174,5 @@ pos_from_before_after <- function(before, after, len) {
 }
 
 limit_pos_range <- function(pos, len) {
-  max(c(0, min(c(len, pos))))
+  max(c(0L, min(c(len, pos))))
 }


### PR DESCRIPTION
This PR removes `cbind()` from `add_column()` for two reasons as noted in #303. 

1) `grouped_df` objects would fail when adding a new column because `cbind()` attempted to convert them to a matrix.

2) Classes and attributes were lost when using `cbind()`. Classes were originally recovered using `set_class()` at the end of the call to `add_column()`, but attributes were not. Removing the dependency on `cbind()` keeps both.