### PR TITLE
Refresh rownames doc

### DIFF
--- a/R/rownames.R
+++ b/R/rownames.R
@@ -12,9 +12,9 @@
 #' (`has_rownames()`), remove them (`remove_rownames()`), or convert
 #' them back-and-forth between an explicit column (`rownames_to_column()`
 #' and `column_to_rownames()`).
-#' Also included is `rowid_to_column()` which
-#' adds a column at the start of the dataframe of ascending sequential row
-#' ids starting at 1. Note that this will remove any existing row names.
+#' Also included is `rowid_to_column()`, which adds a column at the start of the
+#' dataframe of ascending sequential row ids starting at 1. Note that this will
+#' remove any existing row names.
 #'
 #' @return `column_to_rownames()` always returns a data frame.
 #'   `has_rownames()` returns a scalar logical.

--- a/R/rownames.R
+++ b/R/rownames.R
@@ -23,15 +23,21 @@
 #' @param .data A data frame.
 #' @param var Name of column to use for rownames.
 #' @examples
+#' # Detect row names ----------------------------------------------------
 #' has_rownames(mtcars)
 #' has_rownames(iris)
-#' has_rownames(remove_rownames(mtcars))
 #'
-#' head(rownames_to_column(mtcars))
+#' # Remove row names ----------------------------------------------------
+#' remove_rownames(mtcars) %>% has_rownames()
 #'
-#' mtcars_tbl <- as_tibble(rownames_to_column(mtcars))
+#' # Convert between row names and column --------------------------------
+#' mtcars_tbl <- rownames_to_column(mtcars, var = "car") %>% as_tibble()
 #' mtcars_tbl
-#' head(column_to_rownames(mtcars_tbl))
+#' column_to_rownames(mtcars_tbl, var = "car") %>% head()
+#'
+#' # Adding rowid as a column --------------------------------------------
+#' rowid_to_column(iris) %>% head()
+#'
 #' @name rownames
 NULL
 

--- a/R/rownames.R
+++ b/R/rownames.R
@@ -1,12 +1,14 @@
 #' Tools for working with row names
 #'
+#' @description
 #' While a tibble can have row names (e.g., when converting from a regular data
 #' frame), they are removed when subsetting with the `[` operator.
 #' A warning will be raised when attempting to assign non-`NULL` row names
 #' to a tibble.
 #' Generally, it is best to avoid row names, because they are basically a
-#' character column with different semantics to every other column. These
-#' functions allow to you detect if a data frame has row names
+#' character column with different semantics than every other column.
+#'
+#' These functions allow to you detect if a data frame has row names
 #' (`has_rownames()`), remove them (`remove_rownames()`), or convert
 #' them back-and-forth between an explicit column (`rownames_to_column()`
 #' and `column_to_rownames()`).

--- a/man/rownames.Rd
+++ b/man/rownames.Rd
@@ -35,8 +35,9 @@ frame), they are removed when subsetting with the \code{[} operator.
 A warning will be raised when attempting to assign non-\code{NULL} row names
 to a tibble.
 Generally, it is best to avoid row names, because they are basically a
-character column with different semantics to every other column. These
-functions allow to you detect if a data frame has row names
+character column with different semantics than every other column.
+
+These functions allow to you detect if a data frame has row names
 (\code{has_rownames()}), remove them (\code{remove_rownames()}), or convert
 them back-and-forth between an explicit column (\code{rownames_to_column()}
 and \code{column_to_rownames()}).

--- a/man/rownames.Rd
+++ b/man/rownames.Rd
@@ -41,9 +41,9 @@ These functions allow to you detect if a data frame has row names
 (\code{has_rownames()}), remove them (\code{remove_rownames()}), or convert
 them back-and-forth between an explicit column (\code{rownames_to_column()}
 and \code{column_to_rownames()}).
-Also included is \code{rowid_to_column()} which
-adds a column at the start of the dataframe of ascending sequential row
-ids starting at 1. Note that this will remove any existing row names.
+Also included is \code{rowid_to_column()}, which adds a column at the start of the
+dataframe of ascending sequential row ids starting at 1. Note that this will
+remove any existing row names.
 }
 \examples{
 has_rownames(mtcars)

--- a/man/rownames.Rd
+++ b/man/rownames.Rd
@@ -46,13 +46,19 @@ dataframe of ascending sequential row ids starting at 1. Note that this will
 remove any existing row names.
 }
 \examples{
+# Detect row names ----------------------------------------------------
 has_rownames(mtcars)
 has_rownames(iris)
-has_rownames(remove_rownames(mtcars))
 
-head(rownames_to_column(mtcars))
+# Remove row names ----------------------------------------------------
+remove_rownames(mtcars) \%>\% has_rownames()
 
-mtcars_tbl <- as_tibble(rownames_to_column(mtcars))
+# Convert between row names and column --------------------------------
+mtcars_tbl <- rownames_to_column(mtcars, var = "car") \%>\% as_tibble()
 mtcars_tbl
-head(column_to_rownames(mtcars_tbl))
+column_to_rownames(mtcars_tbl, var = "car") \%>\% head()
+
+# Adding rowid as a column --------------------------------------------
+rowid_to_column(iris) \%>\% head()
+
 }


### PR DESCRIPTION
- Broke up descriptions into two more easily digestible paragraphs.
- Added example of `var` argument
- Added example of `rowid_to_column()`
- Refactored examples with pipes to bring rownames functions to the front. This will hopefully make examples easier to digest. 

Closes #705 