### PR TITLE
Mention "size" instead of "length"

### DIFF
--- a/R/msg.R
+++ b/R/msg.R
@@ -198,9 +198,9 @@ error_inconsistent_cols <- function(.rows, vars, vars_len, rows_source) {
   }
 
   tibble_error(bullets(
-    "Tibble columns must have consistent lengths, only values of length one are recycled:",
-    if (!is.null(.rows)) paste0("Length ", .rows, ": ", rows_source),
-    map2_chr(names(vars_split), vars_split, function(x, y) paste0("Length ", x, ": ", pluralise_commas("Column(s) ", tick(y))))
+    "Tibble columns must have consistent sizes, only values of size one are recycled:",
+    if (!is.null(.rows)) paste0("Size ", .rows, ": ", rows_source),
+    map2_chr(names(vars_split), vars_split, function(x, y) paste0("Size ", x, ": ", pluralise_commas("Column(s) ", tick(y))))
   ))
 }
 

--- a/tests/testthat/errors.txt
+++ b/tests/testthat/errors.txt
@@ -213,19 +213,19 @@ All columns in a tibble must be 1d or 2d objects:
 
 ## error_inconsistent_cols()
 
-Tibble columns must have consistent lengths, only values of length one are recycled:
-* Length 10: Requested with `uvw` argument
-* Length 3: Column `c`
-* Length 4: Columns `a`, `b`
+Tibble columns must have consistent sizes, only values of size one are recycled:
+* Size 10: Requested with `uvw` argument
+* Size 3: Column `c`
+* Size 4: Columns `a`, `b`
 
-Tibble columns must have consistent lengths, only values of length one are recycled:
-* Length 10: Requested with `xyz` argument
-* Length 2: Columns `a`, `b`
-* Length 3: Column `c`
+Tibble columns must have consistent sizes, only values of size one are recycled:
+* Size 10: Requested with `xyz` argument
+* Size 2: Columns `a`, `b`
+* Size 3: Column `c`
 
-Tibble columns must have consistent lengths, only values of length one are recycled:
-* Length 2: Columns `a`, `b`
-* Length 3: Column `c`
+Tibble columns must have consistent sizes, only values of size one are recycled:
+* Size 2: Columns `a`, `b`
+* Size 3: Column `c`
 
 
 ## error_inconsistent_new_cols()


### PR DESCRIPTION
This is less confusing when input is a tibble, as size refers to number of rows while length refers to number of columns.