### PR TITLE
New strategy for syntactic names

### DIFF
--- a/R/repair-names.R
+++ b/R/repair-names.R
@@ -258,9 +258,19 @@ check_unique_names <- function(x) {
   invisible(x)
 }
 
+make_names <- function(name) {
+  name <- gsub("^(|[.][.][.]|[.][.][1-9][0-9]*|[.][0-9].*)$", ".\\1", name)
+  new_name <- make.names(name)
+  different <- which(new_name != name)
+  reserved_in_different <- grep("^[a-zA-Z][a-zA-Z_]*$", name[different])
+  reserved <- different[reserved_in_different]
+  new_name[reserved] <- paste0(".", name[reserved])
+  new_name
+}
+
 make_syntactic <- function(name) {
-  fix_syntactic <- (name != "") & !is_syntactic(name)
-  name[fix_syntactic] <- make.names(name[fix_syntactic])
+  fix_syntactic <- !is_syntactic(name)
+  name[fix_syntactic] <- make_names(name[fix_syntactic])
   name
 }
 

--- a/R/repair-names.R
+++ b/R/repair-names.R
@@ -188,15 +188,7 @@ set_minimal_names <- function(x) {
 }
 
 unique_names <- function(name, quiet = FALSE) {
-  new_name <- minimal_names(name)
-  new_name <- strip_pos(name)
-  new_name <- append_pos(new_name)
-
-  if (!quiet) {
-    describe_repair(name, new_name)
-  }
-
-  new_name
+  tidy_names(name, syntactic = FALSE, quiet = quiet)
 }
 
 set_unique_names <- function(x, quiet = FALSE) {
@@ -205,19 +197,8 @@ set_unique_names <- function(x, quiet = FALSE) {
   set_names(x, new_names)
 }
 
-## TODO: this is just a placeholder = near copy of tidy_names()
-##       but may see more refactoring
 syntactic_names <- function(name, quiet = FALSE) {
-  new_name <- minimal_names(name)
-  new_name <- strip_pos(name)
-  new_name <- make_syntactic(new_name)
-  new_name <- unique_names(new_name, quiet = TRUE)
-
-  if (!quiet) {
-    describe_repair(name, new_name)
-  }
-
-  new_name
+  tidy_names(name, syntactic = TRUE, quiet = quiet)
 }
 
 set_syntactic_names <- function(x, quiet = FALSE) {
@@ -351,7 +332,7 @@ tidy_names <- function(name, syntactic = FALSE, quiet = FALSE) {
   if (syntactic) {
     new_name <- make_syntactic(new_name)
   }
-  new_name <- unique_names(new_name, quiet = TRUE)
+  new_name <- append_pos(new_name)
 
   if (!quiet) {
     describe_repair(name, new_name)

--- a/R/repair-names.R
+++ b/R/repair-names.R
@@ -277,9 +277,12 @@ make_syntactic <- function(name) {
 ## TODO: do we need checks around "syntactic"-ness?
 
 append_pos <- function(name) {
+  name[name == ""] <- "."
+
   need_append_pos <- duplicated(name) |
     duplicated(name, fromLast = TRUE) |
-    name == ""
+    (name == ".")
+
   need_append_pos <- which(need_append_pos)
   name[need_append_pos] <- paste0(name[need_append_pos], "..", need_append_pos)
   name

--- a/R/utils.r
+++ b/R/utils.r
@@ -63,7 +63,7 @@ tick <- function(x) {
 }
 
 is_syntactic <- function(x) {
-  ret <- make.names(x) == x
+  ret <- make_names(x) == x
   ret[is.na(x)] <- FALSE
   ret
 }

--- a/tests/testthat/test-name_repair.R
+++ b/tests/testthat/test-name_repair.R
@@ -47,12 +47,12 @@ test_that("check_minimal() errors when names aren't minimal", {
 
 test_that("unique_names() eliminates emptiness and duplication", {
   x <- c("", "x", "y", "x")
-  expect_identical(unique_names(x), c("..1", "x..2", "y", "x..4"))
+  expect_identical(unique_names(x), c("...1", "x..2", "y", "x..4"))
 })
 
 test_that("unique_names() strips positional suffixes, re-applies as needed", {
   x <- c("..20", "a..1", "b", "", "a..2")
-  expect_identical(unique_names(x), c("..1", "a..2", "b", "..4", "a..5"))
+  expect_identical(unique_names(x), c("...1", "a..2", "b", "...4", "a..5"))
 })
 
 test_that("check_unique() imposes check_minimal()", {

--- a/tests/testthat/test-name_repair.R
+++ b/tests/testthat/test-name_repair.R
@@ -1,5 +1,20 @@
 context("test-name_repair")
 
+# make_names --------------------------------------------------------------
+
+test_that("make_names()", {
+  expect_equal(
+    make_names(c("", ".", "..", "...", "....", "..1", "..13", "..2.", ".2fa")),
+    c(".", ".", "..", "....", "....", "...1", "...13", "..2.", "..2fa")
+  )
+  expect_equal(
+    make_names(c("if", "TRUE", "Inf", "NA_real_", "normal")),
+    c(".if", ".TRUE", ".Inf", ".NA_real_", "normal")
+  )
+})
+
+# minimal -----------------------------------------------------------------
+
 test_that("minimal names are made from `n` when `name = NULL`", {
   expect_identical(minimal_names(NULL, 2), c("", ""))
   expect_error(
@@ -82,8 +97,8 @@ test_that("syntactic_names() pass checks for minimal, unique, and syntactic", {
   x_syn <- syntactic_names(x)
   expect_error(check_minimal(x_syn), NA)
   expect_error(check_unique(x_syn), NA)
-  expect_true(all(is_syntactic(x_syn)))
-  expect_identical(x_syn, c("..1", "..2", "x..3", "x..4", "a1.", "X_x_y."))
+  expect_true(all(!!is_syntactic(x_syn)))
+  expect_identical(x_syn, c("...1", "...2", "x..3", "x..4", "a1.", "X_x_y."))
 })
 
 test_that("name fixers are idempotent", {

--- a/tests/testthat/test-syntactic-names.R
+++ b/tests/testthat/test-syntactic-names.R
@@ -68,6 +68,7 @@ test_that("corner case", {
   expect_equal(syntactic_names(c("a..3", "a", "a")), c("a..1", "a..2", "a..3"))
   expect_equal(syntactic_names(c("a..2", "a", "a")), c("a..1", "a..2", "a..3"))
   expect_equal(syntactic_names(c("a..2", "a..2", "a..2")), c("a..1", "a..2", "a..3"))
+  expect_equal(syntactic_names("if..2"), ".if")
 })
 
 test_that("message", {

--- a/tests/testthat/test-syntactic-names.R
+++ b/tests/testthat/test-syntactic-names.R
@@ -1,0 +1,86 @@
+context("syntactic_names")
+
+test_that("zero-length inputs given character names", {
+  out <- set_syntactic_names(character())
+  expect_equal(names(out), character())
+})
+
+test_that("unnamed input gives uniquely named output", {
+  out <- set_syntactic_names(1:3)
+  expect_equal(names(out), c("...1", "...2", "...3"))
+})
+
+test_that("messages by default", {
+  expect_message(
+    set_syntactic_names(set_names(1, "")),
+    "New names:\n* `` -> ...1\n",
+    fixed = TRUE
+  )
+})
+
+test_that("quiet = TRUE", {
+  expect_message(set_syntactic_names(set_names(1, ""), quiet = TRUE), NA)
+})
+
+test_that("non-syntactic names", {
+  out <- set_syntactic_names(set_names(1, "a b"))
+  expect_equal(names(out), "a.b")
+
+  expect_equal(syntactic_names("a b"), "a.b")
+})
+
+# syntactic_names ---------------------------------------------------------------
+
+test_that("zero-length input", {
+  expect_equal(syntactic_names(character()), character())
+})
+
+test_that("proper names", {
+  expect_equal(syntactic_names(letters), letters)
+})
+
+test_that("dupes", {
+  expect_equal(
+    syntactic_names(c("a", "b", "a", "c", "b")),
+    c("a..1", "b..2", "a..3", "c", "b..5")
+  )
+})
+
+test_that("empty", {
+  expect_equal(syntactic_names(""), "...1")
+})
+
+test_that("dot", {
+  expect_equal(syntactic_names("."), "...1")
+})
+
+test_that("NA", {
+  expect_equal(syntactic_names(NA_character_), "...1")
+})
+
+test_that("corner case", {
+  expect_equal(syntactic_names("..1"), "...1")
+  expect_equal(syntactic_names("..13"), "...1")
+  expect_equal(syntactic_names("..."), "....")
+
+  expect_equal(syntactic_names("a..1"), "a")
+  expect_equal(syntactic_names(c("a..2", "a")), c("a..1", "a..2"))
+  expect_equal(syntactic_names(c("a..3", "a", "a")), c("a..1", "a..2", "a..3"))
+  expect_equal(syntactic_names(c("a..2", "a", "a")), c("a..1", "a..2", "a..3"))
+  expect_equal(syntactic_names(c("a..2", "a..2", "a..2")), c("a..1", "a..2", "a..3"))
+})
+
+test_that("message", {
+  expect_message(
+    syntactic_names(c("", "")),
+    "New names:\n* `` -> ...1\n* `` -> ...2\n",
+    fixed = TRUE
+  )
+})
+
+test_that("quiet", {
+  expect_message(
+    syntactic_names("", quiet = TRUE),
+    NA
+  )
+})

--- a/tests/testthat/test-tidy-names.R
+++ b/tests/testthat/test-tidy-names.R
@@ -7,13 +7,13 @@ test_that("zero-length inputs given character names", {
 
 test_that("unnamed input gives uniquely named output", {
   out <- set_tidy_names(1:3)
-  expect_equal(names(out), c("..1", "..2", "..3"))
+  expect_equal(names(out), c("...1", "...2", "...3"))
 })
 
 test_that("messages by default", {
   expect_message(
     set_tidy_names(set_names(1, "")),
-    "New names:\n* `` -> `..1`\n",
+    "New names:\n* `` -> ...1\n",
     fixed = TRUE
   )
 })
@@ -22,9 +22,11 @@ test_that("quiet = TRUE", {
   expect_message(set_tidy_names(set_names(1, ""), quiet = TRUE), NA)
 })
 
-test_that("syntactic = TRUE", {
-  out <- set_tidy_names(set_names(1, "a b"), syntactic = TRUE)
-  expect_equal(names(out), "a.b")
+test_that("non-syntactic names", {
+  out <- set_tidy_names(set_names(1, "a b"))
+  expect_equal(names(out), "a b")
+
+  expect_equal(tidy_names("a b"), "a b")
 })
 
 # tidy_names ---------------------------------------------------------------
@@ -45,39 +47,33 @@ test_that("dupes", {
 })
 
 test_that("empty", {
-  expect_equal(tidy_names(""), "..1")
+  expect_equal(tidy_names(""), "...1")
+})
+
+test_that("dot", {
+  expect_equal(tidy_names("."), "...1")
 })
 
 test_that("NA", {
-  expect_equal(tidy_names(NA_character_), "..1")
+  expect_equal(tidy_names(NA_character_), "...1")
 })
 
 test_that("corner case", {
-  expect_equal(tidy_names("..1"), "..1")
-  expect_equal(tidy_names("..13"), "..1")
+  expect_equal(tidy_names("..1"), "...1")
+  expect_equal(tidy_names("..13"), "...1")
   expect_equal(tidy_names("..."), "...")
 
+  expect_equal(tidy_names("a..1"), "a")
   expect_equal(tidy_names(c("a..2", "a")), c("a..1", "a..2"))
   expect_equal(tidy_names(c("a..3", "a", "a")), c("a..1", "a..2", "a..3"))
   expect_equal(tidy_names(c("a..2", "a", "a")), c("a..1", "a..2", "a..3"))
   expect_equal(tidy_names(c("a..2", "a..2", "a..2")), c("a..1", "a..2", "a..3"))
 })
 
-test_that("syntactic", {
-  expect_equal(tidy_names("a b", syntactic = TRUE), make.names("a b"))
-})
-
-test_that("some syntactic + message (#260)", {
-  expect_equal(
-    tidy_names(c("a b", "c"), syntactic = TRUE),
-    c(make.names("a b"), "c")
-  )
-})
-
 test_that("message", {
   expect_message(
     tidy_names(c("", "")),
-    "New names:\n* `` -> `..1`\n* `` -> `..2`\n",
+    "New names:\n* `` -> ...1\n* `` -> ...2\n",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-tidy-names.R
+++ b/tests/testthat/test-tidy-names.R
@@ -68,6 +68,7 @@ test_that("corner case", {
   expect_equal(tidy_names(c("a..3", "a", "a")), c("a..1", "a..2", "a..3"))
   expect_equal(tidy_names(c("a..2", "a", "a")), c("a..1", "a..2", "a..3"))
   expect_equal(tidy_names(c("a..2", "a..2", "a..2")), c("a..1", "a..2", "a..3"))
+  expect_equal(tidy_names("if..2"), "if")
 })
 
 test_that("message", {

--- a/tests/testthat/test-tidy_names.R
+++ b/tests/testthat/test-tidy_names.R
@@ -13,7 +13,7 @@ test_that("unnamed input gives uniquely named output", {
 test_that("messages by default", {
   expect_message(
     set_tidy_names(set_names(1, "")),
-    "New names:\n* `` -> ..1\n",
+    "New names:\n* `` -> `..1`\n",
     fixed = TRUE
   )
 })
@@ -23,8 +23,8 @@ test_that("quiet = TRUE", {
 })
 
 test_that("syntactic = TRUE", {
-  out <- set_tidy_names(set_names(1, "a b"))
-  expect_equal(names(out), tidy_names("a b"))
+  out <- set_tidy_names(set_names(1, "a b"), syntactic = TRUE)
+  expect_equal(names(out), "a.b")
 })
 
 # tidy_names ---------------------------------------------------------------
@@ -53,6 +53,10 @@ test_that("NA", {
 })
 
 test_that("corner case", {
+  expect_equal(tidy_names("..1"), "..1")
+  expect_equal(tidy_names("..13"), "..1")
+  expect_equal(tidy_names("..."), "...")
+
   expect_equal(tidy_names(c("a..2", "a")), c("a..1", "a..2"))
   expect_equal(tidy_names(c("a..3", "a", "a")), c("a..1", "a..2", "a..3"))
   expect_equal(tidy_names(c("a..2", "a", "a")), c("a..1", "a..2", "a..3"))
@@ -73,7 +77,7 @@ test_that("some syntactic + message (#260)", {
 test_that("message", {
   expect_message(
     tidy_names(c("", "")),
-    "New names:\n* `` -> ..1\n* `` -> ..2\n",
+    "New names:\n* `` -> `..1`\n* `` -> `..2`\n",
     fixed = TRUE
   )
 })


### PR DESCRIPTION
For both unique and syntactic:

- Number-only names are always syntactic
- Single dot also gets a number
- We still strip existing `..#` prefixes

For syntactic names, additionally:

- If a name is blank or a reserved word, a dot is prepended

Closes #459.