### PR TITLE
Add `validate_name_repair()` for arg-matching `.name_repair` early

### DIFF
--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -69,6 +69,7 @@ as_tibble.data.frame <- function(x, validate = NULL, ...,
                                  rownames = pkgconfig::get_config("tibble::rownames", NULL)) {
 
   .name_repair <- compat_name_repair(.name_repair, validate)
+  .name_repair <- validate_name_repair(.name_repair)
 
   old_rownames <- raw_rownames(x)
   if (is.null(.rows)) {
@@ -97,6 +98,7 @@ as_tibble.list <- function(x, validate = NULL, ..., .rows = NULL,
                            .name_repair = c("check_unique", "unique", "universal", "minimal")) {
 
   .name_repair <- compat_name_repair(.name_repair, validate)
+  .name_repair <- validate_name_repair(.name_repair)
 
   lst_to_tibble(x, .rows, .name_repair, col_lengths(x))
 }

--- a/R/repair-names.R
+++ b/R/repair-names.R
@@ -1,17 +1,29 @@
 set_repaired_names <- function(x,
-                               .name_repair = c("check_unique", "unique", "universal", "minimal"),
+                               .name_repair,
                                quiet = FALSE) {
   set_names(x, repaired_names(names2(x), .name_repair = .name_repair, quiet = quiet))
 }
 
 repaired_names <- function(name,
-                           .name_repair = c("check_unique", "unique", "universal", "minimal"),
+                           .name_repair,
                            quiet = FALSE) {
-
   subclass_name_repair_errors(name = name,
     vec_as_names(name, repair = .name_repair, quiet = quiet)
   )
 
+}
+
+# vctrs:::validate_repair()
+validate_name_repair <- function(.name_repair) {
+  if (is_formula(.name_repair, scoped = TRUE, lhs = FALSE)) {
+    .name_repair <- as_function(.name_repair)
+  }
+
+  if (is_function(.name_repair)) {
+    .name_repair
+  } else {
+    arg_match(.name_repair, c("check_unique", "unique", "universal", "minimal"))
+  }
 }
 
 check_names_non_null <- function(name, abort = rlang::abort) {

--- a/R/tibble.R
+++ b/R/tibble.R
@@ -140,6 +140,8 @@ tibble <- function(...,
 
   is_null <- map_lgl(xs, quo_is_null)
 
+  .name_repair <- validate_name_repair(.name_repair)
+
   tibble_quos(xs[!is_null], .rows, .name_repair)
 }
 
@@ -161,6 +163,8 @@ tibble_row <- function(...,
   xs <- quos(...)
 
   is_null <- map_lgl(xs, quo_is_null)
+
+  .name_repair <- validate_name_repair(.name_repair)
 
   tibble_quos(xs[!is_null], .rows = 1, .name_repair = .name_repair, single_row = TRUE)
 }


### PR DESCRIPTION
Closes r-lib/vctrs#790
Closes r-lib/rlang#917

See also, changes made in: https://github.com/r-lib/rlang/pull/914

The general idea with this PR is that we need to `arg_match()` the `.name_repair` argument in tibble, not in vctrs, because the ordering of the arguments is different in tibble than it is in vctrs.

`validate_name_repair()` is very similar to `vctrs:::validate_repair()`, but arg-matches with tibble's ordering of the `.name_repair` options. It "knows" that `.name_repair` can also be a formula or function.

I've been careful to only validate _after_ running `compat_name_repair()` first.

Travis errors seem to be because in dev vctrs we've slightly tweaked an error message that tibble uses `verify_output()` on, and that dev version is getting installed on the builds.