### PR TITLE
faster internal version of update_tibble_attrs()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,7 +64,9 @@ VignetteBuilder:
 RdMacros: 
     lifecycle
 Remotes: 
-    r-lib/pillar
+    r-lib/pillar, 
+    r-lib/vctrs,		
+    r-lib/rlang
 Encoding: UTF-8
 LazyData: yes
 Roxygen: list(markdown = TRUE)

--- a/R/new.R
+++ b/R/new.R
@@ -114,7 +114,7 @@ validate_nrow <- function(names, lengths, nrow) {
 }
 
 update_tibble_attrs <- function(x, ...) {
-  structure(x, ...)
+  .Call(`tibble_update_attrs`, x, pairlist2(...))
 }
 
 tibble_class <- c("tbl_df", "tbl", "data.frame")

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -589,20 +589,6 @@ vectbl_recycle_rows <- function(x, n, j, name) {
   abort(error_inconsistent_cols(n, name, size, "Existing data"))
 }
 
-attrs_names_only <- c("names", "row.names")
-
 vectbl_restore <- function(xo, x) {
-  n <- fast_nrow(xo)
-
-  # FIXME: Use new_tibble()?
-  forbidden <- attrs_names_only
-  attrs <- attributes(x)
-  attrs <- attrs[!(names(attrs) %in% forbidden)]
-
-  attributes(xo)[names(attrs)] <- attrs
-
-  # Need to patch manually
-  attr(xo, "row.names") <- .set_row_names(n)
-
-  xo
+  .Call(`tibble_restore_impl`, xo, x)
 }

