### PR TITLE
bring error msg in line with allowed matrix/df cols as per #416

### DIFF
--- a/R/msg.R
+++ b/R/msg.R
@@ -94,7 +94,7 @@ error_column_must_have_unique_name <- function(names) {
 
 error_column_must_be_vector <- function(names, classes) {
   bullets(
-    "All columns in a tibble must be a 1d vector or a list:",
+    "All columns in a tibble must be a 1d vector, a list or a matrix:",
     paste0("Column ", tick(names), " is ", classes)
   )
 }

--- a/R/msg.R
+++ b/R/msg.R
@@ -94,7 +94,7 @@ error_column_must_have_unique_name <- function(names) {
 
 error_column_must_be_vector <- function(names, classes) {
   bullets(
-    "All columns in a tibble must be a 1d vector, a list or a matrix:",
+    "All columns in a tibble must be 1d or 2d objects:",
     paste0("Column ", tick(names), " is ", classes)
   )
 }

--- a/tests/testthat/test-msg.R
+++ b/tests/testthat/test-msg.R
@@ -168,7 +168,7 @@ test_that("error_column_must_be_vector()", {
   expect_equal(
     error_column_must_be_vector("a", "environment"),
     bullets(
-      "All columns in a tibble must be a 1d vector, a list or a matrix:",
+      "All columns in a tibble must be 1d or 2d objects:",
       "Column `a` is environment"
     )
   )
@@ -176,7 +176,7 @@ test_that("error_column_must_be_vector()", {
   expect_equal(
     error_column_must_be_vector(letters[2:3], c("name", "NULL")),
     bullets(
-      "All columns in a tibble must be a 1d vector, a list or a matrix:",
+      "All columns in a tibble must be 1d or 2d objects:",
       "Column `b` is name",
       "Column `c` is NULL"
     )
@@ -185,7 +185,7 @@ test_that("error_column_must_be_vector()", {
   expect_equal(
     error_column_must_be_vector(LETTERS, letters),
     bullets(
-      "All columns in a tibble must be a 1d vector, a list or a matrix:",
+      "All columns in a tibble must be 1d or 2d objects:",
       paste0("Column `", LETTERS, "` is ", letters)
     )
   )

--- a/tests/testthat/test-msg.R
+++ b/tests/testthat/test-msg.R
@@ -168,7 +168,7 @@ test_that("error_column_must_be_vector()", {
   expect_equal(
     error_column_must_be_vector("a", "environment"),
     bullets(
-      "All columns in a tibble must be a 1d vector or a list:",
+      "All columns in a tibble must be a 1d vector, a list or a matrix:",
       "Column `a` is environment"
     )
   )
@@ -176,7 +176,7 @@ test_that("error_column_must_be_vector()", {
   expect_equal(
     error_column_must_be_vector(letters[2:3], c("name", "NULL")),
     bullets(
-      "All columns in a tibble must be a 1d vector or a list:",
+      "All columns in a tibble must be a 1d vector, a list or a matrix:",
       "Column `b` is name",
       "Column `c` is NULL"
     )
@@ -185,7 +185,7 @@ test_that("error_column_must_be_vector()", {
   expect_equal(
     error_column_must_be_vector(LETTERS, letters),
     bullets(
-      "All columns in a tibble must be a 1d vector or a list:",
+      "All columns in a tibble must be a 1d vector, a list or a matrix:",
       paste0("Column `", LETTERS, "` is ", letters)
     )
   )


### PR DESCRIPTION
Since matrix/df columns are now allowed, maybe this error msg should be changed accordingly, as well as respective tests.

Didn't mention df's explicitly, because those are, after all, lists.