### PR TITLE
Fix to use the created (or passed) title argument rather than string …

### DIFF
--- a/R/view.R
+++ b/R/view.R
@@ -21,7 +21,7 @@ view <- function(x, title = NULL, ...) {
   }
 
   view_fun <- get("View", envir = as.environment("package:utils"))
-  eval_tidy(quo(view_fun(!!x, "title")))
+  eval_tidy(view_fun({{x}}, {{title}}))
 
   invisible(x)
 }


### PR DESCRIPTION
One of my students just showed me that they could not use the little clipboard button in the viewer because the name of the object was always changed to "title", which is a departure from `utils::View()`.

Not sure if current fixed "title" is desired. Removing the quotes "seems" to fix the problem. Unfortunately I have no idea on how to test this (I could not find related tests in the repo).