### PR TITLE
Use vctrs errors for column subsetting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     pkgconfig,
     rlang (>= 0.4.2.9001),
     utils,
-    vctrs (>= 0.2.0.9001)
+    vctrs (>= 0.2.0.9003)
 Suggests: 
     bench,
     covr,
@@ -60,7 +60,7 @@ RdMacros:
     lifecycle
 Remotes: 
     r-lib/pillar,
-    r-lib/vctrs,
+    r-lib/vctrs#765,
     r-lib/rlang
 Encoding: UTF-8
 LazyData: yes

--- a/R/msg.R
+++ b/R/msg.R
@@ -335,7 +335,7 @@ subclass_name_repair_errors <- function(expr, name) {
   )
 }
 
-subclass_col_index_errors <- function(expr) {
+subclass_col_index_errors <- function(expr, arg = NULL) {
   tryCatch(
     force(expr),
 
@@ -347,7 +347,7 @@ subclass_col_index_errors <- function(expr) {
     },
 
     vctrs_error_subscript = function(cnd) {
-      cnd$arg <- quote(tbl[i])
+      cnd$arg <- arg
       cnd$subscript_elt <- c("column", "columns")
       cnd$subscript_input <- "tibble"
       cnd_signal(cnd)

--- a/R/msg.R
+++ b/R/msg.R
@@ -339,26 +339,17 @@ subclass_col_index_errors <- function(expr) {
   tryCatch(
     force(expr),
 
-    vctrs_error_subscript_oob_name = function(cnd) {
-      cnd <- error_unknown_column_names(setdiff(cnd$i, cnd$names), parent = cnd)
-      cnd_signal(cnd)
-    },
-
-    vctrs_error_subscript_oob_location = function(cnd) {
-      i <- cnd$i
-      size <- cnd$size
-      if (any(i < 0)) {
-        cnd <- error_small_column_index(cnd$size, i[i < -size], parent = cnd)
-      } else {
-        cnd <- error_large_column_index(cnd$size, i[i > size], parent = cnd)
-      }
-      cnd_signal(cnd)
-    },
-
     vctrs_error_subscript_bad_type = function(cnd) {
       body <- cnd_body(cnd)
       cnd$body <- function(...) body
       cnd <- error_unsupported_column_index(cnd)
+      cnd_signal(cnd)
+    },
+
+    vctrs_error_subscript = function(cnd) {
+      cnd$arg <- quote(tbl[i])
+      cnd$subscript_elt <- c("column", "columns")
+      cnd$subscript_input <- "tibble"
       cnd_signal(cnd)
     }
   )

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -199,7 +199,7 @@ NULL
   }
 
   # From here on, i, j and drop contain correct values:
-  xo <- tbl_subset_col(x, j = j)
+  xo <- tbl_subset_col(x, j = j, arg = substitute(x))
 
   if (!is.null(i)) {
     xo <- tbl_subset_row(xo, i = i)
@@ -321,7 +321,7 @@ warn_oob_negative <- function(oob, n) {
   }
 }
 
-vectbl_as_col_index <- function(j, x) {
+vectbl_as_col_index <- function(j, x, arg = NULL) {
   stopifnot(!is.null(j))
 
   if (anyNA(j)) {
@@ -329,7 +329,8 @@ vectbl_as_col_index <- function(j, x) {
   }
 
   subclass_col_index_errors(
-    vec_as_location(j, length(x), names(x), arg = "j")
+    vec_as_location(j, length(x), names(x), arg = "j"),
+    arg = arg
   )
 }
 
@@ -353,9 +354,9 @@ tbl_subset2 <- function(x, j) {
   .subset2(x, j)
 }
 
-tbl_subset_col <- function(x, j) {
+tbl_subset_col <- function(x, j, arg = NULL) {
   if (is_null(j)) return(x)
-  j <- vectbl_as_col_index(j, x)
+  j <- vectbl_as_col_index(j, x, arg = arg)
   xo <- .subset(x, j)
   xo <- set_repaired_names(xo, .name_repair = "minimal")
   set_tibble_class(xo, nrow = fast_nrow(x))

--- a/tests/testthat/error/test-subsetting.txt
+++ b/tests/testthat/error/test-subsetting.txt
@@ -4,11 +4,11 @@
 
 > foo <- tibble(x = 1:10, y = 1:10)
 > foo[c("x", "y", "z")]
-Error: Must subset existing columns in `tbl[i]`.
+Error: Must subset existing columns in `foo`.
 x Can't subset column with unknown name `z`.
 
 > foo[c("w", "x", "y", "z")]
-Error: Must subset existing columns in `tbl[i]`.
+Error: Must subset existing columns in `foo`.
 x Can't subset columns with unknown names `w` and `z`.
 
 > foo[as.matrix("x")]
@@ -27,7 +27,7 @@ Error: Must subset columns with an index vector.
 x Lossy cast from `j` <double> to <integer>.
 
 > foo[1:5]
-Error: Must subset existing columns in `tbl[i]`.
+Error: Must subset existing columns in `foo`.
 x Can't subset locations 4 and 5.
 i There are only 3 columns.
 
@@ -40,7 +40,7 @@ Error: Must subset columns with an index vector.
 i The subscript has a positive value at location 2.
 
 > foo[-4]
-Error: Must remove existing columns in `tbl[i]`.
+Error: Must remove existing columns in `foo`.
 x Can't remove location 4.
 i There are only 3 columns.
 
@@ -94,7 +94,7 @@ x `j` has the wrong type `list`.
 i These indices must be indicators, locations or names.
 
 > foo[factor(1:3)]
-Error: Must subset existing columns in `tbl[i]`.
+Error: Must subset existing columns in `foo`.
 x Can't subset columns with unknown names `1`, `2`, and `3`.
 
 > foo[Sys.Date()]

--- a/tests/testthat/error/test-subsetting.txt
+++ b/tests/testthat/error/test-subsetting.txt
@@ -4,10 +4,12 @@
 
 > foo <- tibble(x = 1:10, y = 1:10)
 > foo[c("x", "y", "z")]
-Error: Can't find column `z` in `.data`.
+Error: Must subset existing columns in `tbl[i]`.
+x Can't subset column with unknown name `z`.
 
 > foo[c("w", "x", "y", "z")]
-Error: Can't find columns `w`, `z` in `.data`.
+Error: Must subset existing columns in `tbl[i]`.
+x Can't subset columns with unknown names `w` and `z`.
 
 > foo[as.matrix("x")]
 Error: `j` must be a logical vector.
@@ -25,7 +27,9 @@ Error: Must subset columns with an index vector.
 x Lossy cast from `j` <double> to <integer>.
 
 > foo[1:5]
-Error: Cannot subset columns 4, 5 in tibble with 3 columns.
+Error: Must subset existing columns in `tbl[i]`.
+x Can't subset locations 4 and 5.
+i There are only 3 columns.
 
 > foo[-1:1]
 Error: Must subset columns with an index vector.
@@ -36,7 +40,9 @@ Error: Must subset columns with an index vector.
 i The subscript has a positive value at location 2.
 
 > foo[-4]
-Error: Cannot exclude column 4 in tibble with 3 columns.
+Error: Must remove existing columns in `tbl[i]`.
+x Can't remove location 4.
+i There are only 3 columns.
 
 > foo[c(1:3, NA)]
 Error: Can't use NA as column index with `[` at position 4.
@@ -88,7 +94,8 @@ x `j` has the wrong type `list`.
 i These indices must be indicators, locations or names.
 
 > foo[factor(1:3)]
-Error: Can't find columns `1`, `2`, `3` in `.data`.
+Error: Must subset existing columns in `tbl[i]`.
+x Can't subset columns with unknown names `1`, `2`, and `3`.
 
 > foo[Sys.Date()]
 Error: Must subset columns with an index vector.

--- a/tests/testthat/test-subsetting.R
+++ b/tests/testthat/test-subsetting.R
@@ -66,33 +66,34 @@ test_that("[ with explicit NULL works as expected (#696)", {
 
 test_that("[.tbl_df is careful about names (#1245)", {
   foo <- tibble(x = 1:10, y = 1:10)
-  expect_tibble_error(
+
+  expect_error(
     foo["z"],
-    error_unknown_column_names("z")
+    class = "vctrs_error_subscript_oob"
   )
-  expect_tibble_error(
+  expect_error(
     foo[c("x", "y", "z")],
-    error_unknown_column_names("z")
+    class = "vctrs_error_subscript_oob"
   )
 
-  expect_tibble_error(
+  expect_error(
     foo[, "z"],
-    error_unknown_column_names("z")
+    class = "vctrs_error_subscript_oob"
   )
-  expect_tibble_error(
+  expect_error(
     foo[, c("x", "y", "z")],
-    error_unknown_column_names("z")
+    class = "vctrs_error_subscript_oob"
   )
 
   verify_errors({
     foo <- tibble(x = 1:10, y = 1:10)
-    expect_tibble_error(
+    expect_error(
       foo[c("x", "y", "z")],
-      error_unknown_column_names("z")
+      class = "vctrs_error_subscript_oob"
     )
-    expect_tibble_error(
+    expect_error(
       foo[c("w", "x", "y", "z")],
-      error_unknown_column_names(c("w", "z"))
+      class = "vctrs_error_subscript_oob"
     )
     expect_error(
       foo[as.matrix("x")],
@@ -114,9 +115,9 @@ test_that("[.tbl_df is careful about column indexes (#83)", {
       foo[0.5],
       error_unsupported_column_index()
     )
-    expect_tibble_error(
+    expect_error(
       foo[1:5],
-      error_large_column_index(3, 4:5)
+      class = "vctrs_error_subscript_oob"
     )
 
     expect_error(
@@ -128,9 +129,9 @@ test_that("[.tbl_df is careful about column indexes (#83)", {
       class = "tibble_error_unsupported_column_index"
     )
 
-    expect_tibble_error(
+    expect_error(
       foo[-4],
-      error_small_column_index(3, -4)
+      class = "vctrs_error_subscript_oob"
     )
     expect_tibble_error(
       foo[c(1:3, NA)],
@@ -189,9 +190,9 @@ test_that("[.tbl_df rejects unknown column indexes (#83)", {
       foo[as.list(1:3)],
       error_unsupported_column_index()
     )
-    expect_tibble_error(
+    expect_error(
       foo[factor(1:3)],
-      error_unknown_column_names(as.character(1:3))
+      class = "vctrs_error_subscript_oob"
     )
     expect_tibble_error(
       foo[Sys.Date()],


### PR DESCRIPTION
Branched from #698.

Uses r-lib/vctrs#765 to move the generation of error messages to vctrs, and to avoid subclassing the error classes when there is no need.