### PR TITLE
 Informative error message for as_tibble() when rownames is missing

### DIFF
--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -77,6 +77,9 @@ as_tibble.data.frame <- function(x, validate = TRUE, ..., rownames = NA) {
     attr(result, "row.names") <- old_rownames
     result
   } else {
+    if (is.na(old_rownames[1])) {
+      stopc("Object does not have existing row names to be turned into a column")
+    }
     add_column(result, !! rownames := old_rownames, .before = 1L)
   }
 }

--- a/tests/testthat/test-data-frame.R
+++ b/tests/testthat/test-data-frame.R
@@ -268,6 +268,14 @@ test_that("as_tibble() can convert row names", {
   expect_identical(unclass(as_tibble(df)), unclass(df))
 })
 
+test_that("as_tibble() throws an error when user turns missing row names into column", {
+  df <- data.frame(a = 1:3, b = 2:4)
+  expect_error(
+    as_tibble(df, rownames = "id"),
+    "Object does not have existing row names to be turned into a column",
+    fixed = TRUE
+  )
+})
 
 test_that("as_data_frame is an alias of as_tibble", {
   expect_identical(as_data_frame(NULL), as_tibble(NULL))

--- a/tests/testthat/test-matrix.R
+++ b/tests/testthat/test-matrix.R
@@ -105,3 +105,10 @@ test_that("converting from matrix supports storing row names in a column", {
   out <- as_tibble(x, rownames = "id")
   expect_identical(out, df)
 })
+
+test_that("converting from matrix throws an error if user turns missing row names into column", {
+  x <- matrix(1:30, 6, 5)
+  expect_error(as_tibble(x, rownames = "id"),
+               "Object does not have existing row names to be turned into a column",
+               fixed = TRUE)
+})


### PR DESCRIPTION
`as_tibble()` now throws an error when user wants to convert row names into a column but row names is missing. Close #386.

**Question**: I wanted the error message to mention the object name, i.e. "Object my_matrix does not have existing row names"). However, I can't get `rlang::enexpr()` to capture the user-submitted expression. Instead, `rlang::enexpr()` returns the object. 

I think that this happens because when the expression goes through the generic function, the promise is already evaluated and can no longer be captured once it reaches `as_tibble.data.frame`. Is understanding correct?

If so, how can we capture the user-submitted expression?