### PR TITLE
Allow implicit row names for data frame class objects.

### DIFF
--- a/tests/testthat/test-data-frame.R
+++ b/tests/testthat/test-data-frame.R
@@ -478,11 +478,13 @@ test_that("as_tibble() can convert row names", {
   expect_identical(unclass(tbl_df), unclass(df))
 })
 
-test_that("as_tibble() throws an error when user turns missing row names into column", {
+#test_that("as_tibble() throws an error when user turns missing row names into column", {
+test_that("as_tibble() throws a warning when user turns implicit row names into column", {
   df <- data.frame(a = 1:3, b = 2:4)
-  expect_error(
+  expect_warning(
     as_tibble(df, rownames = "id"),
-    error_as_tibble_needs_rownames(),
+    #error_as_tibble_needs_rownames(),
+    "Implicit rownames detected, moving to column: id",
     fixed = TRUE
   )
 })


### PR DESCRIPTION
Allow implicit row names for data frames (with warning) but keep error for matrices with implicit row names. Update unit tests accordingly. There are a few comments left in place that I would like to remove prior to merge if you approve of the changes. There is also an option to use the existing framework of warning once per session, or with each `as_tibble()` call. Whichever you prefer. Thanks!

Fixes #567