### PR TITLE
Fix condition expectations in prevision of testthat breaking change

### DIFF
--- a/tests/testthat/test-as_tibble.R
+++ b/tests/testthat/test-as_tibble.R
@@ -204,12 +204,14 @@ test_that("as_tibble() implements custom name repair", {
 })
 
 test_that("as_tibble.matrix() supports validate (with warning) (#558)", {
-  expect_identical(
-    expect_warning(as_tibble(diag(3), validate = TRUE)),
-    tibble(
-      V1 = c(1, 0, 0),
-      V2 = c(0, 1, 0),
-      V3 = c(0, 0, 1)
+  expect_warning(
+    expect_identical(
+      as_tibble(diag(3), validate = TRUE),
+      tibble(
+        V1 = c(1, 0, 0),
+        V2 = c(0, 1, 0),
+        V3 = c(0, 0, 1)
+      )
     )
   )
 })


### PR DESCRIPTION
We are planning a breaking change to the condition expectations in testthat release (see NEWS item in https://github.com/r-lib/testthat/pull/1401). This PR implements a preventive fix that works with and without the breaking change.

There is no hurry to get this fix on CRAN since we are skipping one released version of testthat before going through with the change.
