### PR TITLE
Resolve #365: `as_tibble` checks column length twice

### DIFF
--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -102,7 +102,7 @@ list_to_tibble <- function(x, validate) {
   }
   x <- recycle_columns(x)
 
-  new_tibble(x, validate = FALSE)
+  new_tibble(x)
 }
 
 #' @export

--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -102,7 +102,7 @@ list_to_tibble <- function(x, validate) {
   }
   x <- recycle_columns(x)
 
-  new_tibble(x)
+  new_tibble(x, validate = FALSE)
 }
 
 #' @export

--- a/R/new.R
+++ b/R/new.R
@@ -7,7 +7,6 @@
 #' @param x A tibble-like object
 #' @param ... Passed on to [structure()]
 #' @param nrow The number of rows, guessed from the data by default
-#' @param validate Whether to validate that columns have matching \code{nrow}, or are recyclable
 #' @param subclass Subclasses to assign to the new object, default: none
 #' @export
 #' @examples

--- a/R/new.R
+++ b/R/new.R
@@ -7,7 +7,6 @@
 #' @param x A tibble-like object
 #' @param ... Passed on to [structure()]
 #' @param nrow The number of rows, guessed from the data by default
-#' @param validate Whether to validate that columns have matching \code{nrow}, or are recyclable
 #' @param subclass Subclasses to assign to the new object, default: none
 #' @export
 #' @examples
@@ -21,12 +20,12 @@
 #'
 #' \dontrun{
 #' # All columns must be the same length:
-#' new_tibble(list(a = 1:3, b = 4:6))
+#' new_tibble(list(a = 1:3, b = 4.6))
 #'
 #' # The length must be consistent with the nrow argument if available:
 #' new_tibble(list(a = 1:3, b = 4:6), nrow = 2)
 #' }
