### PR TITLE
Improve error message in column length checking logic.

### DIFF
--- a/R/msg.R
+++ b/R/msg.R
@@ -101,8 +101,8 @@ error_time_column_must_be_posixct <- function(names) {
 
 error_inconsistent_cols <- function(expected_nrow, nrow_set_method, vars, vars_len) {
   bullets(
-    "All columns in a tibble must have consistent lengths:",
-    paste0("Expected column length is ", expected_nrow, " based on ", nrow_set_method),
+    "Tibble columns must have consistent lengths:",
+    paste0("The required length is ", expected_nrow, " (from ", nrow_set_method, ")"),
     paste0("Column ", tick(vars), " has length ", vars_len)
   )
 }

--- a/R/new.R
+++ b/R/new.R
@@ -45,12 +45,19 @@ new_tibble <- function(x, ..., nrow = NULL, subclass = NULL) {
     nrow <- guess$nrow
     nrow_set_method <- guess$method
   } else {
-    nrow_set_method <- "value of `nrow` argument"
+    nrow_set_method <- "`nrow`"
   }
   attr(x, "row.names") <- .set_row_names(nrow)
   #' The `new_tibble()` constructor makes sure that the `row.names` attribute
   #' is consistent with the data before returning.
-  validate_nrow(x, nrow_set_method)
+  # Validate column lengths, don't recycle
+  lengths <- map_int(x, NROW)
+  bad_len <- which(lengths != nrow)
+  if (has_length(bad_len)) {
+    abort(error_inconsistent_cols(
+      nrow, nrow_set_method, names(x)[bad_len], lengths[bad_len]
+    ))
+  }
 
   #' @details
   #' The `class` attribute of the returned object always consists of
@@ -85,22 +92,12 @@ guess_nrow <- function(x) {
   } else if (length(x) == 0) {
     list(nrow = 0L, method = "detected empty list")
   } else {
-    list(nrow = NROW(x[[1L]]), method = "length of first column")
+    col_lens <- map_int(x, NROW)
+    longest_cols <- names(col_lens)[col_lens == max(col_lens)]
+    list(nrow = max(map_int(x, NROW)),
+         method = paste("the longest", pluralise("column(s)", longest_cols),
+                        paste(tick(longest_cols), collapse = ",")))
   }
-}
-
-validate_nrow <- function(x, nrow_set_method) {
-  # Validate column lengths, don't recycle
-  lengths <- map_int(x, NROW)
-  expected_nrow <- .row_names_info(x, 2L)
-  bad_len <- which(lengths != expected_nrow)
-  if (has_length(bad_len)) {
-    abort(error_inconsistent_cols(
-      expected_nrow, nrow_set_method, names(x)[bad_len], lengths[bad_len]
-    ))
-  }
-
-  invisible(x)
 }
 
 set_tibble_class <- function(x, subclass = NULL) {

--- a/tests/testthat/test-data-frame.R
+++ b/tests/testthat/test-data-frame.R
@@ -40,7 +40,7 @@ test_that("length 1 vectors are recycled", {
   expect_equal(nrow(tibble(x = 1:10, y = 1)), 10)
   expect_error(
     tibble(x = 1:10, y = 1:2),
-    error_inconsistent_cols(10, "length of first column", "y", 2),
+    error_inconsistent_cols(10, "the longest column `x`", "y", 2),
     fixed = TRUE
   )
 })
@@ -95,16 +95,16 @@ test_that("tibble aliases", {
 test_that("columns must be same length", {
   expect_error(
     as_tibble(list(x = 1:2, y = 1:3)),
-    error_inconsistent_cols(2, "length of first column", "y", 3),
+    error_inconsistent_cols(3, "the longest column `y`", "x", 2),
     fixed = TRUE
   )
   expect_error(
     as_tibble(list(x = 1:2, y = 1:3, z = 1:4)),
     error_inconsistent_cols(
-      2,
-      "length of first column",
-      c("y", "z"),
-      3:4
+      4,
+      "the longest column `z`",
+      c("x", "y"),
+      2:3
     ),
     fixed = TRUE
   )
@@ -112,7 +112,7 @@ test_that("columns must be same length", {
     as_tibble(list(x = 1:4, y = 1:2, z = 1:2)),
     error_inconsistent_cols(
       4,
-      "length of first column",
+      "the longest column `x`",
       c("y", "z"),
       c(2, 2)
     ),
@@ -239,6 +239,16 @@ test_that("as_data_frame is an alias of as_tibble", {
 
 test_that("as.tibble is an alias of as_tibble", {
   expect_identical(as.tibble(NULL), as_tibble(NULL))
+})
+
+# new_tibble -------------------------------------------------------------
+
+test_that("new_tibble can specify nrow,", {
+  expect_error(
+    new_tibble(list(x = 1:2, y = 1:3), nrow = 4),
+    error_inconsistent_cols(4, "`nrow`", c("x", "y"), c(2, 3)),
+    fixed = TRUE
+  )
 })
 
 

--- a/tests/testthat/test-msg.R
+++ b/tests/testthat/test-msg.R
@@ -208,8 +208,8 @@ test_that("error_inconsistent_cols()", {
       2:3
     ),
     bullets(
-      "All columns in a tibble must have consistent lengths:",
-      "Expected column length is 10 based on detection method",
+      "Tibble columns must have consistent lengths:",
+      "The required length is 10 (from detection method)",
       "Column `a` has length 2",
       "Column `b` has length 3"
     )


### PR DESCRIPTION
Addresses #437.

- The required column length is now the length of the longest column (instead of the first column)
- Improve error message as specified in #437.