### PR TITLE
rex-ify make_syntactic()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ LazyData: yes
 Roxygen: list(markdown = TRUE, roclets = c("collate", "namespace", "rd", "pkgapi::api_roclet"))
 RoxygenNote: 6.1.0.9000
 Collate: 
+    'aaa-rex.R'
     'add.R'
     'as_tibble.R'
     'check-names.R'

--- a/R/aaa-rex.R
+++ b/R/aaa-rex.R
@@ -1,0 +1,41 @@
+rex <- function(...) {
+  paste0(...)
+}
+
+group <- function(...) {
+  paste0("(?:", ..., ")")
+}
+
+capture <- function(x) {
+  paste0("(", x, ")")
+}
+
+or <- function(...) {
+  paste0(map_chr(c(...), group), collapse = "|")
+}
+
+zero_or_more <- function(x) {
+  paste0(group(x), "*")
+}
+
+escape <- function(x) {
+  paste0("\\", x)
+}
+
+one_of <- function(...) {
+  paste0("[", ..., "]")
+}
+
+range <- function(from, to) {
+  one_of(paste0(from, "-", to))
+}
+
+any <- "."
+
+nothing <- ""
+
+anything <- zero_or_more(any)
+
+start <- "^"
+
+end <- "$"

--- a/R/aaa-rex.R
+++ b/R/aaa-rex.R
@@ -11,11 +11,11 @@ capture <- function(x) {
 }
 
 or <- function(...) {
-  paste0(map_chr(c(...), group), collapse = "|")
+  group(paste0(c(...), collapse = "|"))
 }
 
 zero_or_more <- function(x) {
-  paste0(group(x), "*")
+  paste0(x, "*")
 }
 
 escape <- function(x) {
@@ -34,7 +34,7 @@ any <- "."
 
 nothing <- ""
 
-anything <- zero_or_more(any)
+anything <- ".*"
 
 start <- "^"
 

--- a/R/repair-names.R
+++ b/R/repair-names.R
@@ -360,10 +360,13 @@ prepend_syntactic_dot_rx <- rex(
     group(escape("."), range("0", "9"), anything)
   )),
 
-  # We capture the entire string and prepend a dot and a second dot if needed.
-
   end
 )
+
+# We capture the entire string and prepend a dot and a second dot if needed.
+prepend_syntactic_dot_sub <- ".\\2\\1"
+
+
 
 ## makes each individual name syntactic
 ## does not enforce unique-ness
@@ -381,11 +384,7 @@ make_syntactic <- function(name) {
   ##   * declined its addition of 'X' prefixes
   ##   * turned its '.' suffixes to '.' prefixes
 
-  new_name <- gsub(
-    "^(|[_].*|[.][.][.]|(?:([.])|[.][.])[1-9][0-9]*|[.][0-9].*)$",
-    ".\\2\\1",
-    new_name
-  )
+  new_name <- gsub(prepend_syntactic_dot_rx, prepend_syntactic_dot_sub, new_name)
 
   new_name
 }

--- a/R/repair-names.R
+++ b/R/repair-names.R
@@ -371,7 +371,7 @@ prepend_syntactic_dot_rx <- rex(
       ),
 
       # and follows by an integer,
-      range("1", "9"),
+      range("0", "9"),
       zero_or_more(range("0", "9"))
 
       # (this results in three dots if the rest of the name is a proper integer,

--- a/R/repair-names.R
+++ b/R/repair-names.R
@@ -325,7 +325,32 @@ check_syntactic_names <- function(x) {
   invisible(x)
 }
 
