### PR TITLE
If `.name_repair` is a function, no repair messages are shown

### DIFF
--- a/R/names.R
+++ b/R/names.R
@@ -10,7 +10,7 @@ repaired_names <- function(name,
                            details = NULL) {
 
   subclass_name_repair_errors(name = name, details = details,
-    vec_as_names(name, repair = .name_repair, quiet = quiet)
+    vec_as_names(name, repair = .name_repair, quiet = quiet || !is_character(.name_repair))
   )
 }
 

--- a/tests/testthat/test-as_tibble.R
+++ b/tests/testthat/test-as_tibble.R
@@ -176,9 +176,11 @@ test_that("as_tibble() implements universal names", {
 
 
 test_that("as_tibble() implements custom name repair", {
-  invalid_df <- as_tibble(
-    list(3, 4, 5),
-    .name_repair = function(x) make.names(x, unique = TRUE)
+  expect_silent(
+    invalid_df <- as_tibble(
+      list(3, 4, 5),
+      .name_repair = function(x) make.names(x, unique = TRUE)
+    )
   )
   expect_equal(length(invalid_df), 3)
   expect_equal(nrow(invalid_df), 1)


### PR DESCRIPTION
Otherwise there's no way to silence them.