### PR TITLE
Link to `base::matrix()` in `as_tibble()` docs

### DIFF
--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -10,7 +10,7 @@
 #' `as_tibble()` is an S3 generic, with methods for:
 #' * [`data.frame`][base::data.frame()]: Thin wrapper around the `list` method
 #'   that implements tibble's treatment of [rownames].
-#' * [`matrix`][methods::matrix-class], [`poly`][stats::poly()],
+#' * [`matrix`][base::matrix()], [`poly`][stats::poly()],
 #'   [`ts`][stats::ts()], [`table`][base::table()]
 #' * Default: Other inputs are first coerced with [base::as.data.frame()].
 #'

--- a/man/as_tibble.Rd
+++ b/man/as_tibble.Rd
@@ -105,7 +105,7 @@ in contrast with \code{\link[=tibble]{tibble()}}, which builds a tibble from ind
 \itemize{
 \item \code{\link[base:data.frame]{data.frame}}: Thin wrapper around the \code{list} method
 that implements tibble's treatment of \link{rownames}.
-\item \code{\link[methods:StructureClasses]{matrix}}, \code{\link[stats:poly]{poly}},
+\item \code{\link[base:matrix]{matrix}}, \code{\link[stats:poly]{poly}},
 \code{\link[stats:ts]{ts}}, \code{\link[base:table]{table}}
 \item Default: Other inputs are first coerced with \code{\link[base:as.data.frame]{base::as.data.frame()}}.
 }


### PR DESCRIPTION
In `as_tibble()`, we currently link to `methods::matrix-class`, which expands in the man file to linking to `methods:StructureClasses`.

If I document tidyr, which re-exports `as_tibble()`, I see:

```r
Warning: Link to unknown topic in inherited text: methods::StructureClasses
```

Is there any way we could just link to `base::matrix()` instead? It seems more useful anyways, since the current link is very S4 related