-new_tibble <- function(x, ..., nrow = NULL, subclass = NULL, validate = TRUE) {
+new_tibble <- function(x, ..., nrow = NULL, subclass = NULL) {
   #' @details
   #' `x` must be a named (or empty) list, but the names are not currently
   #' checked for correctness.
@@ -84,11 +83,11 @@ update_tibble_attrs <- function(x, ...) {
 
 guess_nrow <- function(x) {
   if (!is.null(.row_names_info(x, 0L))) {
-    list("nrow" = .row_names_info(x, 2L), "method" = "attribute")
+    list(nrow = .row_names_info(x, 2L), method = "row.names attribute")
   } else if (length(x) == 0) {
-    list("nrow" = 0L, "method" = "detected empty list")
+    list(nrow = 0L, method = "detected empty list")
   } else {
-    list("nrow" = NROW(x[[1L]]), "method" = "first column length")
+    list(nrow = NROW(x[[1L]]), method = "length of first column")
   }
 }
 

--- a/R/new.R
+++ b/R/new.R
@@ -102,7 +102,7 @@ validate_nrow <- function(x, nrow_set_method) {
       msg <- c(
         msg[1:5],
         paste0(
-          "... with ", length(bad_len) - 5, " more inconsistent",
+          pre_dots("with"), length(bad_len) - 5, " more inconsistent",
           pluralise_n(" column(s): ", length(bad_len) - 5),
           collapse(tick(vars[6:length(vars)]))
         )

--- a/R/new.R
+++ b/R/new.R
@@ -97,16 +97,21 @@ validate_nrow <- function(x, nrow_set_method) {
   if (any(bad_len)) {
     vars <- names(x)[bad_len]
     vars_len <- lengths[bad_len]
-    msg <- paste0("* Column `", vars, "` has length ", vars_len, "\n")
+    msg <- paste0("* Column ", tick(vars), " has length ", vars_len, "\n")
     if (length(bad_len) > 5) {
-      msg <- c(msg[1:5],
-               paste0("... and ", length(bad_len) - 5, " more inconsistent ",
-                      pluralise_n("column(s)", length(bad_len) - 5)))
+      msg <- c(
+        msg[1:5],
+        paste0(
+          "... with ", length(bad_len) - 5, " more inconsistent",
+          pluralise_n(" column(s): ", length(bad_len) - 5),
+          collapse(tick(vars[6:length(vars)]))
+        )
+      )
     }
     stopc(
       pluralise("Column(s) ", vars), "must have consistent lengths:\n",
       "* Expected column length is ", expected_nrow, " based on ", nrow_set_method, "\n",
-      do.call(paste0, as.list(msg))
+      invoke(paste0, as.list(msg))
     )
   }
 

--- a/R/new.R
+++ b/R/new.R
@@ -19,13 +19,11 @@
 #' # It's safest to always pass it along:
 #' new_tibble(list(a = 1:3, b = 4:6), nrow = 3)
 #'
-#' \dontrun{
 #' # All columns must be the same length:
-#' new_tibble(list(a = 1:3, b = 4.6))
+#' try(new_tibble(list(a = 1:3, b = 4:5)))
 #'
 #' # The length must be consistent with the nrow argument if available:
-#' new_tibble(list(a = 1:3, b = 4:6), nrow = 2)
-#' }
+#' try(new_tibble(list(a = 1:3, b = 4:6), nrow = 2))
 new_tibble <- function(x, ..., nrow = NULL, subclass = NULL) {
   #' @details
   #' `x` must be a named (or empty) list, but the names are not currently
@@ -101,6 +99,11 @@ validate_nrow <- function(x, nrow_set_method) {
     vars <- names(x)[bad_len]
     vars_len <- lengths[bad_len]
     msg <- paste0("* Column `", vars, "` has length ", vars_len, "\n")
+    if (length(bad_len) > 5) {
+      msg <- c(msg[1:5],
+               paste0("... and ", length(bad_len) - 5, " more inconsistent ",
+                      pluralise_n("column(s)", length(bad_len) - 5)))
+    }
     stopc(
       pluralise("Column(s) ", vars), "must have consistent lengths:\n",
       "* Expected column length is ", expected_nrow, " based on ", nrow_set_method, "\n",

--- a/R/new.R
+++ b/R/new.R
@@ -25,7 +25,7 @@
 #' # The length must be consistent with the nrow argument if available:
 #' new_tibble(list(a = 1:3, b = 4:6), nrow = 2)
 #' }
-new_tibble <- function(x, ..., nrow = NULL, subclass = NULL) {
+new_tibble <- function(x, ..., nrow = NULL, subclass = NULL, validate = TRUE) {
   #' @details
   #' `x` must be a named (or empty) list, but the names are not currently
   #' checked for correctness.
@@ -46,7 +46,7 @@ new_tibble <- function(x, ..., nrow = NULL, subclass = NULL) {
   attr(x, "row.names") <- .set_row_names(nrow)
   #' The `new_tibble()` constructor makes sure that the `row.names` attribute
   #' is consistent with the data before returning.
-  validate_nrow(x)
+  if (validate) validate_nrow(x)
 
   #' @details
   #' The `class` attribute of the returned object always consists of

--- a/R/new.R
+++ b/R/new.R
@@ -7,6 +7,7 @@
 #' @param x A tibble-like object
 #' @param ... Passed on to [structure()]
 #' @param nrow The number of rows, guessed from the data by default
+#' @param validate Whether to validate that columns have matching \code{nrow}, or are recyclable
 #' @param subclass Subclasses to assign to the new object, default: none
 #' @export
 #' @examples

--- a/R/new.R
+++ b/R/new.R
@@ -98,13 +98,12 @@ validate_nrow <- function(x, nrow_set_method) {
     vars <- names(x)[bad_len]
     vars_len <- lengths[bad_len]
     msg <- paste0("* Column ", tick(vars), " has length ", vars_len, "\n")
-    if (length(bad_len) > 5) {
+    if (sum(bad_len) > 5) {
       msg <- c(
         msg[1:5],
         paste0(
-          pre_dots("with"), length(bad_len) - 5, " more inconsistent",
-          pluralise_n(" column(s): ", length(bad_len) - 5),
-          collapse(tick(vars[6:length(vars)]))
+          pre_dots("with "), sum(bad_len) - 5, " more inconsistent",
+          pluralise_n(" column(s)", sum(bad_len) - 5)
         )
       )
     }

--- a/R/tibble.R
+++ b/R/tibble.R
@@ -128,13 +128,6 @@ recycle_columns <- function(x) {
 
   max <- max(lengths[lengths != 1L], 0L)
 
-  bad_len <- lengths != 1L & lengths != max
-  if (any(bad_len)) {
-    invalid_df_msg(
-      paste0("must be length 1 or ", max, ", not "), x, bad_len, lengths[bad_len]
-    )
-  }
-
   short <- lengths == 1
   if (max > 1L && any(short)) {
     x[short] <- map(x[short], rep, max)
@@ -150,15 +143,5 @@ invalid_df <- function(problem, df, vars) {
   stopc(
     pluralise_msg("Column(s) ", vars), " ",
     pluralise(problem, vars)
-  )
-}
-
-invalid_df_msg <- function(problem, df, vars, extra) {
-  if (is.logical(vars)) {
-    vars <- names(df)[vars]
-  }
-  stopc(
-    pluralise_msg("Column(s) ", vars), " ",
-    pluralise_msg(problem, extra)
   )
 }

--- a/tests/testthat/test-data-frame.R
+++ b/tests/testthat/test-data-frame.R
@@ -58,7 +58,11 @@ test_that("length 1 vectors are recycled", {
   expect_equal(nrow(tibble(x = 1:10, y = 1)), 10)
   expect_error(
     tibble(x = 1:10, y = 1:2),
-    "Error: Columns must have consistent lengths:\n* Column `x` has length 10\n* Column `y` has length 2",
+    paste0(
+      "Column must have consistent lengths:\n",
+      "* Expected column length is 10 based on length of first column\n",
+      "* Column `y` has length 2"
+    ),
     fixed = TRUE
   )
 })
@@ -113,17 +117,31 @@ test_that("tibble aliases", {
 test_that("columns must be same length", {
   expect_error(
     as_tibble(list(x = 1:2, y = 1:3)),
-    "Column `x` must be length 1 or 3, not 2",
+    paste0(
+      "Column must have consistent lengths:\n",
+      "* Expected column length is 2 based on length of first column\n",
+      "* Column `y` has length 3"
+    ),
     fixed = TRUE
   )
   expect_error(
     as_tibble(list(x = 1:2, y = 1:3, z = 1:4)),
-    "Columns `x`, `y` must be length 1 or 4, not 2, 3",
+    paste0(
+      "Columns must have consistent lengths:\n",
+      "* Expected column length is 2 based on length of first column\n",
+      "* Column `y` has length 3\n",
+      "* Column `z` has length 4"
+    ),
     fixed = TRUE
   )
   expect_error(
     as_tibble(list(x = 1:4, y = 1:2, z = 1:2)),
-    "Columns `y`, `z` must be length 1 or 4, not 2, 2",
+    paste0(
+      "Columns must have consistent lengths:\n",
+      "* Expected column length is 4 based on length of first column\n",
+      "* Column `y` has length 2\n",
+      "* Column `z` has length 2"
+    ),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-data-frame.R
+++ b/tests/testthat/test-data-frame.R
@@ -58,7 +58,7 @@ test_that("length 1 vectors are recycled", {
   expect_equal(nrow(tibble(x = 1:10, y = 1)), 10)
   expect_error(
     tibble(x = 1:10, y = 1:2),
-    "Column `y` must be length 1 or 10, not 2",
+    "Error: Columns must have consistent lengths:\n* Column `x` has length 10\n* Column `y` has length 2",
     fixed = TRUE
   )
 })


### PR DESCRIPTION
Skip column length check in `as_tibble` by making `validate_nrow` optional in `new_tibble`