### PR TITLE
Verify subsetting errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
     methods,
     pillar (>= 1.4.2.9001),
     pkgconfig,
-    rlang (>= 0.4.2),
+    rlang (>= 0.4.2.9001),
     utils,
     vctrs (>= 0.2.0.9001)
 Suggests: 
@@ -60,7 +60,8 @@ RdMacros:
     lifecycle
 Remotes: 
     r-lib/pillar,
-    r-lib/vctrs
+    r-lib/vctrs,
+    r-lib/rlang
 Encoding: UTF-8
 LazyData: yes
 Roxygen: list(markdown = TRUE)

--- a/R/subsetting-matrix.R
+++ b/R/subsetting-matrix.R
@@ -23,8 +23,12 @@ tbl_subassign_matrix <- function(x, j, value) {
 }
 
 matrix_to_cells <- function(j, x) {
-  stopifnot(is_bare_logical(j))
-  stopifnot(identical(dim(j), dim(x)))
+  if (!is_bare_logical(j)) {
+    rlang::abort("`j` must be a logical vector.")
+  }
+  if (!identical(dim(j), dim(x))) {
+    rlang::abort("`j` and `x` must have identical dimensions.")
+  }
 
   # Need unlist(list(...)) because apply() isn't type stable if the return
   # has the same length everywhere

--- a/tests/testthat/error/test-subsetting.txt
+++ b/tests/testthat/error/test-subsetting.txt
@@ -73,6 +73,34 @@ Error: `j` and `x` must have identical dimensions.
 Error: `i` must have one dimension, not 3.
 
 
+[.tbl_df rejects unknown column indexes (#83)
+=============================================
+
+> foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
+> foo[list(1:3)]
+Error: Must subset columns with an index vector.
+x `j` has the wrong type `list`.
+i These indices must be indicators, locations or names.
+
+> foo[as.list(1:3)]
+Error: Must subset columns with an index vector.
+x `j` has the wrong type `list`.
+i These indices must be indicators, locations or names.
+
+> foo[factor(1:3)]
+Error: Can't find columns `1`, `2`, `3` in `.data`.
+
+> foo[Sys.Date()]
+Error: Must subset columns with an index vector.
+x `j` has the wrong type `date`.
+i These indices must be indicators, locations or names.
+
+> foo[Sys.time()]
+Error: Must subset columns with an index vector.
+x `j` has the wrong type `datetime<local>`.
+i These indices must be indicators, locations or names.
+
+
 [[.tbl_df throws error with NA index
 ====================================
 

--- a/tests/testthat/error/test-subsetting.txt
+++ b/tests/testthat/error/test-subsetting.txt
@@ -25,7 +25,7 @@ Error: Cannot exclude column 4 in tibble with 3 columns.
 Error: Can't use NA as column index with `[` at position 4.
 
 > foo[as.matrix(1)]
-Error in matrix_to_cells(j, x): is_bare_logical(j) is not TRUE
+Error: `j` must be a logical vector.
 
 > foo[array(1, dim = c(1, 1, 1))]
 Error: Can't cast <integer[,1,1]> to <integer>.
@@ -50,7 +50,7 @@ x The subscript has size 4.
 Error: Can't use NA as column index with `[` at position 3.
 
 > foo[as.matrix(TRUE)]
-Error in matrix_to_cells(j, x): identical(dim(j), dim(x)) is not TRUE
+Error: `j` and `x` must have identical dimensions.
 
 > foo[array(TRUE, dim = c(1, 1, 1))]
 Error: `i` must have one dimension, not 3.

--- a/tests/testthat/error/test-subsetting.txt
+++ b/tests/testthat/error/test-subsetting.txt
@@ -37,13 +37,13 @@ Can not decrease dimensions
 
 > foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
 > foo[c(TRUE, TRUE)]
-Error: Logical subscripts must match the size of the indexed input.
-i The input has size 3.
+Error: Logical subscripts must match the size of the indexed vector.
+i The indexed vector has size 3.
 x The subscript has size 2.
 
 > foo[c(TRUE, TRUE, FALSE, FALSE)]
-Error: Logical subscripts must match the size of the indexed input.
-i The input has size 3.
+Error: Logical subscripts must match the size of the indexed vector.
+i The indexed vector has size 3.
 x The subscript has size 4.
 
 > foo[c(TRUE, TRUE, NA)]
@@ -54,6 +54,31 @@ Error in matrix_to_cells(j, x): identical(dim(j), dim(x)) is not TRUE
 
 > foo[array(TRUE, dim = c(1, 1, 1))]
 Error: `i` must have one dimension, not 3.
+
+
+[[.tbl_df throws error with NA index
+====================================
+
+> foo <- tibble(x = 1:10, y = 1:10)
+> foo[[NA]]
+Error: Must extract with a single subscript.
+x `j` can't be `NA`.
+i This subscript can't be missing.
+
+> foo[[NA_integer_]]
+Error: Must extract with a single subscript.
+x `j` can't be `NA`.
+i This subscript can't be missing.
+
+> foo[[NA_real_]]
+Error: Must extract with a single subscript.
+x `j` can't be `NA`.
+i This subscript can't be missing.
+
+> foo[[NA_character_]]
+Error: Must extract with a single subscript.
+x `j` can't be `NA`.
+i This subscript can't be missing.
 
 
 [<-.tbl_df throws an error with duplicate indexes (#658)

--- a/tests/testthat/error/test-subsetting.txt
+++ b/tests/testthat/error/test-subsetting.txt
@@ -1,4 +1,21 @@
 
+[.tbl_df is careful about names (#1245)
+=======================================
+
+> foo <- tibble(x = 1:10, y = 1:10)
+> foo[c("x", "y", "z")]
+Error: Can't find column `z` in `.data`.
+
+> foo[c("w", "x", "y", "z")]
+Error: Can't find columns `w`, `z` in `.data`.
+
+> foo[as.matrix("x")]
+Error: `j` must be a logical vector.
+
+> foo[array("x", dim = c(1, 1, 1))]
+Error: `i` must have one dimension, not 3.
+
+
 [.tbl_df is careful about column indexes (#83)
 ==============================================
 

--- a/tests/testthat/error/test-subsetting.txt
+++ b/tests/testthat/error/test-subsetting.txt
@@ -37,13 +37,13 @@ Can not decrease dimensions
 
 > foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
 > foo[c(TRUE, TRUE)]
-Error: Logical subscripts must match the size of the indexed vector.
-i The indexed vector has size 3.
+Error: Logical subscripts must match the size of the indexed input.
+i The input has size 3.
 x The subscript has size 2.
 
 > foo[c(TRUE, TRUE, FALSE, FALSE)]
-Error: Logical subscripts must match the size of the indexed vector.
-i The indexed vector has size 3.
+Error: Logical subscripts must match the size of the indexed input.
+i The input has size 3.
 x The subscript has size 4.
 
 > foo[c(TRUE, TRUE, NA)]

--- a/tests/testthat/error/test-subsetting.txt
+++ b/tests/testthat/error/test-subsetting.txt
@@ -1,0 +1,86 @@
+
+[.tbl_df is careful about column indexes (#83)
+==============================================
+
+> foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
+> foo[0.5]
+Error: Must subset columns with an index vector.
+x Lossy cast from `j` <double> to <integer>.
+
+> foo[1:5]
+Error: Cannot subset columns 4, 5 in tibble with 3 columns.
+
+> foo[-1:1]
+Error: Must subset columns with an index vector.
+i The subscript has a positive value at location 3.
+
+> foo[c(-1, 1)]
+Error: Must subset columns with an index vector.
+i The subscript has a positive value at location 2.
+
+> foo[-4]
+Error: Cannot exclude column 4 in tibble with 3 columns.
+
+> foo[c(1:3, NA)]
+Error: Can't use NA as column index with `[` at position 4.
+
+> foo[as.matrix(1)]
+Error in matrix_to_cells(j, x): is_bare_logical(j) is not TRUE
+
+> foo[array(1, dim = c(1, 1, 1))]
+Error: Can't cast <integer[,1,1]> to <integer>.
+Can not decrease dimensions
+
+
+[.tbl_df is careful about column flags (#83)
+============================================
+
+> foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
+> foo[c(TRUE, TRUE)]
+Error: Logical subscripts must match the size of the indexed input.
+i The input has size 3.
+x The subscript has size 2.
+
+> foo[c(TRUE, TRUE, FALSE, FALSE)]
+Error: Logical subscripts must match the size of the indexed input.
+i The input has size 3.
+x The subscript has size 4.
+
+> foo[c(TRUE, TRUE, NA)]
+Error: Can't use NA as column index with `[` at position 3.
+
+> foo[as.matrix(TRUE)]
+Error in matrix_to_cells(j, x): identical(dim(j), dim(x)) is not TRUE
+
+> foo[array(TRUE, dim = c(1, 1, 1))]
+Error: `i` must have one dimension, not 3.
+
+
+[<-.tbl_df throws an error with duplicate indexes (#658)
+========================================================
+
+> df <- tibble(x = 1:2, y = x)
+> df[c(1, 1)] <- 3
+Error: Column index 1 is used more than once for assignment.
+
+> df[, c(1, 1)] <- 3
+Error: Column index 1 is used more than once for assignment.
+
+> df[c(1, 1), ] <- 3
+Error: Row index 1 is used more than once for assignment.
+
+
+$<- recycles only values of length one
+======================================
+
+> df <- tibble(x = 1:3)
+> df$w <- 8:9
+Error: Tibble columns must have consistent sizes, only values of size one are recycled:
+* Size 3: Existing data
+* Size 2: Column `w`
+
+> df$a <- character()
+Error: Tibble columns must have consistent sizes, only values of size one are recycled:
+* Size 3: Existing data
+* Size 0: Column `a`
+

--- a/tests/testthat/helper-error.R
+++ b/tests/testthat/helper-error.R
@@ -5,3 +5,6 @@ get_defunct_error_class <- function() {
     "defunctError"
   }
 }
+
+# Dummy to remind us to keep tests and verifications in sync
+verify_errors <- identity

--- a/tests/testthat/test-subsetting.R
+++ b/tests/testthat/test-subsetting.R
@@ -179,27 +179,29 @@ test_that("[.tbl_df is careful about column flags (#83)", {
 })
 
 test_that("[.tbl_df rejects unknown column indexes (#83)", {
-  foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
-  expect_tibble_error(
-    foo[list(1:3)],
-    error_unsupported_column_index()
-  )
-  expect_tibble_error(
-    foo[as.list(1:3)],
-    error_unsupported_column_index()
-  )
-  expect_tibble_error(
-    foo[factor(1:3)],
-    error_unknown_column_names(as.character(1:3))
-  )
-  expect_tibble_error(
-    foo[Sys.Date()],
-    error_unsupported_column_index()
-  )
-  expect_tibble_error(
-    foo[Sys.time()],
-    error_unsupported_column_index()
-  )
+  verify_errors({
+    foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
+    expect_tibble_error(
+      foo[list(1:3)],
+      error_unsupported_column_index()
+    )
+    expect_tibble_error(
+      foo[as.list(1:3)],
+      error_unsupported_column_index()
+    )
+    expect_tibble_error(
+      foo[factor(1:3)],
+      error_unknown_column_names(as.character(1:3))
+    )
+    expect_tibble_error(
+      foo[Sys.Date()],
+      error_unsupported_column_index()
+    )
+    expect_tibble_error(
+      foo[Sys.time()],
+      error_unsupported_column_index()
+    )
+  })
 })
 
 test_that("[.tbl_df supports character subsetting (#312)", {
@@ -616,6 +618,14 @@ test_that("subsetting has informative errors", {
     foo[c(TRUE, TRUE, NA)]
     foo[as.matrix(TRUE)]
     foo[array(TRUE, dim = c(1, 1, 1))]
+
+    "# [.tbl_df rejects unknown column indexes (#83)"
+    foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
+    foo[list(1:3)]
+    foo[as.list(1:3)]
+    foo[factor(1:3)]
+    foo[Sys.Date()]
+    foo[Sys.time()]
 
     "# [[.tbl_df throws error with NA index"
     foo <- tibble(x = 1:10, y = 1:10)

--- a/tests/testthat/test-subsetting.R
+++ b/tests/testthat/test-subsetting.R
@@ -95,75 +95,76 @@ test_that("[.tbl_df is careful about names (#1245)", {
 })
 
 test_that("[.tbl_df is careful about column indexes (#83)", {
-  foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
-  expect_identical(foo[1:3], foo)
+  verify_errors({
+    foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
+    expect_identical(foo[1:3], foo)
 
-  expect_tibble_error(
-    foo[0.5],
-    error_unsupported_column_index()
-  )
-  expect_tibble_error(
-    foo[1:5],
-    error_large_column_index(3, 4:5)
-  )
+    expect_tibble_error(
+      foo[0.5],
+      error_unsupported_column_index()
+    )
+    expect_tibble_error(
+      foo[1:5],
+      error_large_column_index(3, 4:5)
+    )
 
-  expect_error(
-    foo[-1:1],
-    class = "tibble_error_unsupported_column_index"
-  )
-  expect_error(
-    foo[c(-1, 1)],
-    class = "tibble_error_unsupported_column_index"
-  )
+    expect_error(
+      foo[-1:1],
+      class = "tibble_error_unsupported_column_index"
+    )
+    expect_error(
+      foo[c(-1, 1)],
+      class = "tibble_error_unsupported_column_index"
+    )
 
-  expect_tibble_error(
-    foo[-4],
-    error_small_column_index(3, -4)
-  )
-  expect_error(
-    foo[c(-1, 2)],
-    class = "tibble_error_unsupported_column_index"
-  )
-  expect_tibble_error(
-    foo[c(1:3, NA)],
-    error_na_column_index(4)
-  )
+    expect_tibble_error(
+      foo[-4],
+      error_small_column_index(3, -4)
+    )
+    expect_tibble_error(
+      foo[c(1:3, NA)],
+      error_na_column_index(4)
+    )
 
-  expect_error(foo[as.matrix(1)])
-  expect_error(
-    foo[array(1, dim = c(1, 1, 1))],
-    class = "vctrs_error_incompatible_cast"
-  )
+    expect_error(foo[as.matrix(1)])
+
+    expect_error(
+      foo[array(1, dim = c(1, 1, 1))],
+      class = "vctrs_error_incompatible_cast"
+    )
+  })
 })
 
 test_that("[.tbl_df is careful about column flags (#83)", {
-  foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
-  expect_identical(foo[TRUE], foo)
-  expect_identical(foo[c(TRUE, TRUE, TRUE)], foo)
-  expect_identical(foo[FALSE], foo[integer()])
-  expect_identical(foo[c(FALSE, TRUE, FALSE)], foo[2])
+  verify_errors({
+    foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
+    expect_identical(foo[TRUE], foo)
+    expect_identical(foo[c(TRUE, TRUE, TRUE)], foo)
+    expect_identical(foo[FALSE], foo[integer()])
+    expect_identical(foo[c(FALSE, TRUE, FALSE)], foo[2])
 
-  expect_error(
-    foo[c(TRUE, TRUE)],
-    class = "vctrs_error_indicator_bad_size"
-  )
-  expect_error(
-    foo[c(TRUE, TRUE, FALSE, FALSE)],
-    class = "vctrs_error_indicator_bad_size"
-  )
-  expect_tibble_error(
-    foo[c(TRUE, TRUE, NA)],
-    error_na_column_index(3)
-  )
+    expect_error(
+      foo[c(TRUE, TRUE)],
+      class = "vctrs_error_indicator_bad_size"
+    )
+    expect_error(
+      foo[c(TRUE, TRUE, FALSE, FALSE)],
+      class = "vctrs_error_indicator_bad_size"
+    )
+    expect_tibble_error(
+      foo[c(TRUE, TRUE, NA)],
+      error_na_column_index(3)
+    )
 
-  expect_error(
-    foo[as.matrix(TRUE)],
-    "."
-  )
-  expect_error(
-    foo[array(TRUE, dim = c(1, 1, 1))],
-    "."
-  )
+    expect_error(
+      foo[as.matrix(TRUE)],
+      "."
+    )
+    expect_error(
+      foo[array(TRUE, dim = c(1, 1, 1))],
+      "."
+    )
+  })
 })
 
 test_that("[.tbl_df rejects unknown column indexes (#83)", {
@@ -394,19 +395,21 @@ test_that("[[<-.tbl_df can remove columns (#666)", {
 # [<- ---------------------------------------------------------------------
 
 test_that("[<-.tbl_df throws an error with duplicate indexes (#658)", {
-  df <- tibble(x = 1:2, y = x)
-  expect_tibble_error(
-    df[c(1, 1)] <- 3,
-    error_duplicate_column_subscript_for_assignment(c(1, 1))
-  )
-  expect_tibble_error(
-    df[, c(1, 1)] <- 3,
-    error_duplicate_column_subscript_for_assignment(c(1, 1))
-  )
-  expect_tibble_error(
-    df[c(1, 1), ] <- 3,
-    error_duplicate_row_subscript_for_assignment(c(1, 1))
-  )
+  verify_errors({
+    df <- tibble(x = 1:2, y = x)
+    expect_tibble_error(
+      df[c(1, 1)] <- 3,
+      error_duplicate_column_subscript_for_assignment(c(1, 1))
+    )
+    expect_tibble_error(
+      df[, c(1, 1)] <- 3,
+      error_duplicate_column_subscript_for_assignment(c(1, 1))
+    )
+    expect_tibble_error(
+      df[c(1, 1), ] <- 3,
+      error_duplicate_row_subscript_for_assignment(c(1, 1))
+    )
+  })
 })
 
 test_that("[<-.tbl_df supports adding new rows with [i, j] (#651)", {
@@ -558,13 +561,51 @@ test_that("$<- recycles only values of length one", {
   expect_identical(df, tibble(x = 1:3, y = 4, z = 5:7))
   expect_false(has_rownames(df))
 
-  expect_tibble_error(
-    df$w <- 8:9,
-    error_inconsistent_cols(3, "w", 2, "Existing data")
-  )
+  verify_errors({
+    df <- tibble(x = 1:3)
 
-  expect_tibble_error(
-    df$a <- character(),
-    error_inconsistent_cols(3, "a", 0, "Existing data")
-  )
+    expect_tibble_error(
+      df$w <- 8:9,
+      error_inconsistent_cols(3, "w", 2, "Existing data")
+    )
+
+    expect_tibble_error(
+      df$a <- character(),
+      error_inconsistent_cols(3, "a", 0, "Existing data")
+    )
+  })
+})
+
+test_that("subsetting has informative errors", {
+  verify_output(test_path("error", "test-subsetting.txt"), {
+    "# [.tbl_df is careful about column indexes (#83)"
+    foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
+    foo[0.5]
+    foo[1:5]
+    foo[-1:1]
+    foo[c(-1, 1)]
+    foo[-4]
+    foo[c(1:3, NA)]
+    foo[as.matrix(1)]
+    foo[array(1, dim = c(1, 1, 1))]
+
+    "# [.tbl_df is careful about column flags (#83)"
+    foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
+    foo[c(TRUE, TRUE)]
+    foo[c(TRUE, TRUE, FALSE, FALSE)]
+    foo[c(TRUE, TRUE, NA)]
+    foo[as.matrix(TRUE)]
+    foo[array(TRUE, dim = c(1, 1, 1))]
+
+    "# [<-.tbl_df throws an error with duplicate indexes (#658)"
+    df <- tibble(x = 1:2, y = x)
+    df[c(1, 1)] <- 3
+    df[, c(1, 1)] <- 3
+    df[c(1, 1), ] <- 3
+
+    "# $<- recycles only values of length one"
+    df <- tibble(x = 1:3)
+    df$w <- 8:9
+    df$a <- character()
+  })
 })

--- a/tests/testthat/test-subsetting.R
+++ b/tests/testthat/test-subsetting.R
@@ -84,14 +84,25 @@ test_that("[.tbl_df is careful about names (#1245)", {
     error_unknown_column_names("z")
   )
 
-  expect_error(
-    foo[as.matrix("x")],
-    "."
-  )
-  expect_error(
-    foo[array("x", dim = c(1, 1, 1))],
-    "."
-  )
+  verify_errors({
+    foo <- tibble(x = 1:10, y = 1:10)
+    expect_tibble_error(
+      foo[c("x", "y", "z")],
+      error_unknown_column_names("z")
+    )
+    expect_tibble_error(
+      foo[c("w", "x", "y", "z")],
+      error_unknown_column_names(c("w", "z"))
+    )
+    expect_error(
+      foo[as.matrix("x")],
+      "."
+    )
+    expect_error(
+      foo[array("x", dim = c(1, 1, 1))],
+      "."
+    )
+  })
 })
 
 test_that("[.tbl_df is careful about column indexes (#83)", {
@@ -580,6 +591,13 @@ test_that("$<- recycles only values of length one", {
 
 test_that("subsetting has informative errors", {
   verify_output(test_path("error", "test-subsetting.txt"), {
+    "# [.tbl_df is careful about names (#1245)"
+    foo <- tibble(x = 1:10, y = 1:10)
+    foo[c("x", "y", "z")]
+    foo[c("w", "x", "y", "z")]
+    foo[as.matrix("x")]
+    foo[array("x", dim = c(1, 1, 1))]
+
     "# [.tbl_df is careful about column indexes (#83)"
     foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
     foo[0.5]

--- a/tests/testthat/test-subsetting.R
+++ b/tests/testthat/test-subsetting.R
@@ -315,11 +315,13 @@ test_that("[[.tbl_df ignores exact argument", {
 })
 
 test_that("[[.tbl_df throws error with NA index", {
-  foo <- tibble(x = 1:10, y = 1:10)
-  expect_error(foo[[NA]])
-  expect_error(foo[[NA_integer_]])
-  expect_error(foo[[NA_real_]])
-  expect_error(foo[[NA_character_]])
+  verify_errors({
+    foo <- tibble(x = 1:10, y = 1:10)
+    expect_error(foo[[NA]])
+    expect_error(foo[[NA_integer_]])
+    expect_error(foo[[NA_real_]])
+    expect_error(foo[[NA_character_]])
+  })
 })
 
 test_that("can use recursive indexing with [[", {
@@ -596,6 +598,13 @@ test_that("subsetting has informative errors", {
     foo[c(TRUE, TRUE, NA)]
     foo[as.matrix(TRUE)]
     foo[array(TRUE, dim = c(1, 1, 1))]
+
+    "# [[.tbl_df throws error with NA index"
+    foo <- tibble(x = 1:10, y = 1:10)
+    foo[[NA]]
+    foo[[NA_integer_]]
+    foo[[NA_real_]]
+    foo[[NA_character_]]
 
     "# [<-.tbl_df throws an error with duplicate indexes (#658)"
     df <- tibble(x = 1:2, y = x)

--- a/tests/testthat/test-subsetting.R
+++ b/tests/testthat/test-subsetting.R
@@ -107,15 +107,23 @@ test_that("[.tbl_df is careful about column indexes (#83)", {
     error_large_column_index(3, 4:5)
   )
 
-  # Message from base R
-  expect_error(foo[-1:1])
-  expect_error(foo[c(-1, 1)])
+  expect_error(
+    foo[-1:1],
+    class = "tibble_error_unsupported_column_index"
+  )
+  expect_error(
+    foo[c(-1, 1)],
+    class = "tibble_error_unsupported_column_index"
+  )
 
   expect_tibble_error(
     foo[-4],
     error_small_column_index(3, -4)
   )
-  expect_error(foo[c(-1, 2)], ".")
+  expect_error(
+    foo[c(-1, 2)],
+    class = "tibble_error_unsupported_column_index"
+  )
   expect_tibble_error(
     foo[c(1:3, NA)],
     error_na_column_index(4)
@@ -137,11 +145,11 @@ test_that("[.tbl_df is careful about column flags (#83)", {
 
   expect_error(
     foo[c(TRUE, TRUE)],
-    "."
+    class = "vctrs_error_indicator_bad_size"
   )
   expect_error(
     foo[c(TRUE, TRUE, FALSE, FALSE)],
-    "."
+    class = "vctrs_error_indicator_bad_size"
   )
   expect_tibble_error(
     foo[c(TRUE, TRUE, NA)],
@@ -251,7 +259,7 @@ test_that("[.tbl_df supports logical subsetting (#318)", {
   expect_identical(foo[TRUE, ], foo)
   expect_identical(foo[FALSE, ], foo[0L, ])
 
-  expect_error(foo[c(TRUE, FALSE), ], ".")
+  expect_error(foo[c(TRUE, FALSE), ], class = "vctrs_error_indicator_bad_size")
 })
 
 test_that("[.tbl_df is no-op if args missing", {


### PR DESCRIPTION
* Add missing error classes in expectations.

* Verify `[` and `[[` errors in a file-wide `verify_output()`. This follows conventions we have started to develop for vctrs and dplyr.

* Depend on dev rlang for a deparsing fix. I'll release it before the conference.