### PR TITLE
fix examples with suggested packages

### DIFF
--- a/R/glimpse.R
+++ b/R/glimpse.R
@@ -20,10 +20,8 @@
 #' @examples
 #' glimpse(mtcars)
 #'
-#' if (!requireNamespace("nycflights13", quietly = TRUE))
-#'   stop("Please install the nycflights13 package to run the rest of this example")
-#'
-#' glimpse(nycflights13::flights)
+#' if (requireNamespace("nycflights13", quietly = TRUE))
+#'   glimpse(nycflights13::flights)
 glimpse <- function(x, width = NULL, ...) {
   UseMethod("glimpse")
 }

--- a/R/utils-format.r
+++ b/R/utils-format.r
@@ -23,11 +23,10 @@
 #' print(as_tibble(mtcars), n = 3)
 #' print(as_tibble(mtcars), n = 100)
 #'
-#' if (!requireNamespace("nycflights13", quietly = TRUE))
-#'   stop("Please install the nycflights13 package to run the rest of this example")
-#'
-#' print(nycflights13::flights, n_extra = 2)
-#' print(nycflights13::flights, width = Inf)
+#' if (requireNamespace("nycflights13", quietly = TRUE)) {
+#'   print(nycflights13::flights, n_extra = 2)
+#'   print(nycflights13::flights, width = Inf)
+#' }
 #' @name formatting
 NULL
 


### PR DESCRIPTION
A `stop` call after `requireNamespace` causes `R CMD check` to fail if the suggested package `nycflights13` is not installed.