### PR TITLE
Coerce to data frame in column_to_rownames()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,13 @@ The `tibble()` and `as_tibble()` functions, and the low-level `new_tibble()` con
 
 - `as.tibble()` and `as_data_frame()` are officially deprecated and not generic anymore, please use/implement `as_tibble()` (#111).
 
-- `as_tibble.data.frame()` (and also `as_tibble.matrix()`) strip row names by default.  Call `pkgconfig::set_config("tibble::rownames", NA)` to revert to the old behavior of keeping row names, this also works for packages that import _tibble_.
+- `as_tibble.data.frame()` (and also `as_tibble.matrix()`) strip row names by default.  Code that relies on tibbles keeping row names now will see:
+    - a different result when calling `rownames()` or `row.names()`,
+    - rows full of `NA` values when subsetting rows with with a character vector, e.g. `as_tibble(mtcars)["Mazda RX4", ]`.
+    
+    Call `pkgconfig::set_config("tibble::rownames", NA)` to revert to the old behavior of keeping row names. Packages that import _tibble_ can call `set_config()` in their `.onLoad()` function (#114).
+
+- `column_to_rownames()` now always coerces to a data frame, because row names are no longer supported in tibbles (#114).
 
 - The `print()` method prints a message if a tibble is missing the `"tbl"` class (#264).
 

--- a/R/rownames.R
+++ b/R/rownames.R
@@ -92,6 +92,7 @@ column_to_rownames <- function(.data, var = "rowname") {
     abort(error_unknown_names(var))
   }
 
+  .data <- as.data.frame(.data)
   rownames(.data) <- .data[[var]]
   .data[[var]] <- NULL
   .data

--- a/R/rownames.R
+++ b/R/rownames.R
@@ -14,8 +14,9 @@
 #' adds a column at the start of the dataframe of ascending sequential row
 #' ids starting at 1. Note that this will remove any existing row names.
 #'
-#' In the printed output, the presence of row names is indicated by a star just
-#' above the row numbers.
+#' @return `column_to_rownames()` always returns a data frame.
+#'   `has_rownames()` returns a scalar logical.
+#'   All other functions return an object of the same class as the input.
 #'
 #' @param .data A data frame.
 #' @param var Name of column to use for rownames.
@@ -28,7 +29,7 @@
 #'
 #' mtcars_tbl <- as_tibble(rownames_to_column(mtcars))
 #' mtcars_tbl
-#' head(column_to_rownames(as.data.frame(mtcars_tbl)))
+#' head(column_to_rownames(mtcars_tbl))
 #' @name rownames
 NULL
 

--- a/man/rownames.Rd
+++ b/man/rownames.Rd
@@ -24,6 +24,11 @@ column_to_rownames(.data, var = "rowname")
 
 \item{var}{Name of column to use for rownames.}
 }
+\value{
+\code{column_to_rownames()} always returns a data frame.
+\code{has_rownames()} returns a scalar logical.
+All other functions return an object of the same class as the input.
+}
 \description{
 While a tibble can have row names (e.g., when converting from a regular data
 frame), they are removed when subsetting with the \code{[} operator.
@@ -39,10 +44,6 @@ Also included is \code{rowid_to_column()} which
 adds a column at the start of the dataframe of ascending sequential row
 ids starting at 1. Note that this will remove any existing row names.
 }
-\details{
-In the printed output, the presence of row names is indicated by a star just
-above the row numbers.
-}
 \examples{
 has_rownames(mtcars)
 has_rownames(iris)
@@ -52,5 +53,5 @@ head(rownames_to_column(mtcars))
 
 mtcars_tbl <- as_tibble(rownames_to_column(mtcars))
 mtcars_tbl
-head(column_to_rownames(as.data.frame(mtcars_tbl)))
+head(column_to_rownames(mtcars_tbl))
 }

--- a/tests/testthat/test-rownames.R
+++ b/tests/testthat/test-rownames.R
@@ -73,16 +73,16 @@ test_that("column_to_rownames returns tbl", {
 
   expect_true(has_rownames(mtcars1))
   res0 <- rownames_to_column(mtcars1, var)
-  expect_warning(res <- column_to_rownames(res0, var))
+  expect_warning(res <- column_to_rownames(res0, var), NA)
   expect_true(has_rownames(res))
-  expect_equal(class(res), class(mtcars1))
+  expect_equal(class(res), class(mtcars))
   expect_equal(rownames(res), rownames(mtcars1))
-  expect_equal(res, mtcars1)
+  expect_equal(res, mtcars)
   expect_false(has_name(res, var))
 
   mtcars1$num <- rev(seq_len(nrow(mtcars)))
   res0 <- rownames_to_column(mtcars1)
-  expect_warning(res <- column_to_rownames(res0, var = "num"))
+  expect_warning(res <- column_to_rownames(res0, var = "num"), NA)
   expect_true(has_rownames(res))
   expect_equal(rownames(res), as.character(mtcars1$num))
   expect_error(


### PR DESCRIPTION
Closes #114 -- the last bits of that issue, stripping row names in `as_tibble()` is already implemented.