-# In make_syntactic, we'll prepend a dot if
+
+# In make_syntactic(), we'll
+strip_x_rx <- rex(
+  # strip the leading
+  start,
+
+  # X added by make.names() and
+  "X",
+
+  group(or(
+    # keep the following letter only if it's an underscore or a digit (capture #1),
+    capture(one_of("_", "0-9")),
+
+    # the dot we strip,
+    escape("."),
+
+    # and we also allow the string to end there.
+    end
+  ))
+)
+
+# We replace with a dot and the underscore/digit if appropriate.
+strip_x_sub <- ".\\1"
+
+
+# In make_syntactic(), we'll prepend a dot if
 prepend_syntactic_dot_rx <- rex(
   start,
 
@@ -333,9 +358,6 @@ prepend_syntactic_dot_rx <- rex(
   capture(or(
     # - is blank
     nothing,
-
-    # - starts with an underscore
-    group(escape("_"), anything),
 
     # - is the ellipsis
     group(escape("."), escape("."), escape(".")),
@@ -375,7 +397,7 @@ make_syntactic <- function(name) {
   new_name <- make.names(name)
 
   X_prefix <- which(grepl("^X", new_name) & !grepl("^X", name))
-  new_name[X_prefix] <- gsub("^X", "", new_name[X_prefix])
+  new_name[X_prefix] <- gsub(strip_x_rx, strip_x_sub, new_name[X_prefix])
 
   dot_suffix <- which(new_name == paste0(name, "."))
   new_name[dot_suffix] <- gsub("^(.*)[.]$", ".\\1", new_name[dot_suffix])

--- a/tests/testthat/test-syntactic_names.R
+++ b/tests/testthat/test-syntactic_names.R
@@ -1,65 +1,103 @@
 context("syntactic_names")
 
 # make_syntactic -------------------------------------------------------------
+expect_syntactic <- function(name, exp_syn_name) {
+  expect_identical(
+    syn_name <- make_syntactic(name),
+    exp_syn_name
+  )
+  expect_identical(syn_name, make.names(syn_name))
+}
+
 test_that("make_syntactic(): empty or NA", {
-  expect_identical(
-    syn_name <- make_syntactic(
-      c( "", NA_character_)
-    ),
-    c(".", ".")
+  expect_syntactic(
+      c( "", NA_character_),
+      c(".", ".")
   )
-  expect_identical(syn_name, make.names(syn_name))
-})
-
-test_that("make_syntactic(): dots", {
-  expect_identical(
-    syn_name <- make_syntactic(
-      c(".", "..",  "...", "....")
-    ),
-    c(".", "..", "....", "....")
-  )
-  expect_identical(syn_name, make.names(syn_name))
-})
-
-test_that("make_syntactic(): dot(s) followed by a number", {
-  expect_identical(
-    syn_name <- make_syntactic(
-      c(  ".1",   ".13",  "..1",  "..13", "...1", "...13")
-    ),
-    c("...1", "...13", "...1", "...13", "...1", "...13")
-  )
-  expect_identical(syn_name, make.names(syn_name))
-})
-
-test_that("make_syntactic(): dot(s) followed by a number then a non-number", {
-  syn_name <- make_syntactic(
-    c( ".1)",  ".13)", "..1)", "..13)", "...1)", "...13)", ".0", ".0x", "1", "13", "0")
-  )
-  expect_identical(
-    syn_name,
-    c("..1.", "..13.", "..1.", "..13.", "...1.", "...13.", "..0", "..0x", "...1", "...13", "..0")
-  )
-  expect_identical(syn_name, make.names(syn_name))
 })
 
 test_that("make_syntactic(): reserved words", {
-  expect_identical(
-    syn_name <- make_syntactic(
-      c("if", "TRUE", "Inf", "NA_real_", "normal")
-    ),
+  expect_syntactic(
+    c("if", "TRUE", "Inf", "NA_real_", "normal"),
     c(".if", ".TRUE", ".Inf", ".NA_real_", "normal")
   )
-  expect_identical(syn_name, make.names(syn_name))
 })
 
 test_that("make_syntactic(): underscore", {
-  expect_identical(
-    syn_name <- make_syntactic(
-      c( "_",  "_1",  "_a}")
-    ),
+  expect_syntactic(
+    c( "_",  "_1",  "_a}"),
     c("._", "._1", "._a.")
   )
-  expect_identical(syn_name, make.names(syn_name))
+})
+
+test_that("make_syntactic(): dots", {
+  expect_syntactic(
+    c(".", "..",  "...", "...."),
+    c(".", "..", "....", "....")
+  )
+})
+
+test_that("make_syntactic(): number", {
+  expect_syntactic(
+      c(   "0",    "1",    "22",    "333"),
+      c("...0", "...1", "...22", "...333")
+  )
+})
+
+test_that("make_syntactic(): number then character", {
+  expect_syntactic(
+    c(  "0a",   "1b",   "22c",   "333d"),
+    c("..0a", "..1b", "..22c", "..333d")
+  )
+})
+
+test_that("make_syntactic(): number then non-character", {
+  expect_syntactic(
+    c(  "0)",   "1&",   "22*",   "333@"),
+    c("..0.", "..1.", "..22.", "..333.")
+  )
+})
+
+test_that("make_syntactic(): dot then number", {
+  expect_syntactic(
+    c(  ".0",   ".1",   ".22",   ".333"),
+    c("...0", "...1", "...22", "...333")
+  )
+})
+
+test_that("make_syntactic(): dot then number then character", {
+  expect_syntactic(
+    c( ".0a",  ".1b",  ".22c",  ".333d"),
+    c("..0a", "..1b", "..22c", "..333d")
+  )
+})
+
+test_that("make_syntactic(): dot then number then non-character", {
+  expect_syntactic(
+    c( ".0)",  ".1&",  ".22*",  ".333@"),
+    c("..0.", "..1.", "..22.", "..333.")
+  )
+})
+
+test_that("make_syntactic(): dot dot then number", {
+  expect_syntactic(
+    c( "..0",  "..1",  "..22",  "..333"),
+    c("...0", "...1", "...22", "...333")
+  )
+})
+
+test_that("make_syntactic(): dot dot then number then character", {
+  expect_syntactic(
+    c("..0a", "..1b", "..22c", "..333d"),
+    c("..0a", "..1b", "..22c", "..333d")
+  )
+})
+
+test_that("make_syntactic(): dot dot then number then non-character", {
+  expect_syntactic(
+    c("..0)",  "..1&",  "..22*",  "..333@"),
+    c("..0.", "..1.", "..22.", "..333.")
+  )
 })
 
 # syntactic_names() -----------------------------------------------------------

--- a/tests/testthat/test-syntactic_names.R
+++ b/tests/testthat/test-syntactic_names.R
@@ -33,11 +33,11 @@ test_that("make_syntactic(): dot(s) followed by a number", {
 
 test_that("make_syntactic(): dot(s) followed by a number then a non-number", {
   syn_name <- make_syntactic(
-    c( ".1)",  ".13)", "..1)", "..13)", "...1)", "...13)", ".0", ".0x")
+    c( ".1)",  ".13)", "..1)", "..13)", "...1)", "...13)", ".0", ".0x", "1", "13", "0")
   )
   expect_identical(
     syn_name,
-    c("..1.", "..13.", "..1.", "..13.", "...1.", "...13.", "..0", "..0x")
+    c("..1.", "..13.", "..1.", "..13.", "...1.", "...13.", "..0", "..0x", "...1", "...13", "..0")
   )
   expect_identical(syn_name, make.names(syn_name))
 })


### PR DESCRIPTION
Decided to rely on `make.names()` but reduce the number of `gsub()` calls involved. Added a lightweight _rex_ replica to make the complex regular expression easier to digest and comment.