### PR TITLE
Allow for implicit row names in as_tibble.data.frame()

### DIFF
--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -104,8 +104,8 @@ as_tibble.data.frame <- function(x, validate = NULL, ...,
     attr(result, "row.names") <- old_rownames
     result
   } else {
-    if (is.integer(old_rownames)) {
-      abort(error_as_tibble_needs_rownames())
+    if (length(old_rownames) > 0 && is.na(old_rownames[1L])) {  # if implicit
+      old_rownames <- as.character(1:abs(old_rownames[2L]))
     }
     add_column(result, !!rownames := old_rownames, .before = 1L)
   }

--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -105,7 +105,7 @@ as_tibble.data.frame <- function(x, validate = NULL, ...,
     result
   } else {
     if (length(old_rownames) > 0 && is.na(old_rownames[1L])) {  # if implicit
-      old_rownames <- as.character(1:abs(old_rownames[2L]))
+      old_rownames <- as.character(seq_len(abs(old_rownames[2L])))
     }
     add_column(result, !!rownames := old_rownames, .before = 1L)
   }

--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -104,9 +104,10 @@ as_tibble.data.frame <- function(x, validate = NULL, ...,
     attr(result, "row.names") <- old_rownames
     result
   } else {
-    if (length(old_rownames) > 0 && is.na(old_rownames[1L])) {  # if implicit
-      old_rownames <- as.character(seq_len(abs(old_rownames[2L])))
+    if (length(old_rownames) > 0 && is.na(old_rownames[1L])) {  # if implicit rownames
+      old_rownames <- seq_len(abs(old_rownames[2L]))
     }
+    old_rownames <- as.character(old_rownames)
     add_column(result, !!rownames := old_rownames, .before = 1L)
   }
 }

--- a/R/msg.R
+++ b/R/msg.R
@@ -237,10 +237,6 @@ error_already_has_rownames <- function() {
   tibble_error("`df` must be a data frame without row names in `column_to_rownames()`.")
 }
 
-error_as_tibble_needs_rownames <- function() {
-  tibble_error("Object passed to `as_tibble()` must have row names if the `rownames` argument is set.")
-}
-
 error_glimpse_infinite_width <- function() {
   tibble_error("`glimpse()` requires a finite value for the `width` argument.")
 }

--- a/tests/testthat/errors.txt
+++ b/tests/testthat/errors.txt
@@ -261,11 +261,6 @@ Can't specify both `.before` and `.after`.
 `df` must be a data frame without row names in `column_to_rownames()`.
 
 
-## error_as_tibble_needs_rownames()
-
-Object passed to `as_tibble()` must have row names if the `rownames` argument is set.
-
-
 ## error_glimpse_infinite_width()
 
 `glimpse()` requires a finite value for the `width` argument.

--- a/tests/testthat/test-matrix.R
+++ b/tests/testthat/test-matrix.R
@@ -135,10 +135,15 @@ test_that("converting from matrix supports storing row names in a column", {
   expect_identical(out, df)
 })
 
-test_that("converting from matrix throws an error if user turns missing row names into column", {
+test_that("converting from matrix uses implicit row names when `rownames =` is passed", {
   x <- matrix(1:30, 6, 5)
-  expect_tibble_error(
-    as_tibble(x, rownames = "id", .name_repair = "minimal"),
-    error_as_tibble_needs_rownames()
-  )
+  y <- as_tibble(x, rownames = "id", .name_repair = "minimal")
+  z <- tibble(id = c("1", "2", "3", "4", "5", "6"),
+              ...2 = c(1L, 2L, 3L, 4L, 5L, 6L),
+              ...3 = c(7L, 8L, 9L, 10L, 11L, 12L),
+              ...4 = c(13L, 14L, 15L, 16L, 17L, 18L),
+              ...5 = c(19L, 20L, 21L, 22L, 23L, 24L),
+              ...6 = c(25L, 26L, 27L, 28L, 29L, 30L)
+            )
+  expect_equal(y, z)
 })

--- a/tests/testthat/test-msg.R
+++ b/tests/testthat/test-msg.R
@@ -122,8 +122,6 @@ test_that("error messages", {
 
     error_already_has_rownames(),
 
-    error_as_tibble_needs_rownames(),
-
     error_glimpse_infinite_width(),
 
     error_tribble_needs_columns(),

--- a/tests/testthat/test-tibble.R
+++ b/tests/testthat/test-tibble.R
@@ -497,15 +497,15 @@ test_that("as_tibble() can convert row names for zero-row tibbles", {
   expect_identical(unclass(tbl_df), unclass(df))
 })
 
-test_that("as_tibble() throws an error when user turns missing row names into column", {
+test_that("as_tibble() converts implicit row names when `rownames =` is passed", {
   df <- data.frame(a = 1:3, b = 2:4)
-  expect_tibble_error(
+  expect_equal(
     as_tibble(df, rownames = "id"),
-    error_as_tibble_needs_rownames()
+    tibble(id = as.character(1:3), a = 1:3, b = 2:4)
   )
-  expect_tibble_error(
+  expect_equal(
     as_tibble(df[0, ], rownames = "id"),
-    error_as_tibble_needs_rownames()
+    tibble(id = integer(0), a = integer(0), b = integer(0))
   )
 })
 

--- a/tests/testthat/test-tibble.R
+++ b/tests/testthat/test-tibble.R
@@ -505,7 +505,7 @@ test_that("as_tibble() converts implicit row names when `rownames =` is passed",
   )
   expect_equal(
     as_tibble(df[0, ], rownames = "id"),
-    tibble(id = integer(0), a = integer(0), b = integer(0))
+    tibble(id = character(0), a = integer(0), b = integer(0))
   )
 })
 


### PR DESCRIPTION
- logic for implicit rownames in 'as_tibble.data.frame()'
- rm 'error_as_tibble_needs_rownames()' helper
- update 'errors.txt'
- update unit tests; no more rowname errors, add implicit rownames tests
- rm 'error_as_tibble_needs_rownames()' from 'test-msg.R'
- fixes #567