### PR TITLE
tribble should ignore trailing commas

### DIFF
--- a/R/tribble.R
+++ b/R/tribble.R
@@ -59,7 +59,15 @@ frame_matrix <- function(...) {
 }
 
 extract_frame_data_from_dots <- function(...) {
-  dots <- list(...)
+  dots <- as.list(sys.call(which = sys.parent())[-1L])
+  len <- length(dots)
+  if (len > 1) {
+    last <- dots[[len]]
+    if (missing(last)) {
+      dots <- dots[-len]
+    }
+  }
+  dots <- lapply(dots, eval, parent.frame())
 
   # Extract the names.
   frame_names <- extract_frame_names_from_dots(dots)

--- a/R/tribble.R
+++ b/R/tribble.R
@@ -59,15 +59,7 @@ frame_matrix <- function(...) {
 }
 
 extract_frame_data_from_dots <- function(...) {
-  dots <- as.list(sys.call(which = sys.parent())[-1L])
-  len <- length(dots)
-  if (len > 1) {
-    last <- dots[[len]]
-    if (missing(last)) {
-      dots <- dots[-len]
-    }
-  }
-  dots <- lapply(dots, eval, parent.frame())
+  dots <- dots_list(...)
 
   # Extract the names.
   frame_names <- extract_frame_names_from_dots(dots)

--- a/tests/testthat/test-tribble.R
+++ b/tests/testthat/test-tribble.R
@@ -1,7 +1,6 @@
 context("tribble()")
 
 test_that("tribble() constructs 'tibble' as expected", {
-
   result <- tribble(
     ~colA, ~colB,
     "a", 1,
@@ -44,6 +43,17 @@ test_that("tribble() constructs 'tibble' as expected", {
 
   expect_equal(long, long_expectation)
 
+})
+
+test_that("tribble() tolerates a trailing comma", {
+  result <- tribble(
+    ~colA, ~colB,
+    "a", 1,
+    "b", 2,
+  )
+
+  compared <- tibble(colA = c("a", "b"), colB = c(1, 2))
+  expect_equal(result, compared)
 })
 
 test_that("tribble() handles columns with a class (#161)", {


### PR DESCRIPTION
Close #338 

## Idea:
- Use `sys.call()` to get the list of function arguments
- Get rid of trailing commas
- Pass the remaining arguments forward

## Problem (need help): 

If there are unevaluated expressions in the list of arguments, I don't know how to keep track of the environment where they are created and should be evaluated in. For example, the following test case currently fails:

```
test_that("tribble() handles columns with a class (#161)", {
  sys_date <- Sys.Date()
  sys_time <- Sys.time()
  date_time_col <- tribble(
    ~dt, ~dttm,
    sys_date, sys_time,
    as.Date("2003-01-02"), as.POSIXct("2004-04-05 13:45:17", tz = "UTC")
  )

  <<rest is omitted>>
})
```

`extract_frame_data_from_dots` is not intelligent enough to look for `sys_date` and `sys_time` by traversing up the tree of calling environments. How to do this?