### PR TITLE
Special case empty dots rather than overwriting `"row.names"`

### DIFF
--- a/R/add.R
+++ b/R/add.R
@@ -48,8 +48,12 @@ add_row <- function(.data, ..., .before = NULL, .after = NULL) {
     deprecate_warn("2.1.1", "add_row(.data = 'must be a data frame')")
   }
 
-  df <- tibble(...)
-  attr(df, "row.names") <- .set_row_names(max(1L, nrow(df)))
+  if (dots_n(...) == 0L) {
+    # A single row of missing values is added if no input is supplied
+    df <- new_tibble(list(), nrow = 1L)
+  } else {
+    df <- tibble(...)
+  }
 
   extra_vars <- setdiff(names(df), names(.data))
   if (has_length(extra_vars)) {

--- a/tests/testthat/test-add.R
+++ b/tests/testthat/test-add.R
@@ -36,7 +36,9 @@ test_that("add_row() keeps class of object when adding in the beginning", {
 })
 
 test_that("adds empty row if no arguments", {
-  new_iris_row <- add_row(iris)[nrow(iris) + 1, , drop = TRUE]
+  iris1 <- add_row(iris)
+  expect_equal(nrow(iris1), nrow(iris) + 1)
+  new_iris_row <- iris1[nrow(iris1), , drop = TRUE]
   expect_true(all(is.na(new_iris_row)))
 })
 

--- a/tests/testthat/test-add.R
+++ b/tests/testthat/test-add.R
@@ -137,6 +137,16 @@ test_that("add_row() fails nicely for grouped data frames (#179)", {
   )
 })
 
+test_that("add_row() works when adding zero row input (#809)", {
+  x <- tibble(x = 1, y = 2)
+  y <- tibble(y = double())
+
+  expect_identical(add_row(x, x = double()), x)
+  expect_identical(add_row(x, y), x)
+  expect_identical(add_row(x, NULL), x)
+  expect_identical(add_row(x, ), x)
+})
+
 # add_column ------------------------------------------------------------
 
 test_that("can add new column", {


### PR DESCRIPTION
Closes #809 

Rather than overwriting the `"row.names"` attribute, this now checks if the user supplied any input explicitly with `dots_n(...)` to decide if a single missing row should be added, or if `tibble(...)` should be used instead to control the added rows.

The behavior of `add_row(df, NULL)` and `add_row(df, )` are slightly different now (they don't add rows), but I think this is overall a little more consistent? If `add_row(df, x = double())` doesn't add any rows, then I think `add_row(df, NULL)` shouldn't either.

I haven't added a NEWS bullet yet in case someone doesn't agree with this behavior change.

Before:

``` r
library(tibble)

df <- tibble(x = 1, y = 2)

add_row(df, x = double())
#> Error: Internal error in `vec_assign()`: `value` should have been recycled to fit `x`.

add_row(df, tibble(x = double()))
#> Error: Internal error in `vec_assign()`: `value` should have been recycled to fit `x`.

add_row(df, NULL)
#> # A tibble: 2 x 2
#>       x     y
#>   <dbl> <dbl>
#> 1     1     2
#> 2    NA    NA

add_row(df)
#> # A tibble: 2 x 2
#>       x     y
#>   <dbl> <dbl>
#> 1     1     2
#> 2    NA    NA

add_row(df, )
#> # A tibble: 2 x 2
#>       x     y
#>   <dbl> <dbl>
#> 1     1     2
#> 2    NA    NA
```

<sup>Created on 2020-09-01 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

After:

``` r
library(tibble)

df <- tibble(x = 1, y = 2)

add_row(df, x = double())
#> # A tibble: 1 x 2
#>       x     y
#>   <dbl> <dbl>
#> 1     1     2

add_row(df, tibble(x = double()))
#> # A tibble: 1 x 2
#>       x     y
#>   <dbl> <dbl>
#> 1     1     2

# No longer adds 1 row.
# Passed on to become `tibble(NULL)`, which is a 0-row tibble
add_row(df, NULL)
#> # A tibble: 1 x 2
#>       x     y
#>   <dbl> <dbl>
#> 1     1     2

# Still adds 1 new row if user supplies no input
add_row(df)
#> # A tibble: 2 x 2
#>       x     y
#>   <dbl> <dbl>
#> 1     1     2
#> 2    NA    NA

# Because of how `dots_n()` works, looks like user supplied input
add_row(df, )
#> # A tibble: 1 x 2
#>       x     y
#>   <dbl> <dbl>
#> 1     1     2
```

<sup>Created on 2020-09-01 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>