### PR TITLE
strip_names() calling vctrs::set_names2() only when the names is not NULL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - Internal changes only.
 
+- strip_names() calling vctrs::set_names2() only when the names is not NULL
 
 # tibble 2.1.3
 

--- a/R/utils.r
+++ b/R/utils.r
@@ -18,7 +18,10 @@ has_nonnull_names <- function(x) {
 set_class <- `class<-`
 
 strip_names <- function(x) {
-  vctrs:::set_names2(x, NULL)
+  if (!is.null(names(x))) {
+    x <- vctrs:::set_names2(x, NULL)
+  }
+  x
 }
 
 needs_list_col <- function(x) {


### PR DESCRIPTION
``` r
library(tibble)
library(lobstr)

identical(
  obj_addrs(mtcars), 
  obj_addrs(as_tibble(mtcars))
)
#> [1] TRUE
```

Otherwise it breaks these dplyr tests: https://github.com/tidyverse/dplyr/blob/master/tests/testthat/test-copying.R#L3
