### PR TITLE
docs: Mention `median()` in Recovery section of `vignette("numbers")`

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -56,6 +56,10 @@ reference:
   - contains("matrix")
 
 articles:
+- title: Get started
+  contents:
+  - tibble
+
 - title: Basics
   navbar: ~
   contents:
@@ -69,6 +73,11 @@ articles:
   - extending
   - invariants
   - formats
+
+- title: WIP
+  contents:
+  - wip/subset
+  - wip/subassign
 
 news:
   releases:

--- a/tests/testthat/_snaps/vignette-numbers/numbers.md
+++ b/tests/testthat/_snaps/vignette-numbers/numbers.md
@@ -210,6 +210,15 @@ var(x)
 #> [1] 2.333333
 ```
 
+The `median()` function is worse, it breaks for `num()` objects:
+
+
+```r
+median(x)
+#> Error in `median()`:
+#> ! `median.pillar_num()` not implemented.
+```
+
 One way to recover is to apply `num()` to the result:
 
 
@@ -217,6 +226,9 @@ One way to recover is to apply `num()` to the result:
 num(var(x), notation = "eng")
 #> <pillar_num(eng)[1]>
 #> [1] 2.33e0
+num(median(as.numeric(x)), notation = "eng")
+#> <pillar_num(eng)[1]>
+#> [1] 2e0
 ```
 
 For automatic recovery, we can also define our version of `var()`, or even overwrite the base implementation.

--- a/vignettes/numbers.Rmd
+++ b/vignettes/numbers.Rmd
@@ -136,10 +136,17 @@ x <- num(c(1, 2, 4), notation = "eng")
 var(x)
 ```
 
+The `median()` function is worse, it breaks for `num()` objects:
+
+```{r numbers-16-a, error = TRUE}
+median(x)
+```
+
 One way to recover is to apply `num()` to the result:
 
 ```{r numbers-16a}
 num(var(x), notation = "eng")
+num(median(as.numeric(x)), notation = "eng")
 ```
 
 For automatic recovery, we can also define our version of `var()`, or even overwrite the base implementation.


### PR DESCRIPTION
Closes https://github.com/r-lib/pillar/issues/520.

CC @mgirlich.