### PR TITLE
Speed up `new_tibble()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Bump required versions of ellipsis and vctrs to avoid warning during package load.
 
+- `new_tibble()` is now faster (#901, @mgirlich).
+
 
 # tibble 3.1.2
 

--- a/R/new.R
+++ b/R/new.R
@@ -76,7 +76,9 @@ new_tibble <- function(x, ..., nrow, class = NULL, subclass = NULL) {
     cnd_signal(error_names_must_be_non_null())
   }
 
-  set_tibble_subclass(x, nrow, class)
+  attr(x, "row.names") <- .set_row_names(nrow)
+  class(x) <- c(class[!class %in% tibble_class], tibble_class)
+  x
 }
 
 #' @description
@@ -134,13 +136,6 @@ update_tibble_attrs <- function(x, ...) {
 }
 
 tibble_class <- c("tbl_df", "tbl", "data.frame")
-
-# Two dedicated functions for faster creation
-set_tibble_subclass <- function(x, nrow, subclass) {
-  attr(x, "row.names") <- .set_row_names(nrow)
-  class(x) <- c(class[!class %in% tibble_class], tibble_class)
-  x
-}
 
 # Errors ------------------------------------------------------------------
 

--- a/R/new.R
+++ b/R/new.R
@@ -138,7 +138,7 @@ tibble_class <- c("tbl_df", "tbl", "data.frame")
 # Two dedicated functions for faster creation
 set_tibble_subclass <- function(x, nrow, subclass) {
   attr(x, "row.names") <- .set_row_names(nrow)
-  class(x) <- c(setdiff(subclass, tibble_class), tibble_class)
+  class(x) <- c(class[!class %in% tibble_class], tibble_class)
   x
 }
 


### PR DESCRIPTION
Relates to #726.

Some minor code changes give a nice speed up for `new_tibble()`

``` r
library(tibble)

# empty
y <- list()
y_nrow <- 0L

bench::mark(
  tbl = new_tibble(y, nrow = y_nrow),
  iterations = 100000
)
# master
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tbl          8.66µs   10.5µs    88253.    35.4KB     19.4

# replace `setdiff()`
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tbl          5.92µs    7.7µs   115497.      36KB     17.3

# this PR
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tbl          5.29µs   6.56µs   133027.    32.3KB     18.6

x <- unclass(mtcars)
nrow <- 32L

bench::mark(
  tbl = new_tibble(x, nrow = nrow),
  iterations = 100000
)
# master
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tbl           8.1µs   9.95µs    93560.        0B     22.5

# replace `setdiff()`
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tbl          5.48µs   7.07µs   128840.        0B     20.6

# this PR
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tbl             5µs   6.01µs   143254.        0B     20.1


bench::mark(
  tbl = new_tibble(x, nrow = nrow, foo = "bar", foo2 = 1, foo3 = "x"),
  iterations = 100000
)
# master
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tbl          10.3µs   12.1µs    77771.        0B     24.1

# replace `setdiff()`
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tbl          7.21µs   9.05µs   103539.        0B     23.8

# this PR
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tbl           6.3µs   8.06µs   112465.        0B     22.5
```

<sup>Created on 2021-07-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>