### PR TITLE
improved meaningfulness of error message for column_to_rownames()

### DIFF
--- a/R/rownames.R
+++ b/R/rownames.R
@@ -83,7 +83,7 @@ column_to_rownames <- function(df, var = "rowname") {
   }
 
   if (!has_name(df, var)) {
-    stopc("Column `num2` not found")
+    stopc(paste0("Column `", var, "` not found"))
   }
 
   rownames(df) <- df[[var]]


### PR DESCRIPTION
The error message from `column_to_rownames()` currently refers to `num2` instead of the var argument value.

This PR removes num2 and adds the var argument value to the error message