### PR TITLE
POSIXlt is ok now as a column, via vctrs support

### DIFF
--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -151,12 +151,6 @@ check_valid_cols <- function(x) {
     abort(error_column_must_be_vector(names_x[is_xd], classes))
   }
 
-  # TODO: Remove with dplyr 0.9.0 (vctrs support)
-  posixlt <- which(map_lgl(x, inherits, "POSIXlt"))
-  if (has_length(posixlt)) {
-    abort(error_time_column_must_be_posixct(names_x[posixlt]))
-  }
-
   invisible(x)
 }
 

--- a/R/msg.R
+++ b/R/msg.R
@@ -137,10 +137,6 @@ error_column_must_be_vector <- function(names, classes) {
   )
 }
 
-error_time_column_must_be_posixct <- function(names) {
-  invalid_df("[is](are) [a ]date(s)/time(s) and must be stored as POSIXct, not POSIXlt", names)
-}
-
 error_inconsistent_cols <- function(.rows, vars, vars_len, rows_source) {
   vars_split <- split(vars, vars_len)
 

--- a/tests/testthat/test-data-frame.R
+++ b/tests/testthat/test-data-frame.R
@@ -533,14 +533,6 @@ test_that("as.tibble is an alias of as_tibble", {
 
 # Validation --------------------------------------------------------------
 
-test_that("POSIXlt isn't a valid column", {
-  expect_error(
-    check_valid_cols(list(x = as.POSIXlt(Sys.time()))),
-    error_time_column_must_be_posixct("x"),
-    fixed = TRUE
-  )
-})
-
 test_that("NULL isn't a valid column", {
   expect_error(
     check_valid_cols(list(a = NULL)),

--- a/tests/testthat/test-msg.R
+++ b/tests/testthat/test-msg.R
@@ -250,21 +250,6 @@ test_that("error_column_must_be_vector()", {
   )
 })
 
-test_that("error_time_column_must_be_posixct()", {
-  expect_equal(
-    error_time_column_must_be_posixct("a"),
-    "Column `a` is a date/time and must be stored as POSIXct, not POSIXlt."
-  )
-  expect_equal(
-    error_time_column_must_be_posixct(letters[2:3]),
-    "Columns `b`, `c` are dates/times and must be stored as POSIXct, not POSIXlt."
-  )
-  expect_equal(
-    unell(error_time_column_must_be_posixct(LETTERS)),
-    "Columns `A`, `B`, `C`, `D`, `E`, ... (and 21 more) are dates/times and must be stored as POSIXct, not POSIXlt."
-  )
-})
-
 test_that("error_inconsistent_cols()", {
   expect_equal(
     error_inconsistent_cols(


### PR DESCRIPTION
Removed  `error_time_column_must_be_posixct()` function, because it's now ok to have POSIXlt as columns. 

At least it will be ok with dplyr 0.9.0, so we can merge this at a later time, but e.g. this https://github.com/tidyverse/dplyr/pull/4504 can depend on this