### PR TITLE
Changed column validity checks to allow any vector-like object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tibble 2.1.1
 
+- Columns can now be added of any class for which there exists all typical vector manipulation methods: `[`, `[<-`, `[[`, `[[<-`, `c`, `length` (@zachary-foster).
+
 - Three dots are used even for `"unique"` name repair (#566).
 
 - `add_row()`, `add_case()` and `add_column()` now signal a warning once per session if the input is not a data frame (#575).

--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -162,7 +162,15 @@ check_valid_cols <- function(x) {
 
 is_1d_or_2d <- function(x) {
   # dimension check is for matrices and data.frames
-  (is_vector(x) && !needs_dim(x)) || is.data.frame(x) || is.matrix(x)
+  ((is_vector(x) || is_like_vector(x)) && !needs_dim(x)) || is.data.frame(x) || is.matrix(x)
+}
+
+is_like_vector <- function(x) {
+  needed_funcs <- c("[", "[[", "[<-", "[[<-", "length", "c")
+  has_funcs <- map_lgl(needed_funcs, function(func) {
+    any(paste0(func, ".", class(x)) %in% methods(func))
+  })
+  all(has_funcs)
 }
 
 recycle_columns <- function(x, .rows, lengths) {


### PR DESCRIPTION
I made an experimental change to the function that checks the validity of new columns to be added to tibbles, so that it accepts anything that behaves like a vector. I did this because I was trying to see if I could get an R6 class object that behaved like a vector as a column in a tibble. Such functionality would be very useful for the [taxa](https://github.com/ropensci/taxa) package I am working on. It is based on R6 classes that have S3 wrappers. 

Turns out, it seems to work fine, at least according to the tests. However, I don't know the details of how tibbles work internally, so perhaps this is not a good idea for some other reason that the tests do not account for.

I followed [this tutorial](https://cran.r-project.org/web/packages/tibble/vignettes/extending.html) to add the functions needed to make my R6 class work well in a tibble:

```
> table <- tibble(x = 1:3, y = taxa("a", "b", "c"))
> table
# A tibble: 3 x 2
      x      y
  <int> <Taxa>
1     1      a
2     2      b
3     3      c
> table$y
<taxa> 
  no. taxa:  3 
  a / [none] / [none] 
  b / [none] / [none] 
  c / [none] / [none] 
> class(table$y)
[1] "Taxa" "R6"
```

Let me know if you want me to add additional tests or anything else. I can also add a section to  [this tutorial](https://cran.r-project.org/web/packages/tibble/vignettes/extending.html) showing how to do this with R6 classes if that would be useful.