### PR TITLE
Define responsibilities of new_tibble()

### DIFF
--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -97,6 +97,8 @@ list_to_tibble <- function(x, validate) {
 
   if (validate) {
     x <- check_tibble(x)
+  } else if (has_null_names(x)) {
+    x <- set_names(x, rep_along(x, ""))
   }
   x <- recycle_columns(x)
 

--- a/R/new.R
+++ b/R/new.R
@@ -3,34 +3,12 @@
 #' Creates a subclass of a tibble.
 #'
 #' @param x A tibble-like object
-#' @param ... Passed on to [structure()]
 #' @param subclass Subclasses to assign to the new object, default: none
 #' @export
-new_tibble <- function(x, ..., subclass = NULL) {
+new_tibble <- function(x, subclass = NULL) {
   stopifnot(is.list(x))
 
-  x <- update_tibble_attrs(x, ...)
   x <- set_tibble_class(x, subclass = subclass)
-  x
-}
-
-update_tibble_attrs <- function(x, ...) {
-  # Can't use structure() here because it breaks the row.names attribute
-  attribs <- list(...)
-
-  # reduce2() is not in the purrr compat layer
-  nested_attribs <- map2(names(attribs), attribs, function(name, value) set_names(list(value), name))
-  x <- reduce(
-    .init = x,
-    nested_attribs,
-    function(x, attr) {
-      if (!is.null(attr[[1]])) {
-        attr(x, names(attr)) <- attr[[1]]
-      }
-      x
-    }
-  )
-
   x
 }
 

--- a/R/new.R
+++ b/R/new.R
@@ -3,17 +3,46 @@
 #' Creates a subclass of a tibble.
 #'
 #' @param x A tibble-like object
+#' @param ... Passed on to [structure()]
 #' @param nrow The number of rows, guessed from the data by default
 #' @param subclass Subclasses to assign to the new object, default: none
 #' @export
-new_tibble <- function(x, nrow = NULL, subclass = NULL) {
+new_tibble <- function(x, ..., nrow = NULL, subclass = NULL) {
   stopifnot(is.list(x))
   stopifnot(has_nonnull_names(x))
 
+  x <- update_tibble_attrs(x, ...)
   x <- set_tibble_class(x, subclass = subclass)
+  # Make sure that we override any row names that
+  # may have been there previously, in x or in ...
   if (is.null(nrow)) nrow <- guess_nrow(x)
   attr(x, "row.names") <- .set_row_names(nrow)
   validate_nrow(x)
+  x
+}
+
+update_tibble_attrs <- function(x, ...) {
+  # Can't use structure() here because it breaks the row.names attribute
+  attribs <- list(...)
+
+  # reduce2() is not in the purrr compat layer
+  nested_attribs <- map2(names(attribs), attribs, function(name, value) set_names(list(value), name))
+  x <- reduce(
+    .init = x,
+    nested_attribs,
+    function(x, attr) {
+      if (!is.null(attr[[1]])) {
+        attr(x, names(attr)) <- attr[[1]]
+      }
+      x
+    }
+  )
+
+  x
+}
+
+set_tibble_class <- function(x, subclass = NULL) {
+  class(x) <- c(subclass, "tbl_df", "tbl", "data.frame")
   x
 }
 
@@ -36,9 +65,4 @@ validate_nrow <- function(x) {
   }
 
   invisible(x)
-}
-
-set_tibble_class <- function(x, subclass = NULL) {
-  class(x) <- c(subclass, "tbl_df", "tbl", "data.frame")
-  x
 }

--- a/R/new.R
+++ b/R/new.R
@@ -8,7 +8,7 @@
 #' @export
 new_tibble <- function(x, nrow = NULL, subclass = NULL) {
   stopifnot(is.list(x))
-  stopifnot(is_named(x))
+  stopifnot(has_nonnull_names(x))
 
   x <- set_tibble_class(x, subclass = subclass)
   if (is.null(nrow)) nrow <- guess_nrow(x)

--- a/R/new.R
+++ b/R/new.R
@@ -3,13 +3,38 @@
 #' Creates a subclass of a tibble.
 #'
 #' @param x A tibble-like object
+#' @param nrow The number of rows, guessed from the data by default
 #' @param subclass Subclasses to assign to the new object, default: none
 #' @export
-new_tibble <- function(x, subclass = NULL) {
+new_tibble <- function(x, nrow = NULL, subclass = NULL) {
   stopifnot(is.list(x))
 
   x <- set_tibble_class(x, subclass = subclass)
+  if (is.null(nrow)) nrow <- guess_nrow(x)
+  attr(x, "row.names") <- .set_row_names(nrow)
+  validate_nrow(x)
   x
+}
+
+guess_nrow <- function(x) {
+  if (!is.null(.row_names_info(x, 0L))) .row_names_info(x, 2L)
+  else if (length(x) == 0) 0L
+  else NROW(x[[1L]])
+}
+
+validate_nrow <- function(x) {
+  # Validate column lengths, don't recycle
+  lengths <- map_int(x, NROW)
+  first <- .row_names_info(x, 2L)
+
+  bad_len <- lengths != first
+  if (any(bad_len)) {
+    invalid_df_msg(
+      paste0("must be length ", max, ", not "), x, bad_len, lengths[bad_len]
+    )
+  }
+
+  invisible(x)
 }
 
 set_tibble_class <- function(x, subclass = NULL) {

--- a/R/new.R
+++ b/R/new.R
@@ -8,6 +8,7 @@
 #' @export
 new_tibble <- function(x, nrow = NULL, subclass = NULL) {
   stopifnot(is.list(x))
+  stopifnot(is_named(x))
 
   x <- set_tibble_class(x, subclass = subclass)
   if (is.null(nrow)) nrow <- guess_nrow(x)
@@ -30,7 +31,7 @@ validate_nrow <- function(x) {
   bad_len <- lengths != first
   if (any(bad_len)) {
     invalid_df_msg(
-      paste0("must be length ", max, ", not "), x, bad_len, lengths[bad_len]
+      paste0("must be length ", first, ", not "), x, bad_len, lengths[bad_len]
     )
   }
 

--- a/R/new.R
+++ b/R/new.R
@@ -11,7 +11,12 @@
 #' @export
 #' @examples
 #' new_tibble(list(a = 1:3, b = 4:6))
+#'
+#' # One particular situation where the nrow argument is essential:
 #' new_tibble(list(), nrow = 150, subclass = "my_tibble")
+#'
+#' # It's safest to always pass it along:
+#' new_tibble(list(a = 1:3, b = 4:6), nrow = 3)
 #'
 #' \dontrun{
 #' # All columns must be the same length:
@@ -39,7 +44,6 @@ new_tibble <- function(x, ..., nrow = NULL, subclass = NULL) {
   #' If `nrow` is `NULL`, the number of rows will be guessed from the data.
   if (is.null(nrow)) nrow <- guess_nrow(x)
   attr(x, "row.names") <- .set_row_names(nrow)
-
   #' The `new_tibble()` constructor makes sure that the `row.names` attribute
   #' is consistent with the data before returning.
   validate_nrow(x)

--- a/R/new.R
+++ b/R/new.R
@@ -7,6 +7,8 @@
 #' @param subclass Subclasses to assign to the new object, default: none
 #' @export
 new_tibble <- function(x, ..., subclass = NULL) {
+  stopifnot(is.list(x))
+
   x <- update_tibble_attrs(x, ...)
   x <- set_tibble_class(x, subclass = subclass)
   x

--- a/R/new.R
+++ b/R/new.R
@@ -1,23 +1,55 @@
 #' Constructor
 #'
 #' Creates a subclass of a tibble.
+#' This function is mostly useful for package authors that implement subclasses
+#' of a tibble, like \pkg{sf} or \pkg{tibbletime}.
 #'
 #' @param x A tibble-like object
 #' @param ... Passed on to [structure()]
 #' @param nrow The number of rows, guessed from the data by default
 #' @param subclass Subclasses to assign to the new object, default: none
 #' @export
+#' @examples
+#' new_tibble(list(a = 1:3, b = 4:6))
+#' new_tibble(list(), nrow = 150, subclass = "my_tibble")
+#'
+#' \dontrun{
+#' # All columns must be the same length:
+#' new_tibble(list(a = 1:3, b = 4.6))
+#'
+#' # The length must be consistent with the nrow argument if available:
+#' new_tibble(list(a = 1:3, b = 4:6), nrow = 2)
+#' }
 new_tibble <- function(x, ..., nrow = NULL, subclass = NULL) {
+  #' @details
+  #' `x` must be a named (or empty) list, but the names are not currently
+  #' checked for correctness.
   stopifnot(is.list(x))
+  if (length(x) == 0) names(x) <- character()
   stopifnot(has_nonnull_names(x))
 
+  #' @details
+  #' The `...` argument allows adding more attributes to the subclass.
   x <- update_tibble_attrs(x, ...)
-  x <- set_tibble_class(x, subclass = subclass)
-  # Make sure that we override any row names that
-  # may have been there previously, in x or in ...
+
+  #' @details
+  #' The `row.names` attribute will be computed from the `nrow` argument,
+  #' overriding any existing attribute of this name in `x` or in the `...`
+  #' argument.
+  #' If `nrow` is `NULL`, the number of rows will be guessed from the data.
   if (is.null(nrow)) nrow <- guess_nrow(x)
   attr(x, "row.names") <- .set_row_names(nrow)
+
+  #' The constructor makes sure that the `row.names` attribute is consistent
+  #' with the data before returning.
   validate_nrow(x)
+
+  #' @details
+  #' The `class` attribute of the returned object always consists of
+  #' `c("tbl_df", "tbl", "data.frame")`. If the `subclass` argument is set,
+  #' it will be prepended to that list of classes.
+  class(x) <- c(subclass, "tbl_df", "tbl", "data.frame")
+
   x
 }
 
@@ -38,11 +70,6 @@ update_tibble_attrs <- function(x, ...) {
     }
   )
 
-  x
-}
-
-set_tibble_class <- function(x, subclass = NULL) {
-  class(x) <- c(subclass, "tbl_df", "tbl", "data.frame")
   x
 }
 

--- a/R/new.R
+++ b/R/new.R
@@ -35,13 +35,13 @@ new_tibble <- function(x, ..., nrow = NULL, subclass = NULL) {
   #' @details
   #' The `row.names` attribute will be computed from the `nrow` argument,
   #' overriding any existing attribute of this name in `x` or in the `...`
-  #' argument.
+  #' arguments.
   #' If `nrow` is `NULL`, the number of rows will be guessed from the data.
   if (is.null(nrow)) nrow <- guess_nrow(x)
   attr(x, "row.names") <- .set_row_names(nrow)
 
-  #' The constructor makes sure that the `row.names` attribute is consistent
-  #' with the data before returning.
+  #' The `new_tibble()` constructor makes sure that the `row.names` attribute
+  #' is consistent with the data before returning.
   validate_nrow(x)
 
   #' @details

--- a/R/tibble.R
+++ b/R/tibble.R
@@ -118,7 +118,7 @@ recycle_columns <- function(x) {
     return(x)
   }
 
-  # Validate column lengths
+  # Validate column lengths, allow recycling
   lengths <- map_int(x, NROW)
   max <- max(c(lengths[lengths != 1L], 0L))
 

--- a/R/utils.r
+++ b/R/utils.r
@@ -1,10 +1,18 @@
 
 has_dim <- function(x) {
-  length(dim(x)) > 0L || is_named(x)
+  length(dim(x)) > 0L || has_nonnull_names(x)
 }
 
 needs_dim <- function(x) {
   length(dim(x)) > 1L
+}
+
+has_null_names <- function(x) {
+  is.null(names(x))
+}
+
+has_nonnull_names <- function(x) {
+  !has_null_names(x)
 }
 
 set_class <- `class<-`

--- a/man/new_tibble.Rd
+++ b/man/new_tibble.Rd
@@ -4,12 +4,10 @@
 \alias{new_tibble}
 \title{Constructor}
 \usage{
-new_tibble(x, ..., subclass = NULL)
+new_tibble(x, subclass = NULL)
 }
 \arguments{
 \item{x}{A tibble-like object}
-
-\item{...}{Passed on to \code{\link[=structure]{structure()}}}
 
 \item{subclass}{Subclasses to assign to the new object, default: none}
 }

--- a/man/new_tibble.Rd
+++ b/man/new_tibble.Rd
@@ -39,7 +39,12 @@ it will be prepended to that list of classes.
 }
 \examples{
 new_tibble(list(a = 1:3, b = 4:6))
+
+# One particular situation where the nrow argument is essential:
 new_tibble(list(), nrow = 150, subclass = "my_tibble")
+
+# It's safest to always pass it along:
+new_tibble(list(a = 1:3, b = 4:6), nrow = 3)
 
 \dontrun{
 # All columns must be the same length:

--- a/man/new_tibble.Rd
+++ b/man/new_tibble.Rd
@@ -4,10 +4,14 @@
 \alias{new_tibble}
 \title{Constructor}
 \usage{
-new_tibble(x, subclass = NULL)
+new_tibble(x, ..., nrow = NULL, subclass = NULL)
 }
 \arguments{
 \item{x}{A tibble-like object}
+
+\item{...}{Passed on to \code{\link[=structure]{structure()}}}
+
+\item{nrow}{The number of rows, guessed from the data by default}
 
 \item{subclass}{Subclasses to assign to the new object, default: none}
 }

--- a/man/new_tibble.Rd
+++ b/man/new_tibble.Rd
@@ -28,10 +28,10 @@ The \code{...} argument allows adding more attributes to the subclass.
 
 The \code{row.names} attribute will be computed from the \code{nrow} argument,
 overriding any existing attribute of this name in \code{x} or in the \code{...}
-argument.
+arguments.
 If \code{nrow} is \code{NULL}, the number of rows will be guessed from the data.
-The constructor makes sure that the \code{row.names} attribute is consistent
-with the data before returning.
+The \code{new_tibble()} constructor makes sure that the \code{row.names} attribute
+is consistent with the data before returning.
 
 The \code{class} attribute of the returned object always consists of
 \code{c("tbl_df", "tbl", "data.frame")}. If the \code{subclass} argument is set,

--- a/man/new_tibble.Rd
+++ b/man/new_tibble.Rd
@@ -17,4 +17,35 @@ new_tibble(x, ..., nrow = NULL, subclass = NULL)
 }
 \description{
 Creates a subclass of a tibble.
+This function is mostly useful for package authors that implement subclasses
+of a tibble, like \pkg{sf} or \pkg{tibbletime}.
+}
+\details{
+\code{x} must be a named (or empty) list, but the names are not currently
+checked for correctness.
+
+The \code{...} argument allows adding more attributes to the subclass.
+
+The \code{row.names} attribute will be computed from the \code{nrow} argument,
+overriding any existing attribute of this name in \code{x} or in the \code{...}
+argument.
+If \code{nrow} is \code{NULL}, the number of rows will be guessed from the data.
+The constructor makes sure that the \code{row.names} attribute is consistent
+with the data before returning.
+
+The \code{class} attribute of the returned object always consists of
+\code{c("tbl_df", "tbl", "data.frame")}. If the \code{subclass} argument is set,
+it will be prepended to that list of classes.
+}
+\examples{
+new_tibble(list(a = 1:3, b = 4:6))
+new_tibble(list(), nrow = 150, subclass = "my_tibble")
+
+\dontrun{
+# All columns must be the same length:
+new_tibble(list(a = 1:3, b = 4.6))
+
+# The length must be consistent with the nrow argument if available:
+new_tibble(list(a = 1:3, b = 4:6), nrow = 2)
+}
 }

--- a/tests/testthat/test-data-frame.R
+++ b/tests/testthat/test-data-frame.R
@@ -228,6 +228,14 @@ test_that("as_tibble() can validate (#278)", {
 })
 
 
+test_that("as_tibble() adds empty names if not validating", {
+  invalid_df <- as_tibble(list(3, 4, 5), validate = FALSE)
+  expect_equal(length(invalid_df), 3)
+  expect_equal(nrow(invalid_df), 1)
+  expect_equal(names(invalid_df), rep("", 3))
+})
+
+
 test_that("as_tibble() can convert row names", {
   df <- data.frame(a = 1:3, b = 2:4, row.names = letters[5:7])
   expect_identical(

--- a/tests/testthat/test-tbl-df.R
+++ b/tests/testthat/test-tbl-df.R
@@ -323,7 +323,7 @@ test_that("new_tibble", {
 test_that("new_tibble checks", {
   expect_identical(new_tibble(list()), tibble())
   expect_identical(new_tibble(list(a = 1:3, b = 4:6)), tibble(a = 1:3, b = 4:6))
-  expect_error(new_tibble(list()), "names", fixed = TRUE)
+  expect_error(new_tibble(list(1)), "names", fixed = TRUE)
   expect_error(new_tibble(list(a = 1, b = 2:3)), "length", fixed = TRUE)
   expect_error(
     new_tibble(

--- a/tests/testthat/test-tbl-df.R
+++ b/tests/testthat/test-tbl-df.R
@@ -301,6 +301,8 @@ test_that("is_tibble", {
 test_that("new_tibble", {
   tbl <- new_tibble(
     data.frame(a = 1:3),
+    attr1 = "value1",
+    attr2 = 2,
     subclass = "nt"
   )
 
@@ -310,6 +312,8 @@ test_that("new_tibble", {
     unclass(tbl),
     structure(
       list(a = 1:3),
+      attr1 = "value1",
+      attr2 = 2,
       .Names = "a",
       row.names = .set_row_names(3L)
     )

--- a/tests/testthat/test-tbl-df.R
+++ b/tests/testthat/test-tbl-df.R
@@ -315,3 +315,17 @@ test_that("new_tibble", {
     )
   )
 })
+
+test_that("new_tibble checks", {
+  expect_identical(new_tibble(list(a = 1)[-1]), tibble())
+  expect_identical(new_tibble(list(a = 1:3, b = 4:6)), tibble(a = 1:3, b = 4:6))
+  expect_error(new_tibble(list()), "named", fixed = TRUE)
+  expect_error(new_tibble(list(a = 1, b = 2:3)), "length", fixed = TRUE)
+  expect_error(
+    new_tibble(
+      structure(list(a = 1, b = 2), row.names = .set_row_names(2))
+    ),
+    "length",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-tbl-df.R
+++ b/tests/testthat/test-tbl-df.R
@@ -319,7 +319,7 @@ test_that("new_tibble", {
 test_that("new_tibble checks", {
   expect_identical(new_tibble(list(a = 1)[-1]), tibble())
   expect_identical(new_tibble(list(a = 1:3, b = 4:6)), tibble(a = 1:3, b = 4:6))
-  expect_error(new_tibble(list()), "named", fixed = TRUE)
+  expect_error(new_tibble(list()), "names", fixed = TRUE)
   expect_error(new_tibble(list(a = 1, b = 2:3)), "length", fixed = TRUE)
   expect_error(
     new_tibble(

--- a/tests/testthat/test-tbl-df.R
+++ b/tests/testthat/test-tbl-df.R
@@ -300,9 +300,7 @@ test_that("is_tibble", {
 
 test_that("new_tibble", {
   tbl <- new_tibble(
-    data.frame(a = 1),
-    attr1 = "val1",
-    attr2 = "val2",
+    data.frame(a = 1:3),
     subclass = "nt"
   )
 
@@ -311,11 +309,9 @@ test_that("new_tibble", {
   expect_equal(
     unclass(tbl),
     structure(
-      list(a = 1),
+      list(a = 1:3),
       .Names = "a",
-      row.names = c(NA, -1L),
-      attr1 = "val1",
-      attr2 = "val2"
+      row.names = .set_row_names(3L)
     )
   )
 })

--- a/tests/testthat/test-tbl-df.R
+++ b/tests/testthat/test-tbl-df.R
@@ -321,7 +321,7 @@ test_that("new_tibble", {
 })
 
 test_that("new_tibble checks", {
-  expect_identical(new_tibble(list(a = 1)[-1]), tibble())
+  expect_identical(new_tibble(list()), tibble())
   expect_identical(new_tibble(list(a = 1:3, b = 4:6)), tibble(a = 1:3, b = 4:6))
   expect_error(new_tibble(list()), "names", fixed = TRUE)
   expect_error(new_tibble(list(a = 1, b = 2:3)), "length", fixed = TRUE)


### PR DESCRIPTION
@hadley: What should `new_tibble()` check or enforce? We have `as_tibble.list()` that will check column names and recycle columns if necessary, but no attributes are copied. Should `new_tibble()` compute the `row.names` attribute if necessary and do additional checks?

Reference: https://github.com/tidyverse/tibble/issues/330#issuecomment-341687151