### PR TITLE
The `.named` argument can no longer be a width

### DIFF
--- a/R/lst.R
+++ b/R/lst.R
@@ -18,7 +18,7 @@
 #' @export
 #' @rdname tibble
 lst <- function(...) {
-  xs <- quos(..., .named = 500L)
+  xs <- quos(..., .named = TRUE)
   lst_quos(xs)
 }
 


### PR DESCRIPTION
Soft-deprecated in rlang 0.3.0