### PR TITLE
New expect_error_verbose()

### DIFF
--- a/tests/testthat/_snaps/enframe.md
+++ b/tests/testthat/_snaps/enframe.md
@@ -1,11 +1,19 @@
 # output test
 
     Code
-      enframe(1:3, value = NULL)
-    Error <tibble_error_enframe_value_null>
+      expect_error_verbose(enframe(1:3, value = NULL))
+    Output
+      <error/tibble_error_enframe_value_null>
       `value` can't be NULL.
+      Backtrace:
+        1. expect_error_verbose(enframe(1:3, value = NULL))
+       14. tibble::enframe(1:3, value = NULL)
     Code
-      enframe(Titanic)
-    Error <tibble_error_enframe_has_dim>
+      expect_error_verbose(enframe(Titanic))
+    Output
+      <error/tibble_error_enframe_has_dim>
       `x` must not have more than one dimension. `length(dim(x))` must be zero or one, not 4.
+      Backtrace:
+        1. expect_error_verbose(enframe(Titanic))
+       14. tibble::enframe(Titanic)
 

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -24,3 +24,28 @@ expect_error_cnd <- function(object, class, message = NULL, ..., .fixed = TRUE) 
     expect_equal(cnd[names(exp_fields)], exp_fields)
   }
 }
+
+expect_snapshot_with_error <- function(code) {
+  code <- rlang::enexpr(code)
+
+  if (packageVersion("testthat") > "3.0.0") {
+    rlang::eval_tidy(rlang::quo(expect_snapshot(!!code, error = TRUE)))
+  } else {
+    rlang::eval_tidy(rlang::quo(expect_snapshot(!!code)))
+  }
+}
+
+expect_error_verbose <- function(object, ...) {
+  rlang::eval_tidy(rlang::quo(
+    expect_error(
+      tryCatch(
+        {{ object }},
+        error = function(e) {
+          print(e)
+          stop(e)
+        }
+      ),
+      ...
+    )
+  ))
+}

--- a/tests/testthat/test-enframe.R
+++ b/tests/testthat/test-enframe.R
@@ -103,7 +103,7 @@ test_that("can deframe three-column data frame with warning", {
 })
 
 test_that("output test", expect_snapshot({
-  enframe(1:3, value = NULL)
+  expect_error_verbose(enframe(1:3, value = NULL))
 
-  enframe(Titanic)
+  expect_error_verbose(enframe(Titanic))
 }))


### PR DESCRIPTION
to clearly declare which parts of the code in a snapshot test raise errors.