### PR TITLE
Enable subsetting and subassignment for logical matrices

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -88,6 +88,7 @@ Collate:
     'rownames.R'
     'str.R'
     'strrep.R'
+    'subsetting-matrix.R'
     'subsetting.R'
     'tbl-df.R'
     'tibble-package.R'

--- a/R/subsetting-matrix.R
+++ b/R/subsetting-matrix.R
@@ -1,0 +1,41 @@
+tbl_subset_matrix <- function(x, j) {
+  cells <- matrix_to_cells(j, x)
+  col_idx <- cells_to_col_idx(cells)
+
+  if (is_empty(col_idx)) {
+    return(unspecified())
+  }
+
+  values <- map2(x[col_idx], cells[col_idx], vec_slice)
+
+  # Also checks conformity of vectors:
+  unname(vec_c(!!!values, .name_spec = ~ .x))
+}
+
+tbl_subassign_matrix <- function(x, j, value) {
+  stopifnot(vec_is(value, size = 1))
+
+  cells <- matrix_to_cells(j, x)
+  col_idx <- cells_to_col_idx(cells)
+
+  x[col_idx] <- map2(x[col_idx], cells[col_idx], `vec_slice<-`, value)
+  x
+}
+
+matrix_to_cells <- function(j, x) {
+  stopifnot(is_bare_logical(j))
+  stopifnot(identical(dim(j), dim(x)))
+
+  # Need unlist(list(...)) because apply() isn't type stable if the return
+  # has the same length everywhere
+  # FIXME: Faster with a C implementation?
+  cells <- unlist(apply(j, 2, function(x) list(which(x))), recursive = FALSE)
+  cells
+}
+
+cells_to_col_idx <- function(cells) {
+  sizes <- map_int(cells, vec_size)
+  col_idx <- which(sizes > 0)
+
+  col_idx
+}

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -178,7 +178,7 @@ NULL
   # Ignore drop as an argument for counting
   n_real_args <- nargs() - !missing(drop)
 
