### PR TITLE
replaced tibbletime with tsibble in `new_tibble()` description

### DIFF
--- a/R/new.R
+++ b/R/new.R
@@ -3,7 +3,7 @@
 #' @description
 #' Creates or validates a subclass of a tibble.
 #' These function is mostly useful for package authors that implement subclasses
-#' of a tibble, like \pkg{sf} or \pkg{tibbletime}.
+#' of a tibble, like \pkg{sf} or \pkg{tsibble}.
 #'
 #' `new_tibble()` creates a new object as a subclass of `tbl_df`, `tbl` and `data.frame`.
 #' This function is optimized for performance, checks are reduced to a minimum.


### PR DESCRIPTION
Nitpicking. Can I update the description of `new_tibble()` to use [**tsibble**](https://github.com/tidyverts/tsibble) as an example of sub-classing of tibble for tidy time series? **tibbletime** has been put on hold for a long time and no further development. Both teams agree to move tsibble forward for a unified tidy temporal data standard. Thanks heaps.