### PR TITLE
move error_name_length_required() to compat-name-repair.R

### DIFF
--- a/R/compat-name-repair.R
+++ b/R/compat-name-repair.R
@@ -3,6 +3,10 @@
 # This file serves as a reference for compatibility functions for
 # name repair in tibble, until name repair is available in rlang.
 
+error_name_length_required <- function() {
+  "`n` must be specified, when the `names` attribute is `NULL`."
+}
+
 minimal_names <- function(name, n) {
   if (is.null(name) && missing(n)) {
     abort(error_name_length_required())

--- a/R/msg.R
+++ b/R/msg.R
@@ -218,10 +218,6 @@ error_tribble_non_rectangular <- function(cols, cells) {
   )
 }
 
-error_name_length_required <- function() {
-  "`n` must be specified, when the `names` attribute is `NULL`."
-}
-
 error_frame_matrix_list <- function(pos) {
   bullets(
     "All values in `frame_matrix()` must be atomic:",


### PR DESCRIPTION
otherwise when I copy the file in dplyr I get a `check()` note because `error_name_length_required()` does not exist