-  # Column subsetting if nargs() == 2L
+  # Column or matrix subsetting if nargs() == 2L
   if (n_real_args <= 2L) {
     if (!missing(drop)) {
       warn("`drop` argument ignored for subsetting a tibble with `x[j]`, it has an effect only for `x[i, j]`.")
@@ -187,6 +187,11 @@ NULL
 
     j <- i
     i <- NULL
+
+    # Special case, returns a vector:
+    if (is.matrix(j)) {
+      return(tbl_subset_matrix(x, j))
+    }
   }
 
   # From here on, i, j and drop contain correct values:
@@ -218,6 +223,11 @@ NULL
   if (is.null(j) && nargs() < 4) {
     j <- i
     i <- NULL
+
+    # Special case:
+    if (is.matrix(j)) {
+      return(tbl_subassign_matrix(x, j, value))
+    }
   }
 
   tbl_subassign(x, i, j, value)

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -28,13 +28,11 @@
 |:----------------------------|:-------|:------|:-------|:----|
 |[genius](failures.md#genius) |2.2.0   |__+1__ |        |     |
 
-## New problems (91)
+## New problems (73)
 
 |package                                          |version |error  |warning |note |
 |:------------------------------------------------|:-------|:------|:-------|:----|
-|[alakazam](problems.md#alakazam)                 |0.3.0   |__+1__ |        |1    |
 |[amt](problems.md#amt)                           |0.0.7   |__+1__ |        |1    |
-|[banter](problems.md#banter)                     |0.9.3   |__+1__ |        |1    |
 |[basket](problems.md#basket)                     |0.9.10  |__+1__ |        |     |
 |[beadplexr](problems.md#beadplexr)               |0.2.0   |__+1__ |        |1    |
 |[bench](problems.md#bench)                       |1.0.4   |__+2__ |        |     |
@@ -44,33 +42,25 @@
 |[corrr](problems.md#corrr)                       |0.4.0   |__+2__ |        |     |
 |[cutpointr](problems.md#cutpointr)               |1.0.1   |__+1__ |        |     |
 |[cvms](problems.md#cvms)                         |0.3.2   |__+1__ |        |     |
-|[describedata](problems.md#describedata)         |0.1.0   |__+1__ |        |     |
 |[DiagrammeR](problems.md#diagrammer)             |1.0.1   |__+2__ |        |2    |
 |[diffdf](problems.md#diffdf)                     |1.0.3   |__+1__ |        |     |
-|[dplyr](problems.md#dplyr)                       |0.8.3   |__+1__ |        |2    |
 |[drake](problems.md#drake)                       |7.8.0   |__+1__ |        |     |
 |[dssd](problems.md#dssd)                         |0.1.0   |__+1__ |        |     |
-|[easyr](problems.md#easyr)                       |0.1-1   |__+2__ |        |     |
 |[egor](problems.md#egor)                         |0.19.10 |__+2__ |        |     |
 |[eph](problems.md#eph)                           |0.2.0   |__+1__ |        |2    |
 |[evaluator](problems.md#evaluator)               |0.4.1   |__+2__ |        |     |
 |[exuber](problems.md#exuber)                     |0.3.0   |__+1__ |        |1    |
 |[feasts](problems.md#feasts)                     |0.1.1   |__+2__ |        |     |
-|[foghorn](problems.md#foghorn)                   |1.1.4   |__+2__ |        |     |
 |[foieGras](problems.md#foiegras)                 |0.4.0   |__+1__ |        |1    |
 |[forestmangr](problems.md#forestmangr)           |0.9.1   |__+1__ |        |     |
 |[ggplot2](problems.md#ggplot2)                   |3.2.1   |__+1__ |        |2    |
 |[ggspatial](problems.md#ggspatial)               |1.0.3   |__+2__ |        |1    |
-|[ggstatsplot](problems.md#ggstatsplot)           |0.1.4   |__+1__ |        |     |
 |[googlesheets4](problems.md#googlesheets4)       |0.1.0   |__+1__ |        |     |
-|[groupedstats](problems.md#groupedstats)         |0.1.0   |__+2__ |        |     |
-|[gtsummary](problems.md#gtsummary)               |1.2.4   |__+2__ |        |1    |
+|[gtsummary](problems.md#gtsummary)               |1.2.4   |__+1__ |        |1    |
 |[haven](problems.md#haven)                       |2.2.0   |       |__+1__  |2    |
 |[healthcareai](problems.md#healthcareai)         |2.3.0   |__+2__ |        |     |
-|[heatwaveR](problems.md#heatwaver)               |0.4.2   |__+2__ |        |     |
 |[heemod](problems.md#heemod)                     |0.11.0  |__+2__ |        |1    |
 |[INDperform](problems.md#indperform)             |0.2.1   |__+2__ |        |1    |
-|[inspectdf](problems.md#inspectdf)               |0.0.7   |__+1__ |        |     |
 |[interactions](problems.md#interactions)         |1.1.1   |__+2__ |        |2    |
 |[ipumsr](problems.md#ipumsr)                     |0.4.2   |__+2__ |        |     |
 |[janitor](problems.md#janitor)                   |1.2.0   |__+2__ |        |     |
@@ -79,17 +69,13 @@
 |[keyholder](problems.md#keyholder)               |0.1.3   |__+1__ |        |     |
 |[metacoder](problems.md#metacoder)               |0.3.3   |__+1__ |        |1    |
 |[MNLpred](problems.md#mnlpred)                   |0.0.1   |__+2__ |        |     |
-|[modelsummary](problems.md#modelsummary)         |0.1.0   |__+1__ |        |1    |
 |[MPTmultiverse](problems.md#mptmultiverse)       |0.3-3   |__+1__ |        |     |
-|[NACHO](problems.md#nacho)                       |0.6.1   |__+2__ |        |     |
 |[NipponMap](problems.md#nipponmap)               |0.2     |__+1__ |        |2    |
-|[OncoBayes2](problems.md#oncobayes2)             |0.5-8   |__+2__ |        |2    |
+|[OncoBayes2](problems.md#oncobayes2)             |0.5-8   |__+1__ |        |2    |
 |[oppr](problems.md#oppr)                         |0.0.4   |__+1__ |        |2    |
-|[palaeoSig](problems.md#palaeosig)               |2.0-3   |__+1__ |        |1    |
 |[pkgsearch](problems.md#pkgsearch)               |3.0.2   |__+1__ |        |     |
 |[pmdplyr](problems.md#pmdplyr)                   |0.3.0   |__+2__ |        |     |
 |[PML](problems.md#pml)                           |1.1     |__+1__ |        |     |
-|[PopED](problems.md#poped)                       |0.4.0   |__+1__ |        |1    |
 |[projects](problems.md#projects)                 |2.0.0   |__+2__ |        |1    |
 |[psychmeta](problems.md#psychmeta)               |2.3.4   |__+1__ |        |     |
 |[rbin](problems.md#rbin)                         |0.1.1   |__+2__ |        |1    |
@@ -109,18 +95,14 @@
 |[sfdct](problems.md#sfdct)                       |0.0.6   |__+2__ |        |     |
 |[silicate](problems.md#silicate)                 |0.2.0   |__+2__ |        |1    |
 |[simrel](problems.md#simrel)                     |2.0     |__+1__ |        |     |
-|[skimr](problems.md#skimr)                       |2.0.2   |__+2__ |        |     |
+|[skimr](problems.md#skimr)                       |2.0.2   |__+1__ |        |     |
 |[spbabel](problems.md#spbabel)                   |0.5.0   |__+1__ |        |     |
 |[srvyr](problems.md#srvyr)                       |0.3.6   |__+1__ |        |     |
 |[stminsights](problems.md#stminsights)           |0.3.0   |__+1__ |        |1    |
-|[suddengains](problems.md#suddengains)           |0.4.0   |__+1__ |        |     |
 |[taxa](problems.md#taxa)                         |0.3.2   |__+1__ |        |1    |
 |[textrecipes](problems.md#textrecipes)           |0.0.2   |__+2__ |        |1    |
 |[tidyr](problems.md#tidyr)                       |1.0.0   |__+1__ |        |1    |
-|[timetk](problems.md#timetk)                     |0.1.2   |__+1__ |        |     |
 |[units](problems.md#units)                       |0.6-5   |__+1__ |        |     |
-|[utile.tables](problems.md#utiletables)          |0.1.8   |__+1__ |        |     |
-|[utile.tools](problems.md#utiletools)            |0.2.3   |__+1__ |        |1    |
 |[wtss](problems.md#wtss)                         |2.0.1   |__+2__ |        |     |
 |[xpose](problems.md#xpose)                       |0.4.5   |__+2__ |        |     |
 

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -103,55 +103,6 @@ Run `revdep_details(,"amt")` for more info
       All declared Imports should be used.
     ```
 
-# banter
-
-<details>
-
-* Version: 0.9.3
-* Source code: https://github.com/cran/banter
-* Date/Publication: 2018-07-10 15:20:06 UTC
-* Number of recursive dependencies: 62
-
-Run `revdep_details(,"banter")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    ...
-    Running examples in ‘banter-Ex.R’ failed
-    The error most likely occurred in:
-    
-    > ### Name: getBanterModel
-    > ### Title: Extract Random Forest Model
-    > ### Aliases: getBanterModel
-    > 
-    > ### ** Examples
-    > 
-    > data(train.data)
-    > # initialize BANTER model with event data
-    > bant.mdl <- initBanterModel(train.data$events)
-    > # add all detector models
-    > bant.mdl <- addBanterDetector(
-    +   bant.mdl, train.data$detectors, 
-    +   ntree = 50, sampsize = 1, num.cores = 1
-    + )
-    > # run BANTER event model
-    > bant.mdl <- runBanterModel(bant.mdl, ntree = 1000, sampsize = 1)
-    Error: `i` must have one dimension, not 2.
-    Execution halted
-    ```
-
-## In both
-
-*   checking dependencies in R code ... NOTE
-    ```
-    Namespace in Imports field not imported from: ‘ranger’
-      All declared Imports should be used.
-    ```
-
 # basket
 
 <details>
@@ -466,7 +417,6 @@ Run `revdep_details(,"corrr")` for more info
 *   checking examples ... ERROR
     ```
     ...
-    + }
     > 
     > x <- correlate(mtcars)
     
@@ -593,42 +543,12 @@ Run `revdep_details(,"cvms")` for more info
       5. Failure: model_verbose reports the correct model functions in cross_validate() (@test_cross_validate.R#962) 
       6. Failure: model_verbose reports the correct model functions in cross_validate() (@test_cross_validate.R#975) 
       7. Failure: multinomial random predictions work with cross_validate_fn() (@test_cross_validate_fn.R#1448) 
-      8. Error: multinomial evaluations are correct in evaluate() (@test_evaluate.R#396) 
-      9. Failure: model_verbose reports the correct model functions in validate() (@test_validate.R#512) 
+      8. Failure: model_verbose reports the correct model functions in validate() (@test_validate.R#512) 
+      9. Failure: model_verbose reports the correct model functions in validate() (@test_validate.R#523) 
       1. ...
       
       Error: testthat unit tests failed
       Execution halted
-    ```
-
-# describedata
-
-<details>
-
-* Version: 0.1.0
-* Source code: https://github.com/cran/describedata
-* Date/Publication: 2019-08-02 11:50:02 UTC
-* Number of recursive dependencies: 66
-
-Run `revdep_details(,"describedata")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    Running examples in ‘describedata-Ex.R’ failed
-    The error most likely occurred in:
-    
-    > ### Name: ladder
-    > ### Title: Replica of Stata's ladder function
-    > ### Aliases: ladder
-    > 
-    > ### ** Examples
-    > 
-    > ladder(iris$Sepal.Length)
-    Error: Tibble columns must have consistent sizes, only values of size one are recycled:
     ```
 
 # DiagrammeR
@@ -895,68 +815,6 @@ Run `revdep_details(,"dssd")` for more info
     Execution halted
     ```
 
-# easyr
-
-<details>
-
-* Version: 0.1-1
-* Source code: https://github.com/cran/easyr
-* URL: https://github.com/oliver-wyman-actuarial/easyr
-* BugReports: https://github.com/oliver-wyman-actuarial/easyr/issues
-* Date/Publication: 2019-11-27 15:50:02 UTC
-* Number of recursive dependencies: 92
-
-Run `revdep_details(,"easyr")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    Running examples in ‘easyr-Ex.R’ failed
-    The error most likely occurred in:
-    
-    > ### Name: validate.equal
-    > ### Title: Validate Equal
-    > ### Aliases: validate.equal
-    > 
-    > ### ** Examples
-    > 
-    > validate.equal( iris, iris )
-    
-    Row and column counts match. 
-    Column names match. 
-    Error: `i` must have one dimension, not 2.
-    Execution halted
-    ```
-
-*   checking tests ...
-    ```
-    ...
-      easyr::ecopy does not work on unix. 
-      Reading as XML/HTML 
-      Reading as XML/HTML 
-      easyr::tonum: NAs were created. Returning the vector unchanged. 
-        Problematic values include: [ 5'10 ] 
-      ── 1. Error: works as expected (@validateequal.R#110)  ─────────────────────────────
-      `i` must have one dimension, not 2.
-      Backtrace:
-        1. easyr::validate.equal(...)
-        3. tibble:::`[<-.tbl_df`(`*tmp*`, col.types == "ordered", value = "factor") revdep/checks/easyr/new/easyr.Rcheck/00_pkg_src/easyr/R/validateequal.R:110:4
-        4. tibble:::tbl_subassign(x, i, j, value)
-        5. tibble:::vec_as_new_col_index(j, x, value)
-        6. tibble:::vec_as_col_index(j, x)
-       19. vctrs::vec_as_index(j, length(x), names(x), arg = "j")
-      
-      ══ testthat results  ═══════════════════════════════════════════════════════════════
-      [ OK: 282 | SKIPPED: 1 | WARNINGS: 0 | FAILED: 1 ]
-      1. Error: works as expected (@validateequal.R#110) 
-      
-      Error: testthat unit tests failed
-      Execution halted
-    ```
-
 # egor
 
 <details>
@@ -1009,7 +867,7 @@ Run `revdep_details(,"egor")` for more info
       EI-Index: female
       EI-Index: female
       ══ testthat results  ═══════════════════════════════════════════════════════════════
-      [ OK: 69 | SKIPPED: 0 | WARNINGS: 12 | FAILED: 6 ]
+      [ OK: 69 | SKIPPED: 0 | WARNINGS: 0 | FAILED: 6 ]
       1. Failure: Methods are working. (@test_clustered_graphs.R#9) 
       2. Failure: Methods are working with partially missing data. (@test_clustered_graphs.R#23) 
       3. Failure: Methods work (properly) with NAs in grouping variable. (@test_clustered_graphs.R#35) 
@@ -1605,49 +1463,6 @@ Run `revdep_details(,"ggspatial")` for more info
       All declared Imports should be used.
     ```
 
-# ggstatsplot
-
-<details>
-
-* Version: 0.1.4
-* Source code: https://github.com/cran/ggstatsplot
-* URL: https://indrajeetpatil.github.io/ggstatsplot/, https://github.com/IndrajeetPatil/ggstatsplot
-* BugReports: https://github.com/IndrajeetPatil/ggstatsplot/issues
-* Date/Publication: 2019-12-18 20:00:02 UTC
-* Number of recursive dependencies: 238
-
-Run `revdep_details(,"ggstatsplot")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    ...
-    > 
-    > 
-    > # this internal function may not have much utility outside of the package
-    > set.seed(123)
-    > library(ggplot2)
-    > 
-    > # make a plot
-    > p <- ggplot(data = iris, aes(x = Species, y = Sepal.Length)) +
-    +   geom_boxplot()
-    > 
-    > # get a dataframe with means
-    > mean_dat <- ggstatsplot:::mean_labeller(
-    +   data = iris,
-    +   x = Species,
-    +   y = Sepal.Length,
-    +   mean.ci = TRUE,
-    +   k = 3
-    + )
-    Warning: Factor `Species` contains implicit NA, consider using `forcats::fct_explicit_na`
-    Error: object 'n_missing' not found
-    Execution halted
-    ```
-
 # googlesheets4
 
 <details>
@@ -1897,27 +1712,27 @@ Run `revdep_details(,"healthcareai")` for more info
 *   checking examples ... ERROR
     ```
     ...
-    +                 groups = drug,
-    +                 outcome = survived,
-    +                 n_levels = 3)
-    [1] "Epinephrine" "Ibuprofen"   "Paclitaxel" 
     > 
-    > # Identify four drugs likely to make good features and add them to df.
-    > # The "fill", "fun", and "missing_fill" arguments are passed to
-    > # `pivot`, which allows us to use the total doses of each drug given to the
-    > # patient as our new features
+    > ### ** Examples
     > 
-    > new_df <- add_best_levels(d = df,
-    +                           longsheet = meds,
-    +                           id = patient,
-    +                           groups = drug,
-    +                           outcome = survived,
-    +                           n_levels = 4,
-    +                           fill = dose,
-    +                           fun = sum,
-    +                           missing_fill = 0)
-    Error: `i` must have one dimension, not 2.
-    Execution halted
+    > models <- machine_learn(pima_diabetes[1:40, ],
+    +                        patient_id,
+    +                        outcome = diabetes,
+    +                        models = c("XGB", "RF"),
+    +                        tune = FALSE,
+    +                        n_folds = 3)
+    Training new data prep recipe...
+    
+    The argument `options` is deprecated in favor of `freq_cut` and `unique_cut`. options` will be removed in next version.
+    Variable(s) ignored in prep_data won't be used to tune models: patient_id
+    
+    diabetes looks categorical, so training classification algorithms.
+    
+    After data processing, models are being trained on 12 features with 40 observations.
+    Based on n_folds = 3 and hyperparameter settings, the following number of models will be trained: 3 xgb's and 3 rf's 
+    
+    Training at fixed values: eXtreme Gradient Boosting
+    Training at fixed values: Random Forest
     ```
 
 *   checking tests ...
@@ -2098,26 +1913,30 @@ Run `revdep_details(,"INDperform")` for more info
     Running examples in ‘INDperform-Ex.R’ failed
     The error most likely occurred in:
     
-    > ### Name: clust_sc
-    > ### Title: Score-based cluster analysis
-    > ### Aliases: clust_sc
+    > ### Name: merge_models
+    > ### Title: Merging two model output tibbles.
+    > ### Aliases: merge_models
     > 
     > ### ** Examples
     > 
-    > # Using the Baltic Sea demo data
-    > scores_tbl <- scoring(trend_tbl = model_trend_ex,
-    +   mod_tbl = all_results_ex, press_type = press_type_ex)
-    Warning: `.key` is deprecated
-    > scores_mat <- summary_sc(scores_tbl)$scores_matrix
-    Warning: `cols` is now required.
-    Please use `cols = c(press_spec_sc)`
-    Error: `i` must have one dimension, not 2.
+    > # Using some models of the Baltic Sea demo data:
+    > # Merging GAM and GAMM tibbles
+    > test_ids <- 47:50 # choose subset
+    > gam_tbl <- model_gam_ex[test_ids,]
+    > gamm_tbl <- model_gamm(ind_init_ex[test_ids,], filter= gam_tbl$tac)
+    Error in model_gamm(ind_init_ex[test_ids, ], filter = gam_tbl$tac) : 
+      No IND~pressure GAMM could be fitted! Check if you chose the correct error distribution (default is gaussian()).
     Execution halted
     ```
 
 *   checking tests ...
     ```
     ...
+      [90m 10. [39mvctrs::stop_incompatible_type(x, y, x_arg = x_arg, y_arg = y_arg)
+      [90m 11. [39mvctrs:::stop_incompatible(...)
+      [90m 12. [39mvctrs:::stop_vctrs(...)
+      
+      [31m──[39m [31m3. Error: (unknown) (@test_test_interaction.R#27) [39m [31m─────────────────────────────[39m
       No common type for `value` <logical> and `x` <list>.
       [1mBacktrace:[22m
       [90m  1. [39mbase::`[<-`(`*tmp*`, 1, -c(1:4), value = NA)
@@ -2127,15 +1946,10 @@ Run `revdep_details(,"INDperform")` for more info
       [90m 11. [39mvctrs:::stop_vctrs(...)
       
       ══ testthat results  ═══════════════════════════════════════════════════════════════
-      [ OK: 461 | SKIPPED: 0 | WARNINGS: 24 | FAILED: 8 ]
-      1. Error: (unknown) (@test_clust_sc.R#5) 
-      2. Error: (unknown) (@test_dist_sc.R#5) 
-      3. Error: (unknown) (@test_dist_sc_group.R#5) 
-      4. Error: (unknown) (@test_model_gamm.R#4) 
-      5. Error: (unknown) (@test_plot_spiechart.R#5) 
-      6. Error: (unknown) (@test_scoring.R#15) 
-      7. Error: (unknown) (@test_summary_sc.R#6) 
-      8. Error: (unknown) (@test_test_interaction.R#27) 
+      [ OK: 506 | SKIPPED: 0 | WARNINGS: 29 | FAILED: 3 ]
+      1. Error: (unknown) (@test_model_gamm.R#4) 
+      2. Error: (unknown) (@test_scoring.R#15) 
+      3. Error: (unknown) (@test_test_interaction.R#27) 
       
       Error: testthat unit tests failed
       Execution halted
@@ -2310,7 +2124,7 @@ Run `revdep_details(,"ipumsr")` for more info
     Loading required package: sf
     Linking to GEOS 3.7.1, GDAL 2.4.0, PROJ 5.2.0
     options:        ENCODING=latin1 
-    Reading layer `US_pmsa_1990' from data source `/tmp/RtmpiHfTHz/file28e13d80c615/US_pmsa_1990.shp' using driver `ESRI Shapefile'
+    Reading layer `US_pmsa_1990' from data source `/tmp/RtmpC5B1Oa/file1bfe41bff78a2/US_pmsa_1990.shp' using driver `ESRI Shapefile'
     Error in attributes(.Data) <- c(attributes(.Data), attrib) : 
       all attributes must have names [3 does not]
     Calls: read_ipums_sf ... st_read.character -> process_cpl_read_ogr -> <Anonymous> -> structure
@@ -2327,17 +2141,17 @@ Run `revdep_details(,"ipumsr")` for more info
       [90m 9. [39mbase::structure(x, ...)
       
       ══ testthat results  ═══════════════════════════════════════════════════════════════
-      [ OK: 170 | SKIPPED: 11 | WARNINGS: 0 | FAILED: 12 ]
-      1. Error: lbl_collapse: basic (@test_lbls.r#70) 
-      2. Error: lbl_collapse: if recoding to old value it is maintained (even if it's not first) (@test_lbls.r#83) 
-      3. Error: Can read NHGIS extract (with shape as sf) (@test_nhgis.r#31) 
-      4. Error: Can read NHGIS extract (with shape as sf - 1 layer unzipped) (@test_nhgis.r#54) 
-      5. Error: Can read NHGIS extract (with shape as sf - 2 layers unzipped) (@test_nhgis.r#93) 
-      6. Error: NHGIS - sf and sp polygon-data relationships didn't get scrambled in import (@test_nhgis.r#133) 
-      7. Error: Basic join works (sf) (@test_shape_join.r#6) 
-      8. Error: suffix argument works (sf) (@test_shape_join.r#30) 
-      9. Error: complicated by works (sf) (@test_shape_join.r#44) 
-      1. ...
+      [ OK: 172 | SKIPPED: 11 | WARNINGS: 0 | FAILED: 10 ]
+      1.  Error: Can read NHGIS extract (with shape as sf) (@test_nhgis.r#31) 
+      2.  Error: Can read NHGIS extract (with shape as sf - 1 layer unzipped) (@test_nhgis.r#54) 
+      3.  Error: Can read NHGIS extract (with shape as sf - 2 layers unzipped) (@test_nhgis.r#93) 
+      4.  Error: NHGIS - sf and sp polygon-data relationships didn't get scrambled in import (@test_nhgis.r#133) 
+      5.  Error: Basic join works (sf) (@test_shape_join.r#6) 
+      6.  Error: suffix argument works (sf) (@test_shape_join.r#30) 
+      7.  Error: complicated by works (sf) (@test_shape_join.r#44) 
+      8.  Error: error for missing a by variable (sf) (@test_shape_join.r#66) 
+      9.  Error: Join failures are mentioned (@test_shape_join.r#75) 
+      10. Error: Character -> Integer conversion works (#16) (@test_shape_join.r#104) 
       
       Error: testthat unit tests failed
       Execution halted
@@ -2512,14 +2326,14 @@ Run `revdep_details(,"jtools")` for more info
 *   checking tests ...
     ```
     ...
-       18. tibble:::`[<-.tbl_df`(`*tmp*`, zeroes, value = 0) revdep/checks/jtools/new/jtools.Rcheck/00_pkg_src/jtools/R/export_summ.R:979:4
-       19. tibble:::tbl_subassign(x, i, j, value)
-       20. tibble:::vec_as_new_col_index(j, x, value)
-       21. tibble:::vec_as_col_index(j, x)
-       34. vctrs::vec_as_index(j, length(x), names(x), arg = "j")
+      [90m 11. [39mtibble:::tbl_subset2(x, j = i)
+      [90m 12. [39mvctrs::vec_as_position(j, length(x), names(x), arg = "j")
+      [90m 13. [39mvctrs:::maybe_get(...)
       
+      Failed with error:  'there is no package called 'brms''
+      Failed with error:  'there is no package called 'rstanarm''
       ══ testthat results  ═══════════════════════════════════════════════════════════════
-      [ OK: 240 | SKIPPED: 0 | WARNINGS: 29 | FAILED: 37 ]
+      [ OK: 279 | SKIPPED: 0 | WARNINGS: 29 | FAILED: 11 ]
       1. Error: effect_plot works for lm (@test-effect-plot.R#25) 
       2. Error: effect_plot: robust intervals works (@test-effect-plot.R#37) 
       3. Error: effect_plot: rug plots work (@test-effect-plot.R#45) 
@@ -2708,52 +2522,6 @@ Run `revdep_details(,"MNLpred")` for more info
       
       Error: testthat unit tests failed
       Execution halted
-    ```
-
-# modelsummary
-
-<details>
-
-* Version: 0.1.0
-* Source code: https://github.com/cran/modelsummary
-* URL: https://github.com/vincentarelbundock/modelsummary
-* BugReports: https://github.com/vincentarelbundock/modelsummary/issues
-* Date/Publication: 2019-07-15 10:20:03 UTC
-* Number of recursive dependencies: 79
-
-Run `revdep_details(,"modelsummary")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    Running examples in ‘modelsummary-Ex.R’ failed
-    The error most likely occurred in:
-    
-    > ### Name: extract
-    > ### Title: Extract and combine estimates and goodness-of-fit statistics
-    > ###   from several statistical models.
-    > ### Aliases: extract
-    > 
-    > ### ** Examples
-    > 
-    > library(modelsummary)
-    > data(trees)
-    > models <- list()
-    > models[['Bivariate']] <- lm(Girth ~ Height, data = trees)
-    > models[['Multivariate']] <- lm(Girth ~ Height + Volume, data = trees)
-    > extract(models)
-    Error: `i` must have one dimension, not 2.
-    Execution halted
-    ```
-
-## In both
-
-*   checking package dependencies ... NOTE
-    ```
-    Package suggested but not available for checking: ‘gt’
     ```
 
 # MPTmultiverse
@@ -3026,8 +2794,8 @@ Run `revdep_details(,"oppr")` for more info
             The largest [LUSOL v2.2.1.0] fact(B) had 58 NZ entries, 1.1x largest basis.
             The maximum B&B level was 4, 0.1x MIP order, 3 at the optimal solution.
             The constraint matrix inf-norm is 1, with a dynamic range of 10.
-            Time to load data was 0.028 seconds, presolve used 0.000 seconds,
-             ... 0.001 seconds in simplex solver, in total 0.029 seconds.
+            Time to load data was 0.030 seconds, presolve used 0.000 seconds,
+             ... 0.001 seconds in simplex solver, in total 0.031 seconds.
       ══ testthat results  ═══════════════════════════════════════════════════════════════
       [ OK: 1479 | SKIPPED: 35 | WARNINGS: 0 | FAILED: 4 ]
       1. Failure: valid arguments (@test_project_cost_effectiveness.R#27) 
@@ -3052,52 +2820,6 @@ Run `revdep_details(,"oppr")` for more info
       sub-directories of 1Mb or more:
         R      3.9Mb
         libs  14.3Mb
-    ```
-
-# palaeoSig
-
-<details>
-
-* Version: 2.0-3
-* Source code: https://github.com/cran/palaeoSig
-* URL: https://github.com/richardjtelford/palaeoSig
-* BugReports: https://github.com/richardjtelford/palaeoSig/issues
-* Date/Publication: 2019-06-28 08:00:03 UTC
-* Number of recursive dependencies: 107
-
-Run `revdep_details(,"palaeoSig")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    Running examples in ‘palaeoSig-Ex.R’ failed
-    The error most likely occurred in:
-    
-    > ### Name: obs.cor
-    > ### Title: Weighted correlation between weighted averaging optima and
-    > ###   constrained ordination species scores.
-    > ### Aliases: obs.cor plot.obscor identify.obscor autoplot.obscor
-    > ### Keywords: hplot htest multivariate
-    > 
-    > ### ** Examples
-    > 
-    > require(rioja)
-    Loading required package: rioja
-    This is rioja 0.9-21
-    > data(SWAP)
-    > data(RLGH)
-    > rlgh.obs <- obs.cor(spp = sqrt(SWAP$spec), env = SWAP$pH, fos = sqrt(RLGH$spec))
-    Error: Tibble columns must have consistent sizes, only values of size one are recycled:
-    ```
-
-## In both
-
-*   checking Rd cross-references ... NOTE
-    ```
-    Package unavailable to check Rd xrefs: ‘analogue’
     ```
 
 # pkgsearch
@@ -3475,7 +3197,7 @@ Run `revdep_details(,"rbin")` for more info
       1 tertiary       1299   195  1104 -0.313 0.0318    0.610
       2 secondary      2352   231  2121  0.170 0.0141    0.463
       3 unknown         179    25   154 -0.229 0.00227   0.583
-      4 primary         691    66   625  0.201 0.00572   0.455══ testthat results  ═══════════════════════════════════════════════════════════════
+      4 primary         691    66   625  0.201 0.00572   0.455══ testthat results  ══════════════════════════════════════════════════════════════
       [ OK: 10 | SKIPPED: 5 | WARNINGS: 0 | FAILED: 1 ]
       1. Error: output from rbin_create is as expected as expected (@test-bins.R#30) 
       
@@ -3900,26 +3622,26 @@ Run `revdep_details(,"rubias")` for more info
 *   checking examples ... ERROR
     ```
     ...
-    > ### Title: Write a mixture data frame to gsi_sim format baseline and
-    > ###   repunits file
-    > ### Aliases: write_gsi_sim_mixture
-    > 
-    > ### ** Examples
-    > 
-    > # this writes to file prefix "mixfile" in a temporary directory
-    > dd <- tempdir()
-    > prefix <- file.path(dd, "mixfile")
-    > 
-    > # print that
-    > prefix
-    [1] "/tmp/RtmplyL5Xp/mixfile"
     > 
     > # note that in practice you will probably want to specify
     > # your own directory...
     > 
     > # run the function
     > write_gsi_sim_mixture(chinook_mix, 5, prefix)
-    Error: `i` must have one dimension, not 2.
+    Error: No common type for `value` <double> and `x` <character>.
+    [1m<error/vctrs_error_incompatible_type>[22m
+    No common type for `value` <double> and `x` <character>.
+    [1mBacktrace:[22m
+    [90m     [39m█
+    [90m  1. [39m├─rubias::write_gsi_sim_mixture(chinook_mix, 5, prefix)
+    [90m  2. [39m│ ├─base::`[<-`(`*tmp*`, is.na(mix), value = 0) [90m00_pkg_src/rubias/R/write_gsi_sim_mixture.R:36:2[39m
+    [90m  3. [39m│ └─tibble:::`[<-.tbl_df`(`*tmp*`, is.na(mix), value = 0) [90m00_pkg_src/rubias/R/write_gsi_sim_mixture.R:36:2[39m
+    [90m  4. [39m│   └─tibble:::tbl_subassign_matrix(x, j, value)
+    [90m  5. [39m│     └─tibble:::map2(x[col_idx], cells[col_idx], `vec_slice<-`, value)
+    [90m  6. [39m│       └─base::mapply(.f, .x, .y, MoreArgs = list(...), SIMPLIFY = FALSE)
+    [90m  7. [39m│         └─(function (x, i, value) ...
+    [90m  8. [39m├─vctrs:::vec_type2_dispatch(x = x, y = y, x_arg = x_arg, y_arg = y_arg)
+    [90m  9. [39m├─vctrs::vec_ptype2.
     Execution halted
     ```
 
@@ -4513,49 +4235,6 @@ Run `revdep_details(,"stminsights")` for more info
       All declared Imports should be used.
     ```
 
-# suddengains
-
-<details>
-
-* Version: 0.4.0
-* Source code: https://github.com/cran/suddengains
-* URL: https://github.com/milanwiedemann/suddengains
-* BugReports: https://github.com/milanwiedemann/suddengains/issues
-* Date/Publication: 2019-10-27 11:20:02 UTC
-* Number of recursive dependencies: 81
-
-Run `revdep_details(,"suddengains")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    ...
-    > ### Title: Create a data set with one gain per person
-    > ### Aliases: create_byperson
-    > 
-    > ### ** Examples
-    > 
-    > # Create byperson data set, selecting the largest gain in case of muliple gains
-    > create_byperson(data = sgdata,
-    +                 sg_crit1_cutoff = 7,
-    +                 id_var_name = "id",
-    +                 tx_start_var_name = "bdi_s1",
-    +                 tx_end_var_name = "bdi_s12",
-    +                 sg_var_list = c("bdi_s1", "bdi_s2", "bdi_s3",
-    +                                 "bdi_s4", "bdi_s5", "bdi_s6",
-    +                                 "bdi_s7", "bdi_s8", "bdi_s9",
-    +                                 "bdi_s10", "bdi_s11", "bdi_s12"),
-    +                 sg_measure_name = "bdi",
-    +                 multiple_sg_select = "largest")
-    First, second, and third sudden gains criteria were applied.
-    The critical value for the thrid criterion was adjusted for missingness.
-    Error: `i` must have one dimension, not 2.
-    Execution halted
-    ```
-
 # taxa
 
 <details>
@@ -4819,100 +4498,6 @@ Run `revdep_details(,"units")` for more info
       
       Error: testthat unit tests failed
       Execution halted
-    ```
-
-# utile.tables
-
-<details>
-
-* Version: 0.1.8
-* Source code: https://github.com/cran/utile.tables
-* URL: https://github.com/efinite/utile.tables
-* BugReports: https://github.com/efinite/utile.tables/issues
-* Date/Publication: 2019-12-02 10:20:02 UTC
-* Number of recursive dependencies: 30
-
-Run `revdep_details(,"utile.tables")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    ...
-    
-        filter, lag
-    
-    The following objects are masked from ‘package:base’:
-    
-        intersect, setdiff, setequal, union
-    
-    > 
-    > data_lung <- lung %>%
-    +   as_tibble() %>%
-    +   mutate_at(vars(inst, status, sex), as.factor) %>%
-    +   mutate(status = case_when(status == 1 ~ 0, status == 2 ~ 1))
-    > 
-    > # Stand-alone row
-    > build_event_row(
-    +    label = 'Meal calories',
-    +    col = 'meal.cal',
-    +    fit = coxph(Surv(time, status) ~ meal.cal, data = data_lung)
-    + )
-    Error: `i` must have one dimension, not 2.
-    Execution halted
-    ```
-
-# utile.tools
-
-<details>
-
-* Version: 0.2.3
-* Source code: https://github.com/cran/utile.tools
-* URL: https://github.com/efinite/utile.tools
-* BugReports: https://github.com/efinite/utile.tools/issues
-* Date/Publication: 2019-12-01 23:00:06 UTC
-* Number of recursive dependencies: 30
-
-Run `revdep_details(,"utile.tools")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    ...
-    
-    The following objects are masked from ‘package:stats’:
-    
-        filter, lag
-    
-    The following objects are masked from ‘package:base’:
-    
-        intersect, setdiff, setequal, union
-    
-    > 
-    > # Survival data
-    > data_lung <- lung %>%
-    +   as_tibble() %>%
-    +   mutate_at(vars(inst, status, sex), as.factor) %>%
-    +   mutate(status = case_when(status == 1 ~ 0, status == 2 ~ 1))
-    > 
-    > tabulate_model(
-    +   fit = coxph(Surv(time, status) ~ sex + meal.cal + inst, data = data_lung)
-    +  )
-    Error: `i` must have one dimension, not 2.
-    Execution halted
-    ```
-
-## In both
-
-*   checking dependencies in R code ... NOTE
-    ```
-    Namespace in Imports field not imported from: ‘rlang’
-      All declared Imports should be used.
     ```
 
 # wtss

--- a/tests/testthat/test-subsetting-matrix.R
+++ b/tests/testthat/test-subsetting-matrix.R
@@ -1,0 +1,22 @@
+test_that("[.tbl_df supports subsetting with a logical matrix (#649)", {
+  foo <- tibble(x = 1:10, y = 1:10, z = letters[1:10])
+
+  m <- matrix(c(rep(FALSE, 8), rep(TRUE, 3), rep(FALSE, 19)), ncol = 3)
+  expect_equal(foo[m], c(9, 10, 1))
+
+  m <- matrix(c(rep(FALSE, 18), rep(TRUE, 3), rep(FALSE, 9)), ncol = 3)
+  expect_error(foo[m], class = "vctrs_error_incompatible_type")
+})
+
+test_that("[<-.tbl_df supports subsetting with a logical matrix (#649)", {
+  foo <- tibble(x = 1:10, y = 1:10, z = letters[1:10])
+
+  m <- matrix(c(rep(FALSE, 8), rep(TRUE, 3), rep(FALSE, 19)), ncol = 3)
+  foo[m] <- 1
+  expect_equal(foo[m], c(1, 1, 1))
+
+  expect_error(foo[m] <- 1:3)
+
+  m <- matrix(c(rep(FALSE, 18), rep(TRUE, 3), rep(FALSE, 9)), ncol = 3)
+  expect_error(foo[m] <- 1, class = "vctrs_error_incompatible_type")
+})

--- a/tests/testthat/test-subsetting.R
+++ b/tests/testthat/test-subsetting.R
@@ -112,10 +112,7 @@ test_that("[.tbl_df is careful about column indexes (#83)", {
     error_na_column_index(4)
   )
 
-  expect_error(
-    foo[as.matrix(1)],
-    class = "vctrs_error_incompatible_cast"
-  )
+  expect_error(foo[as.matrix(1)])
   expect_error(
     foo[array(1, dim = c(1, 1, 1))],
     class = "vctrs_error_incompatible_cast"

--- a/vignettes/invariants.Rmd
+++ b/vignettes/invariants.Rmd
@@ -277,10 +277,11 @@ For tibbles with repeated column names, subsetting by name uses the first matchi
 df[integer()]
 ```
 
-Unlike data frames, tibbles don't support indexing by a logical matrix.
+Tibbles support indexing by a logical matrix, but only if all values in the returned vector are compatible.
 
 ```{r bracket-j-logical-matrix, dftbl = TRUE}
 df[is.na(df)]
+df[!is.na(df)]
 ```
 
 ### Definition of `x[, j]`
@@ -566,10 +567,12 @@ with_df(df[4] <- list(4:1))
 with_df(df[5] <- list(4:1))
 ```
 
-Unlike data frames, tibbles don't support indexing by a logical matrix.
+Tibbles support indexing by a logical matrix, but only for a scalar RHS, and if all columns updated are compatible with the value assigned.
 
 ```{r bracket-j-assign-logical-matrix, dftbl = TRUE}
 with_df(df[is.na(df)] <- 4)
+with_df(df[is.na(df)] <- 1:2)
+with_df(df[matrix(c(rep(TRUE, 5), rep(FALSE, 7)), ncol = 3)] <- 4)
 ```
 
 ### `a` is another type of vector

--- a/vignettes/invariants.md
+++ b/vignettes/invariants.md
@@ -692,7 +692,8 @@ first matching column.
 </tr>
 </tbody>
 </table>
-Unlike data frames, tibbles don’t support indexing by a logical matrix.
+Tibbles support indexing by a logical matrix, but only if all values in
+the returned vector are compatible.
 
 <table class="dftbl">
 <tbody>
@@ -708,9 +709,49 @@ Unlike data frames, tibbles don’t support indexing by a logical matrix.
 </td>
 <td>
     tbl[is.na(tbl)]
+    #> [1] NA NA
 
-    #> Error: `i` must have one dimension,
-    #> not 2.
+</td>
+</tr>
+<tr style="vertical-align:top">
+<td>
+    df[!is.na(df)]
+    #> [[1]]
+    #> [1] 1
+    #> 
+    #> [[2]]
+    #> [1] 3
+    #> 
+    #> [[3]]
+    #> [1] "e"
+    #> 
+    #> [[4]]
+    #> [1] "f"
+    #> 
+    #> [[5]]
+    #> [1] "g"
+    #> 
+    #> [[6]]
+    #> [1] "h"
+    #> 
+    #> [[7]]
+    #> [1] 9
+    #> 
+    #> [[8]]
+    #> [1] 10 11
+    #> 
+    #> [[9]]
+    #> [1] 12 13 14
+    #> 
+    #> [[10]]
+    #> [1] "text"
+
+</td>
+<td>
+    tbl[!is.na(tbl)]
+
+    #> Error: No common type for `n`
+    #> <integer> and `c` <character>.
 
 </td>
 </tr>
@@ -2204,7 +2245,8 @@ that order of precedence).
 </tr>
 </tbody>
 </table>
-Unlike data frames, tibbles don’t support indexing by a logical matrix.
+Tibbles support indexing by a logical matrix, but only for a scalar RHS,
+and if all columns updated are compatible with the value assigned.
 
 <table class="dftbl">
 <tbody>
@@ -2220,9 +2262,50 @@ Unlike data frames, tibbles don’t support indexing by a logical matrix.
 </td>
 <td>
     with_tbl(tbl[is.na(tbl)] <- 4)
+    #> # A tibble: 4 x 3
+    #>       n c     li       
+    #>   <int> <chr> <list>   
+    #> 1     1 e     <dbl [1]>
+    #> 2     4 f     <int [2]>
+    #> 3     3 g     <int [3]>
+    #> 4     4 h     <chr [1]>
 
-    #> Error: `i` must have one dimension,
-    #> not 2.
+</td>
+</tr>
+<tr style="vertical-align:top">
+<td>
+    with_df(df[is.na(df)] <- 1:2)
+    #>   n c         li
+    #> 1 1 e          9
+    #> 2 1 f     10, 11
+    #> 3 3 g 12, 13, 14
+    #> 4 2 h       text
+
+</td>
+<td>
+    with_tbl(tbl[is.na(tbl)] <- 1:2)
+
+    #> Error in tbl_subassign_matrix(x, j,
+    #> value): vec_is(value, size = 1) is
+    #> not TRUE
+
+</td>
+</tr>
+<tr style="vertical-align:top">
+<td>
+    with_df(df[matrix(c(rep(TRUE, 5), rep(FALSE, 7)), ncol = 3)] <- 4)
+    #>   n c         li
+    #> 1 4 4          9
+    #> 2 4 f     10, 11
+    #> 3 4 g 12, 13, 14
+    #> 4 4 h       text
+
+</td>
+<td>
+    with_tbl(tbl[matrix(c(rep(TRUE, 5), rep(FALSE, 7)), ncol = 3)] <- 4)
+
+    #> Error: No common type for `value`
+    #> <double> and `x` <character>.
 
 </td>
 </tr>


### PR DESCRIPTION
Unlike data frames, we're returning vectors, not lists.

Closes #649.