### PR TITLE
tibble requires vctrs >= 0.4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
     pkgconfig,
     rlang (>= 1.0.2),
     utils,
-    vctrs (>= 0.3.8)
+    vctrs (>= 0.4.0)
 Suggests: 
     bench,
     bit64,


### PR DESCRIPTION
#1237 added the error `call` to `vctrs::vec_as_location()` but this argument only exists in vctrs version 0.4.0 or later (https://github.com/r-lib/vctrs/pull/1507).

When tibble 3.1.8 and vctrs 0.3.8 are used together, unusual errors arise in readr:

```r
read_csv("data.csv")
#> Error in `vec_as_location()`:
#> ! `...` must be empty.
#> ✖ Problematic argument:
#> • call = call
```