--- a/src/attributes.c
+++ b/src/attributes.c
@@ -17,7 +17,7 @@ SEXP tibble_update_attrs(SEXP x, SEXP dots) {
 SEXP tibble_restore_impl(SEXP xo, SEXP x) {
   xo = PROTECT(Rf_shallow_duplicate(xo));
 
-  // copy over all alltributes except `names` and `row.names`
+  // copy over all attributes except `names` and `row.names`
   SEXP attr_x = ATTRIB(x);
   while(attr_x != R_NilValue) {
     SEXP tag = TAG(attr_x);

--- a/src/attributes.c
+++ b/src/attributes.c
@@ -13,3 +13,31 @@ SEXP tibble_update_attrs(SEXP x, SEXP dots) {
   UNPROTECT(1);
   return x;
 }
+
+SEXP tibble_restore_impl(SEXP xo, SEXP x) {
+  xo = PROTECT(Rf_shallow_duplicate(xo));
+
+  // copy over all alltributes except `names` and `row.names`
+  SEXP attr_x = ATTRIB(x);
+  while(attr_x != R_NilValue) {
+    SEXP tag = TAG(attr_x);
+    if (tag != R_NamesSymbol && tag != R_RowNamesSymbol) {
+      Rf_setAttrib(xo, tag, CAR(attr_x));
+    }
+    attr_x = CDR(attr_x);
+  }
+
+  // set row.names if needed
+  SEXP rn = Rf_getAttrib(xo, R_RowNamesSymbol);
+  if(!(Rf_isInteger(rn) && LENGTH(rn) == 2 && INTEGER(rn)[0] == NA_INTEGER) && rn != R_NilValue) {
+    int n = LENGTH(rn);
+    rn = PROTECT(Rf_allocVector(INTSXP, 2));
+    INTEGER(rn)[0] = NA_INTEGER;
+    INTEGER(rn)[1] = -n;
+    Rf_setAttrib(xo, R_RowNamesSymbol, rn);
+    UNPROTECT(1);
+  }
+
+  UNPROTECT(1);
+  return xo;
+}

--- a/src/attributes.c
+++ b/src/attributes.c
@@ -1,6 +1,8 @@
 #include "tibble.h"
 
 SEXP tibble_update_attrs(SEXP x, SEXP dots) {
+  x = PROTECT(Rf_shallow_duplicate(x));
+
   while(!Rf_isNull(dots)) {
     SEXP tag = TAG(dots);
     if (!Rf_isNull(tag)) {
@@ -8,5 +10,6 @@ SEXP tibble_update_attrs(SEXP x, SEXP dots) {
     }
     dots = CDR(dots);
   }
+  UNPROTECT(1);
   return x;
 }

--- a/src/attributes.c
+++ b/src/attributes.c
@@ -1,0 +1,12 @@
+#include "tibble.h"
+
+SEXP tibble_update_attrs(SEXP x, SEXP dots) {
+  while(!Rf_isNull(dots)) {
+    SEXP tag = TAG(dots);
+    if (!Rf_isNull(tag)) {
+      Rf_setAttrib(x, tag, CAR(dots));
+    }
+    dots = CDR(dots);
+  }
+  return x;
+}

--- a/src/attributes.c
+++ b/src/attributes.c
@@ -3,9 +3,9 @@
 SEXP tibble_update_attrs(SEXP x, SEXP dots) {
   x = PROTECT(Rf_shallow_duplicate(x));
 
-  while(!Rf_isNull(dots)) {
+  while(dots != R_NilValue) {
     SEXP tag = TAG(dots);
-    if (!Rf_isNull(tag)) {
+    if (tag != R_NilValue) {
       Rf_setAttrib(x, tag, CAR(dots));
     }
     dots = CDR(dots);

--- a/src/attributes.c
+++ b/src/attributes.c
@@ -27,17 +27,6 @@ SEXP tibble_restore_impl(SEXP xo, SEXP x) {
     attr_x = CDR(attr_x);
   }
 
-  // set row.names if needed
-  SEXP rn = Rf_getAttrib(xo, R_RowNamesSymbol);
-  if(!(Rf_isInteger(rn) && LENGTH(rn) == 2 && INTEGER(rn)[0] == NA_INTEGER) && rn != R_NilValue) {
-    int n = LENGTH(rn);
-    rn = PROTECT(Rf_allocVector(INTSXP, 2));
-    INTEGER(rn)[0] = NA_INTEGER;
-    INTEGER(rn)[1] = -n;
-    Rf_setAttrib(xo, R_RowNamesSymbol, rn);
-    UNPROTECT(1);
-  }
-
   UNPROTECT(1);
   return xo;
 }

--- a/src/init.c
+++ b/src/init.c
@@ -8,6 +8,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"tibble_matrixToDataFrame", (DL_FUNC) &tibble_matrixToDataFrame, 1},
   {"tibble_string_to_indices", (DL_FUNC) &tibble_string_to_indices, 1},
   {"tibble_update_attrs", (DL_FUNC) &tibble_update_attrs, 2},
+  {"tibble_restore_impl", (DL_FUNC) &tibble_restore_impl, 2},
+
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -7,6 +7,7 @@
 static const R_CallMethodDef CallEntries[] = {
   {"tibble_matrixToDataFrame", (DL_FUNC) &tibble_matrixToDataFrame, 1},
   {"tibble_string_to_indices", (DL_FUNC) &tibble_string_to_indices, 1},
+  {"tibble_update_attrs", (DL_FUNC) &tibble_update_attrs, 2},
   {NULL, NULL, 0}
 };
 

--- a/src/tibble.h
+++ b/src/tibble.h
@@ -6,5 +6,6 @@
 
 SEXP tibble_matrixToDataFrame(SEXP xSEXP);
 SEXP tibble_string_to_indices(SEXP x);
+SEXP tibble_update_attrs(SEXP x, SEXP dots);
 
 #endif /* TIBBLE_H */

--- a/src/tibble.h
+++ b/src/tibble.h
@@ -7,5 +7,6 @@
 SEXP tibble_matrixToDataFrame(SEXP xSEXP);
 SEXP tibble_string_to_indices(SEXP x);
 SEXP tibble_update_attrs(SEXP x, SEXP dots);
+SEXP tibble_restore_impl(SEXP xo, SEXP x);
 
 #endif /* TIBBLE_H */

--- a/tests/testthat/error/test-subsetting.txt
+++ b/tests/testthat/error/test-subsetting.txt
@@ -118,19 +118,19 @@ i It must be logical, numeric, or character.
 
 > foo <- tibble(x = 1:10, y = 1:10)
 > foo[[NA]]
-Error: Must extract column with a single subscript.
+Error: Must extract column with a single valid subscript.
 x The subscript `NA` can't be `NA`.
 
 > foo[[NA_integer_]]
-Error: Must extract column with a single subscript.
+Error: Must extract column with a single valid subscript.
 x The subscript `NA_integer_` can't be `NA`.
 
 > foo[[NA_real_]]
-Error: Must extract column with a single subscript.
+Error: Must extract column with a single valid subscript.
 x The subscript `NA_real_` can't be `NA`.
 
 > foo[[NA_character_]]
-Error: Must extract column with a single subscript.
+Error: Must extract column with a single valid subscript.
 x The subscript `NA_character_` can't be `NA`.
 
 


### PR DESCRIPTION
This has come up as part of performance benchmarks for dplyr 1.0.0: 

``` r
library(tibble)
library(rlang)

update_tibble_attrs_old <- function(x, ...) {
  # Compat for https://github.com/r-spatial/sf/pull/1232
  attribs <- list(...)
  if (has_length(attribs) && is_named(attribs)) {
    attributes(x)[names(attribs)] <- attribs
  }
  
  x
}
update_tibble_attrs <- tibble:::update_tibble_attrs


df <- tibble(x = rnorm(1e6), g = sample(rep(1:1e4, 100)))
groups <- tibble(g = unique(df$g))

bench::mark(
  new = update_tibble_attrs(df, groups = groups), 
  old = update_tibble_attrs_old(df, groups = groups) 
)
#> # A tibble: 2 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new          2.09µs   2.72µs   344885.        0B      0  
#> 2 old          3.98ms   4.96ms      201.    3.81MB     18.7
```

<sup>Created on 2020-02-13 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>

I believe this is because the form `attributes(x)[names(attribs)] <- ` pays for setting *all* the attributes, including `row.names` which is expensive to get/set. 

closes tidyverse/dplyr#4855