### PR TITLE
Don't install a `.data` pronoun in the sequential mask

### DIFF
--- a/R/tibble.R
+++ b/R/tibble.R
@@ -23,11 +23,9 @@
 #'   processed with [rlang::quos()] and support unquote via [`!!`] and
 #'   unquote-splice via [`!!!`]. Use `:=` to create columns that start with a dot.
 #'
-#'   Arguments are evaluated sequentially.
-#'   You can refer to previously created elements directly or using the [.data]
-#'   pronoun.
-#'   An existing `.data` pronoun, provided e.g. inside [dplyr::mutate()],
-#'   is not available.
+#'   Arguments are evaluated sequentially, however the [.data] pronoun is not
+#'   available to prevent masking usage in a higher level function, like
+#'   [dplyr::mutate()].
 #' @param .rows The number of rows, useful to create a 0-column tibble or
 #'   just as an additional check.
 #' @param .name_repair Treatment of problematic column names:
@@ -208,7 +206,7 @@ tibble_quos <- function(xs, .rows, .name_repair, single_row = FALSE) {
   output <- rep_along(xs, list(NULL))
 
   env <- new_environment()
-  mask <- new_data_mask_with_data(env)
+  mask <- new_data_mask(env)
 
   first_size <- .rows
 
@@ -257,12 +255,6 @@ tibble_quos <- function(xs, .rows, .name_repair, single_row = FALSE) {
   output <- set_repaired_names(output, .name_repair = .name_repair)
 
   new_tibble(output, nrow = first_size %||% 0L)
-}
-
-new_data_mask_with_data <- function(env) {
-  mask <- new_data_mask(env)
-  mask$.data <- as_data_pronoun(env)
-  mask
 }
 
 add_to_env2 <- function(x, given_name, name = given_name, env) {

--- a/man/lst.Rd
+++ b/man/lst.Rd
@@ -11,11 +11,9 @@ lst(...)
 processed with \code{\link[rlang:quos]{rlang::quos()}} and support unquote via \code{\link{!!}} and
 unquote-splice via \code{\link{!!!}}. Use \verb{:=} to create columns that start with a dot.
 
-Arguments are evaluated sequentially.
-You can refer to previously created elements directly or using the \link{.data}
-pronoun.
-An existing \code{.data} pronoun, provided e.g. inside \code{\link[dplyr:mutate]{dplyr::mutate()}},
-is not available.}
+Arguments are evaluated sequentially, however the \link{.data} pronoun is not
+available to prevent masking usage in a higher level function, like
+\code{\link[dplyr:mutate]{dplyr::mutate()}}.}
 }
 \value{
 A named list.

--- a/man/tibble.Rd
+++ b/man/tibble.Rd
@@ -21,11 +21,9 @@ tibble_row(
 processed with \code{\link[rlang:quos]{rlang::quos()}} and support unquote via \code{\link{!!}} and
 unquote-splice via \code{\link{!!!}}. Use \verb{:=} to create columns that start with a dot.
 
-Arguments are evaluated sequentially.
-You can refer to previously created elements directly or using the \link{.data}
-pronoun.
-An existing \code{.data} pronoun, provided e.g. inside \code{\link[dplyr:mutate]{dplyr::mutate()}},
-is not available.}
+Arguments are evaluated sequentially, however the \link{.data} pronoun is not
+available to prevent masking usage in a higher level function, like
+\code{\link[dplyr:mutate]{dplyr::mutate()}}.}
 
 \item{.rows}{The number of rows, useful to create a 0-column tibble or
 just as an additional check.}

--- a/tests/testthat/test-tibble.R
+++ b/tests/testthat/test-tibble.R
@@ -99,8 +99,26 @@ test_that("attributes are preserved", {
   expect_identical(attr(res, "meta"), attr(df, "meta"))
 })
 
-test_that(".data pronoun", {
-  expect_identical(tibble(a = 1, b = .data$a), tibble(a = 1, b = 1))
+test_that(".data pronoun is not installed by tibble", {
+  local_bindings(.data = list(a = 2))
+
+  expect_identical(
+    tibble(a = 1, b = .data$a),
+    tibble(a = 1, b = 2)
+  )
+})
+
+test_that(".data pronoun can come from another data mask (#721)", {
+  env <- as_environment(list(y = 1))
+  mask <- new_data_mask(env)
+  mask$.data <- as_data_pronoun(env)
+
+  expr <- expr(tibble(x = .data$y))
+
+  expect_identical(
+    eval_tidy(expr, data = mask),
+    tibble(x = 1)
+  )
 })
 
 test_that("tibble aliases", {


### PR DESCRIPTION
Closes #721 

This follows @lionel-'s advice of not installing a `.data` pronoun in the mask. It should fix a few rev deps in dplyr where this was an issue.

Test failures seem unrelated to this