### PR TITLE
feat: Correct top-level calls are shown for the vast majority of errors

### DIFF
--- a/R/add.R
+++ b/R/add.R
@@ -41,7 +41,7 @@
 #' @export
 add_row <- function(.data, ..., .before = NULL, .after = NULL) {
   if (inherits(.data, "grouped_df")) {
-    cnd_signal(error_add_rows_to_grouped_df())
+    abort_add_rows_to_grouped_df()
   }
 
   if (!is.data.frame(.data)) {
@@ -57,7 +57,7 @@ add_row <- function(.data, ..., .before = NULL, .after = NULL) {
 
   extra_vars <- setdiff(names(df), names(.data))
   if (has_length(extra_vars)) {
-    cnd_signal(error_incompatible_new_rows(extra_vars))
+    abort_incompatible_new_rows(extra_vars)
   }
 
   pos <- pos_from_before_after(.before, .after, nrow(.data))
@@ -147,7 +147,7 @@ add_column <- function(.data, ..., .before = NULL, .after = NULL,
     if (nrow(df) == 1) {
       df <- df[rep(1L, nrow(.data)), ]
     } else {
-      cnd_signal(error_incompatible_new_cols(nrow(.data), df))
+      abort_incompatible_new_cols(nrow(.data), df)
     }
   }
 
@@ -189,7 +189,7 @@ pos_from_before_after <- function(before, after, len) {
     if (is.null(after)) {
       limit_pos_range(before - 1L, len)
     } else {
-      cnd_signal(error_both_before_after())
+      abort_both_before_after()
     }
   }
 }
@@ -211,7 +211,7 @@ check_names_before_after <- function(j, x) {
 
 check_needs_no_dim <- function(j) {
   if (needs_dim(j)) {
-    cnd_signal(error_dim_column_index(j))
+    abort_dim_column_index(j)
   }
 }
 
@@ -219,19 +219,19 @@ check_names_before_after_character <- function(j, names) {
   pos <- safe_match(j, names)
   if (anyNA(pos)) {
     unknown_names <- j[is.na(pos)]
-    cnd_signal(error_unknown_column_names(unknown_names))
+    abort_unknown_column_names(unknown_names)
   }
   pos
 }
 
 # Errors ------------------------------------------------------------------
 
-error_add_rows_to_grouped_df <- function() {
-  tibble_error("Can't add rows to grouped data frames.")
+abort_add_rows_to_grouped_df <- function() {
+  tibble_abort("Can't add rows to grouped data frames.")
 }
 
-error_incompatible_new_rows <- function(names) {
-  tibble_error(
+abort_incompatible_new_rows <- function(names) {
+  tibble_abort(
     problems(
       "New rows can't add columns:",
       cnd_message(error_unknown_column_names(names))
@@ -240,16 +240,16 @@ error_incompatible_new_rows <- function(names) {
   )
 }
 
-error_both_before_after <- function() {
-  tibble_error("Can't specify both `.before` and `.after`.")
+abort_both_before_after <- function() {
+  tibble_abort("Can't specify both `.before` and `.after`.")
 }
 
-error_unknown_column_names <- function(j, parent = NULL) {
-  tibble_error(pluralise_commas("Can't find column(s) ", tick(j), " in `.data`."), j = j, parent = parent)
+abort_unknown_column_names <- function(j, parent = NULL) {
+  tibble_abort(pluralise_commas("Can't find column(s) ", tick(j), " in `.data`."), j = j, parent = parent)
 }
 
-error_incompatible_new_cols <- function(n, df) {
-  tibble_error(
+abort_incompatible_new_cols <- function(n, df) {
+  tibble_abort(
     bullets(
       "New columns must be compatible with `.data`:",
       x = paste0(

--- a/R/add.R
+++ b/R/add.R
@@ -226,6 +226,10 @@ check_names_before_after_character <- function(j, names) {
 
 # Errors ------------------------------------------------------------------
 
+msg_unknown_column_names <- function(names) {
+  pluralise_commas("Can't find column(s) ", tick(names), " in `.data`.")
+}
+
 abort_add_rows_to_grouped_df <- function() {
   tibble_abort("Can't add rows to grouped data frames.")
 }
@@ -234,7 +238,7 @@ abort_incompatible_new_rows <- function(names) {
   tibble_abort(
     problems(
       "New rows can't add columns:",
-      cnd_message(error_unknown_column_names(names))
+      msg_unknown_column_names(names)
     ),
     names = names
   )

--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -131,7 +131,7 @@ check_valid_cols <- function(x, pos = NULL) {
   is_xd <- which(!map_lgl(x, is_valid_col))
   if (has_length(is_xd)) {
     classes <- map_chr(x[is_xd], friendly_type_of)
-    cnd_signal(error_column_scalar_type(names_x[is_xd], pos[is_xd], classes))
+    abort_column_scalar_type(names_x[is_xd], pos[is_xd], classes)
   }
 
   # 657
@@ -159,7 +159,7 @@ recycle_columns <- function(x, .rows, lengths) {
   if (is_empty(different_len)) return(new_tibble(x, nrow = nrow, subclass = NULL))
 
   if (any(lengths[different_len] != 1)) {
-    cnd_signal(error_incompatible_size(.rows, names(x), lengths, "Requested with `.rows` argument"))
+    abort_incompatible_size(.rows, names(x), lengths, "Requested with `.rows` argument")
   }
 
   if (nrow != 1L) {
@@ -288,7 +288,7 @@ as_tibble.default <- function(x, ...) {
 as_tibble_row <- function(x,
                           .name_repair = c("check_unique", "unique", "universal", "minimal")) {
   if (!vec_is(x)) {
-    cnd_signal(error_as_tibble_row_vector(x))
+    abort_as_tibble_row_vector(x)
   }
 
   names <- vectbl_names2(x, .name_repair = .name_repair)
@@ -312,7 +312,7 @@ check_all_lengths_one <- function(x) {
 
   bad_lengths <- which(sizes != 1)
   if (!is_empty(bad_lengths)) {
-    cnd_signal(error_as_tibble_row_size_one(
+    cnd_signal(abort_as_tibble_row_size_one(
       seq_along(x)[bad_lengths],
       names2(x)[bad_lengths],
       sizes[bad_lengths]
@@ -348,8 +348,8 @@ matrixToDataFrame <- function(x) {
 
 # Errors ------------------------------------------------------------------
 
-error_column_scalar_type <- function(names, positions, classes) {
-  tibble_error(
+abort_column_scalar_type <- function(names, positions, classes) {
+  tibble_abort(
     problems(
       "All columns in a tibble must be vectors:",
       x = paste0("Column ", name_or_pos(names, positions), " is ", classes)
@@ -358,17 +358,17 @@ error_column_scalar_type <- function(names, positions, classes) {
   )
 }
 
-error_as_tibble_row_vector <- function(x) {
-  tibble_error(paste0(
+abort_as_tibble_row_vector <- function(x) {
+  tibble_abort(paste0(
     "`x` must be a vector in `as_tibble_row()`, not ", class(x)[[1]], "."
   ))
 }
 
-error_as_tibble_row_size_one <- function(j, name, size) {
+abort_as_tibble_row_size_one <- function(j, name, size) {
   desc <- tick(name)
   desc[name == ""] <- paste0("at position ", j[name == ""])
 
-  tibble_error(problems(
+  tibble_abort(problems(
     "All elements must be size one, use `list()` to wrap.",
     paste0("Element ", desc, " is of size ", size, ".")
   ))

--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -312,11 +312,11 @@ check_all_lengths_one <- function(x) {
 
   bad_lengths <- which(sizes != 1)
   if (!is_empty(bad_lengths)) {
-    cnd_signal(abort_as_tibble_row_size_one(
+    abort_as_tibble_row_size_one(
       seq_along(x)[bad_lengths],
       names2(x)[bad_lengths],
       sizes[bad_lengths]
-    ))
+    )
   }
 }
 

--- a/R/enframe.R
+++ b/R/enframe.R
@@ -21,7 +21,7 @@
 #' enframe(list(one = 1, two = 2:3, three = 4:6))
 enframe <- function(x, name = "name", value = "value") {
   if (is.null(value)) {
-    cnd_signal(error_enframe_value_null())
+    abort_enframe_value_null()
   }
 
   if (is.null(x)) {
@@ -30,7 +30,7 @@ enframe <- function(x, name = "name", value = "value") {
 
   # FIXME: Enable again for data frames, add test
   if (!vec_is(x) || is.data.frame(x)) {
-    cnd_signal(error_enframe_must_be_vector(x))
+    abort_enframe_must_be_vector(x)
   }
 
   if (is.null(name)) {
@@ -77,12 +77,12 @@ deframe <- function(x) {
   vectbl_set_names(value, as.character(name))
 }
 
-error_enframe_value_null <- function() {
-  tibble_error("`value` can't be NULL.")
+abort_enframe_value_null <- function() {
+  tibble_abort("`value` can't be NULL.")
 }
 
-error_enframe_must_be_vector <- function(x) {
-  tibble_error(paste0(
+abort_enframe_must_be_vector <- function(x) {
+  tibble_abort(paste0(
     "The `x` argument to `enframe()` must be a vector, not ", class(x)[[1]], "."
   ))
 }

--- a/R/error.R
+++ b/R/error.R
@@ -18,12 +18,10 @@ tibble_error_class <- function(class) {
 }
 
 # Errors get a class name derived from the name of the calling function
-tibble_abort <- function(x, ..., parent = NULL) {
+tibble_abort <- function(x, ..., call = my_caller_call(), parent = NULL) {
   abort_call <- sys.call(-1)
   fn_name <- as_name(abort_call[[1]])
   class <- tibble_error_class(gsub("^abort_", "", fn_name))
-
-  call <- my_caller_call()
 
   abort(x, class, ..., call = call, parent = parent, use_cli_format = TRUE)
 }

--- a/R/error.R
+++ b/R/error.R
@@ -18,7 +18,7 @@ tibble_error_class <- function(class) {
 }
 
 # Errors get a class name derived from the name of the calling function
-tibble_abort <- function(x, ..., call = my_caller_call(), parent = NULL) {
+tibble_abort <- function(x, ..., call = my_caller_env(), parent = NULL) {
   abort_call <- sys.call(-1)
   fn_name <- as_name(abort_call[[1]])
   class <- tibble_error_class(gsub("^abort_", "", fn_name))

--- a/R/error.R
+++ b/R/error.R
@@ -25,7 +25,7 @@ tibble_abort <- function(x, ..., parent = NULL) {
 
   call <- my_caller_call()
 
-  abort(x, class, ..., call = call, parent = parent)
+  abort(x, class, ..., call = call, parent = parent, use_cli_format = TRUE)
 }
 
 tibble_error <- function(x, ..., parent = NULL) {

--- a/R/legacy-compat.R
+++ b/R/legacy-compat.R
@@ -5,7 +5,7 @@ tbl_subset_col <- function(x, j, j_arg) {
   j <- vectbl_as_col_location(j, length(x), names(x), j_arg = j_arg, assign = FALSE)
 
   if (anyNA(j)) {
-    cnd_signal(error_na_column_index(which(is.na(j))))
+    abort_na_column_index(which(is.na(j)))
   }
 
   xo <- .subset(x, j)

--- a/R/names.R
+++ b/R/names.R
@@ -25,15 +25,15 @@ repaired_names <- function(name,
 
 # Errors ------------------------------------------------------------------
 
-abort_column_names_cannot_be_empty <- function(names, repair_hint, details = NULL, parent = NULL, call = my_caller_call()) {
+abort_column_names_cannot_be_empty <- function(names, repair_hint, details = NULL, parent = NULL, call = my_caller_env()) {
   tibble_abort(invalid_df("must be named", names, use_repair(repair_hint)), names = names, parent = parent, call = call)
 }
 
-abort_column_names_cannot_be_dot_dot <- function(names, repair_hint, parent = NULL, call = my_caller_call()) {
+abort_column_names_cannot_be_dot_dot <- function(names, repair_hint, parent = NULL, call = my_caller_env()) {
   tibble_abort(invalid_df("must not have names of the form ... or ..j", names, use_repair(repair_hint)), names = names, parent = parent, call = call)
 }
 
-abort_column_names_must_be_unique <- function(names, repair_hint, parent = NULL, call = my_caller_call()) {
+abort_column_names_must_be_unique <- function(names, repair_hint, parent = NULL, call = my_caller_env()) {
   tibble_abort(invalid_df("must not be duplicated", names, use_repair(repair_hint), message = "Column name(s)"), names = names, parent = parent, call = call)
 }
 

--- a/R/names.R
+++ b/R/names.R
@@ -25,16 +25,16 @@ repaired_names <- function(name,
 
 # Errors ------------------------------------------------------------------
 
-error_column_names_cannot_be_empty <- function(names, repair_hint, parent = NULL) {
-  tibble_error(invalid_df("must be named", names, use_repair(repair_hint)), names = names, parent = parent)
+abort_column_names_cannot_be_empty <- function(names, repair_hint, parent = NULL) {
+  tibble_abort(invalid_df("must be named", names, use_repair(repair_hint)), names = names, parent = parent)
 }
 
-error_column_names_cannot_be_dot_dot <- function(names, repair_hint, parent = NULL) {
-  tibble_error(invalid_df("must not have names of the form ... or ..j", names, use_repair(repair_hint)), names = names, parent = parent)
+abort_column_names_cannot_be_dot_dot <- function(names, repair_hint, parent = NULL) {
+  tibble_abort(invalid_df("must not have names of the form ... or ..j", names, use_repair(repair_hint)), names = names, parent = parent)
 }
 
-error_column_names_must_be_unique <- function(names, repair_hint, parent = NULL) {
-  tibble_error(invalid_df("must not be duplicated", names, use_repair(repair_hint), message = "Column name(s)"), names = names, parent = parent)
+abort_column_names_must_be_unique <- function(names, repair_hint, parent = NULL) {
+  tibble_abort(invalid_df("must not be duplicated", names, use_repair(repair_hint), message = "Column name(s)"), names = names, parent = parent)
 }
 
 # Subclassing errors ------------------------------------------------------

--- a/R/names.R
+++ b/R/names.R
@@ -26,21 +26,20 @@ repaired_names <- function(name,
 # Errors ------------------------------------------------------------------
 
 abort_column_names_cannot_be_empty <- function(names, repair_hint, details = NULL, parent = NULL, call = my_caller_call()) {
-  tibble_abort(invalid_df("must be named", names, use_repair(repair_hint)), names = names, parent = parent)
+  tibble_abort(invalid_df("must be named", names, use_repair(repair_hint)), names = names, parent = parent, call = call)
 }
 
 abort_column_names_cannot_be_dot_dot <- function(names, repair_hint, parent = NULL, call = my_caller_call()) {
-  tibble_abort(invalid_df("must not have names of the form ... or ..j", names, use_repair(repair_hint)), names = names, parent = parent)
+  tibble_abort(invalid_df("must not have names of the form ... or ..j", names, use_repair(repair_hint)), names = names, parent = parent, call = call)
 }
 
 abort_column_names_must_be_unique <- function(names, repair_hint, parent = NULL, call = my_caller_call()) {
-  tibble_abort(invalid_df("must not be duplicated", names, use_repair(repair_hint), message = "Column name(s)"), call = call, names = names, parent = parent)
+  tibble_abort(invalid_df("must not be duplicated", names, use_repair(repair_hint), message = "Column name(s)"), names = names, parent = parent, call = call)
 }
 
 # Subclassing errors ------------------------------------------------------
 
 subclass_name_repair_errors <- function(expr, name, details = NULL, repair_hint = FALSE, call = my_caller_call()) {
-  force(call)
   withCallingHandlers(
     expr,
 

--- a/R/names.R
+++ b/R/names.R
@@ -25,6 +25,18 @@ repaired_names <- function(name,
 
 # Errors ------------------------------------------------------------------
 
+error_column_names_cannot_be_empty <- function(names, repair_hint, parent = NULL) {
+  tibble_error(invalid_df("must be named", names, use_repair(repair_hint)), names = names, parent = parent)
+}
+
+error_column_names_cannot_be_dot_dot <- function(names, repair_hint, parent = NULL) {
+  tibble_error(invalid_df("must not have names of the form ... or ..j", names, use_repair(repair_hint)), names = names, parent = parent)
+}
+
+error_column_names_must_be_unique <- function(names, repair_hint, parent = NULL) {
+  tibble_error(pluralise_commas("Column name(s) ", tick(names), " must not be duplicated.", use_repair(repair_hint)), names = names, parent = parent)
+}
+
 abort_column_names_cannot_be_empty <- function(names, repair_hint, parent = NULL) {
   tibble_abort(invalid_df("must be named", names, use_repair(repair_hint)), names = names, parent = parent)
 }

--- a/R/names.R
+++ b/R/names.R
@@ -25,50 +25,34 @@ repaired_names <- function(name,
 
 # Errors ------------------------------------------------------------------
 
-error_column_names_cannot_be_empty <- function(names, repair_hint, parent = NULL) {
-  tibble_error(invalid_df("must be named", names, use_repair(repair_hint)), names = names, parent = parent)
-}
-
-error_column_names_cannot_be_dot_dot <- function(names, repair_hint, parent = NULL) {
-  tibble_error(invalid_df("must not have names of the form ... or ..j", names, use_repair(repair_hint)), names = names, parent = parent)
-}
-
-error_column_names_must_be_unique <- function(names, repair_hint, parent = NULL) {
-  tibble_error(pluralise_commas("Column name(s) ", tick(names), " must not be duplicated.", use_repair(repair_hint)), names = names, parent = parent)
-}
-
-abort_column_names_cannot_be_empty <- function(names, repair_hint, parent = NULL) {
+abort_column_names_cannot_be_empty <- function(names, repair_hint, details = NULL, parent = NULL, call = my_caller_call()) {
   tibble_abort(invalid_df("must be named", names, use_repair(repair_hint)), names = names, parent = parent)
 }
 
-abort_column_names_cannot_be_dot_dot <- function(names, repair_hint, parent = NULL) {
+abort_column_names_cannot_be_dot_dot <- function(names, repair_hint, parent = NULL, call = my_caller_call()) {
   tibble_abort(invalid_df("must not have names of the form ... or ..j", names, use_repair(repair_hint)), names = names, parent = parent)
 }
 
-abort_column_names_must_be_unique <- function(names, repair_hint, parent = NULL) {
-  tibble_abort(invalid_df("must not be duplicated", names, use_repair(repair_hint), message = "Column name(s)"), names = names, parent = parent)
+abort_column_names_must_be_unique <- function(names, repair_hint, parent = NULL, call = my_caller_call()) {
+  tibble_abort(invalid_df("must not be duplicated", names, use_repair(repair_hint), message = "Column name(s)"), call = call, names = names, parent = parent)
 }
 
 # Subclassing errors ------------------------------------------------------
 
-subclass_name_repair_errors <- function(expr, name, details = NULL, repair_hint = FALSE) {
+subclass_name_repair_errors <- function(expr, name, details = NULL, repair_hint = FALSE, call = my_caller_call()) {
+  force(call)
   withCallingHandlers(
     expr,
 
     # FIXME: use cnd$names with vctrs >= 0.3.0
     vctrs_error_names_cannot_be_empty = function(cnd) {
-      cnd <- error_column_names_cannot_be_empty(detect_empty_names(name), parent = cnd, repair_hint = repair_hint)
-      cnd$body <- details
-
-      cnd_signal(cnd)
+      abort_column_names_cannot_be_empty(detect_empty_names(name), details = details, parent = cnd, repair_hint = repair_hint, call = call)
     },
     vctrs_error_names_cannot_be_dot_dot = function(cnd) {
-      cnd <- error_column_names_cannot_be_dot_dot(detect_dot_dot(name), parent = cnd, repair_hint = repair_hint)
-      cnd_signal(cnd)
+      abort_column_names_cannot_be_dot_dot(detect_dot_dot(name), parent = cnd, repair_hint = repair_hint, call = call)
     },
     vctrs_error_names_must_be_unique = function(cnd) {
-      cnd <- error_column_names_must_be_unique(detect_duplicates(name), parent = cnd, repair_hint = repair_hint)
-      cnd_signal(cnd)
+      abort_column_names_must_be_unique(detect_duplicates(name), parent = cnd, repair_hint = repair_hint, call = call)
     }
   )
 }

--- a/R/names.R
+++ b/R/names.R
@@ -39,7 +39,7 @@ abort_column_names_must_be_unique <- function(names, repair_hint, parent = NULL,
 
 # Subclassing errors ------------------------------------------------------
 
-subclass_name_repair_errors <- function(expr, name, details = NULL, repair_hint = FALSE, call = my_caller_call()) {
+subclass_name_repair_errors <- function(expr, name, details = NULL, repair_hint = FALSE, call = my_caller_env()) {
   withCallingHandlers(
     expr,
 

--- a/R/new.R
+++ b/R/new.R
@@ -126,19 +126,17 @@ validate_tibble <- function(x) {
   x
 }
 
-cnd_signal_if <- function(x) {
-  if (!is.null(x)) {
-    cnd_signal(x)
-  }
-}
-
-check_minimal <- function(name) {
-  cnd_signal_if(cnd_names_non_null(name))
-  cnd_signal_if(cnd_names_non_na(name))
-}
-
 check_minimal_names <- function(x) {
-  check_minimal(names(x))
+  names <- names(x)
+
+  if (is.null(names)) {
+    abort_names_must_be_non_null()
+  }
+
+  if (anyNA(names)) {
+    abort_column_names_cannot_be_empty(which(is.na(name)), repair_hint = FALSE)
+  }
+
   invisible(x)
 }
 

--- a/R/new.R
+++ b/R/new.R
@@ -134,7 +134,7 @@ check_minimal_names <- function(x) {
   }
 
   if (anyNA(names)) {
-    abort_column_names_cannot_be_empty(which(is.na(name)), repair_hint = FALSE)
+    abort_column_names_cannot_be_empty(which(is.na(names)), repair_hint = FALSE)
   }
 
   invisible(x)

--- a/R/new.R
+++ b/R/new.R
@@ -44,7 +44,7 @@ new_tibble <- function(x, ..., nrow = NULL, class = NULL, subclass = NULL) {
   x <- unclass(x)
 
   if (!is.list(x)) {
-    cnd_signal(error_new_tibble_must_be_list())
+    abort_new_tibble_must_be_list()
   }
 
   #' The `nrow` argument may be omitted as of tibble 3.1.4.
@@ -54,7 +54,7 @@ new_tibble <- function(x, ..., nrow = NULL, class = NULL, subclass = NULL) {
   #' This takes the place of the "row.names" attribute in a data frame.
   if (!is.null(nrow)) {
     if (!is.numeric(nrow) || length(nrow) != 1 || nrow < 0 || !is_integerish(nrow, 1) || nrow >= 2147483648) {
-      cnd_signal(error_new_tibble_nrow_must_be_nonnegative())
+      abort_new_tibble_nrow_must_be_nonnegative()
     }
     nrow <- as.integer(nrow)
   }
@@ -84,7 +84,7 @@ new_tibble <- function(x, ..., nrow = NULL, class = NULL, subclass = NULL) {
     # Leaving this because creating a named list of length zero seems difficult
     args[["names"]] <- character()
   } else if (is.null(args[["names"]])) {
-    cnd_signal(error_names_must_be_non_null())
+    abort_names_must_be_non_null()
   }
 
   if (is.null(class)) {
@@ -148,7 +148,7 @@ validate_nrow <- function(names, lengths, nrow) {
   # Validate column lengths, don't recycle
   bad_len <- which(lengths != nrow)
   if (has_length(bad_len)) {
-    cnd_signal(error_incompatible_size(nrow, names, lengths, "Requested with `nrow` argument"))
+    abort_incompatible_size(nrow, names, lengths, "Requested with `nrow` argument")
   }
 }
 
@@ -157,10 +157,10 @@ tibble_class_no_data_frame <- c("tbl_df", "tbl")
 
 # Errors ------------------------------------------------------------------
 
-error_new_tibble_must_be_list <- function() {
-  tibble_error("`x` must be a list.")
+abort_new_tibble_must_be_list <- function() {
+  tibble_abort("`x` must be a list.")
 }
 
-error_new_tibble_nrow_must_be_nonnegative <- function() {
-  tibble_error("`nrow` must be a nonnegative whole number smaller than 2^31.")
+abort_new_tibble_nrow_must_be_nonnegative <- function() {
+  tibble_abort("`nrow` must be a nonnegative whole number smaller than 2^31.")
 }

--- a/R/rownames.R
+++ b/R/rownames.R
@@ -92,11 +92,11 @@ column_to_rownames <- function(.data, var = "rowname") {
   stopifnot(is.data.frame(.data))
 
   if (has_rownames(.data)) {
-    cnd_signal(error_already_has_rownames())
+    abort_already_has_rownames()
   }
 
   if (!has_name(.data, var)) {
-    cnd_signal(error_unknown_column_names(var))
+    abort_unknown_column_names(var)
   }
 
   .data <- as.data.frame(.data)
@@ -119,6 +119,6 @@ raw_rownames <- function(x) {
 
 # Errors ------------------------------------------------------------------
 
-error_already_has_rownames <- function() {
-  tibble_error("`.data` must be a data frame without row names.")
+abort_already_has_rownames <- function() {
+  tibble_abort("`.data` must be a data frame without row names.")
 }

--- a/R/subsetting-matrix.R
+++ b/R/subsetting-matrix.R
@@ -16,11 +16,11 @@ tbl_subassign_matrix <- function(x, j, value, j_arg, value_arg) {
   # FIXME: use size argument in vctrs >= 0.3.0
 
   if (!vec_is(value)) {
-    cnd_signal(error_subset_matrix_scalar_type(j_arg, value_arg))
+    abort_subset_matrix_scalar_type(j_arg, value_arg)
   }
 
   if (vec_size(value) != 1) {
-    cnd_signal(error_subset_matrix_must_be_scalar(j_arg, value_arg))
+    abort_subset_matrix_must_be_scalar(j_arg, value_arg)
   }
 
   cells <- matrix_to_cells(j, x, j_arg)
@@ -40,10 +40,10 @@ tbl_subassign_matrix <- function(x, j, value, j_arg, value_arg) {
 
 matrix_to_cells <- function(j, x, j_arg) {
   if (!is_bare_logical(j)) {
-    cnd_signal(error_subset_matrix_must_be_logical(j_arg))
+    abort_subset_matrix_must_be_logical(j_arg)
   }
   if (!identical(dim(j), dim(x))) {
-    cnd_signal(error_subset_matrix_must_have_same_dimensions(j_arg))
+    abort_subset_matrix_must_have_same_dimensions(j_arg)
   }
 
   # Need unlist(list(...)) because apply() isn't type stable if the return
@@ -62,30 +62,30 @@ cells_to_col_idx <- function(cells) {
 
 # Errors ------------------------------------------------------------------
 
-error_subset_matrix_must_be_logical <- function(j_arg) {
-  tibble_error(paste0(
+abort_subset_matrix_must_be_logical <- function(j_arg) {
+  tibble_abort(paste0(
     "Subscript ", tick(as_label(j_arg)),
     " is a matrix, it must be of type logical."
   ))
 }
 
-error_subset_matrix_must_have_same_dimensions <- function(j_arg) {
-  tibble_error(paste0(
+abort_subset_matrix_must_have_same_dimensions <- function(j_arg) {
+  tibble_abort(paste0(
     "Subscript ", tick(as_label(j_arg)),
     " is a matrix, it must have the same dimensions as the input."
   ))
 }
 
-error_subset_matrix_scalar_type <- function(j_arg, value_arg) {
-  tibble_error(paste0(
+abort_subset_matrix_scalar_type <- function(j_arg, value_arg) {
+  tibble_abort(paste0(
     "Subscript ", tick(as_label(j_arg)),
     " is a matrix, the data ", tick(as_label(value_arg)),
     " must be a vector of size 1."
   ))
 }
 
-error_subset_matrix_must_be_scalar <- function(j_arg, value_arg) {
-  tibble_error(paste0(
+abort_subset_matrix_must_be_scalar <- function(j_arg, value_arg) {
+  tibble_abort(paste0(
     "Subscript ", tick(as_label(j_arg)),
     " is a matrix, the data ", tick(as_label(value_arg)),
     " must have size 1."

--- a/R/subsetting-matrix.R
+++ b/R/subsetting-matrix.R
@@ -12,7 +12,7 @@ tbl_subset_matrix <- function(x, j, j_arg) {
   unname(vec_c(!!!values, .name_spec = ~.x))
 }
 
-tbl_subassign_matrix <- function(x, j, value, j_arg, value_arg) {
+tbl_subassign_matrix <- function(x, j, value, j_arg, value_arg, call = my_caller_call()) {
   # FIXME: use size argument in vctrs >= 0.3.0
 
   if (!vec_is(value)) {
@@ -31,7 +31,7 @@ tbl_subassign_matrix <- function(x, j, value, j_arg, value_arg) {
       x[[j]] <- vectbl_assign(x[[j]], cells[[j]], value)
     },
     vctrs_error_incompatible_type = function(cnd) {
-      cnd_signal(error_assign_incompatible_type(x, rep(list(value), j), j, value_arg, cnd_message(cnd)))
+      abort_assign_incompatible_type(x, rep(list(value), j), j, value_arg, cnd, call = call)
     }
   )
 

--- a/R/subsetting-matrix.R
+++ b/R/subsetting-matrix.R
@@ -12,7 +12,7 @@ tbl_subset_matrix <- function(x, j, j_arg) {
   unname(vec_c(!!!values, .name_spec = ~.x))
 }
 
-tbl_subassign_matrix <- function(x, j, value, j_arg, value_arg, call = my_caller_call()) {
+tbl_subassign_matrix <- function(x, j, value, j_arg, value_arg, call = my_caller_env()) {
   # FIXME: use size argument in vctrs >= 0.3.0
 
   if (!vec_is(value)) {

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -872,7 +872,7 @@ abort_assign_incompatible_size <- function(nrow, value, j, i_arg, value_arg, par
   )
 }
 
-abort_assign_incompatible_type <- function(x, value, j, value_arg, parent = NULL, call = my_caller_call()) {
+abort_assign_incompatible_type <- function(x, value, j, value_arg, parent = NULL, call = my_caller_env()) {
   name <- names(x)[[j]]
 
   tibble_abort(

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -781,10 +781,10 @@ vectbl_recycle_rhs_rows <- function(value, nrow, i_arg, value_arg, call = my_cal
   value
 }
 
-vectbl_recycle_rhs_cols <- function(value, ncol) {
+vectbl_recycle_rhs_cols <- function(value, ncol, call = my_caller_env()) {
   if (length(value) != 1L || ncol != 1L) {
     # Errors have been caught beforehand in vectbl_as_new_col_index()
-    value <- vec_recycle(value, ncol)
+    value <- vec_recycle(value, ncol, call = call)
   }
 
   value

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -599,7 +599,7 @@ vectbl_as_row_location <- function(i, n, i_arg, assign = FALSE, call = my_caller
   subclass_row_index_errors(vec_as_location(i, n, call = call), i_arg = i_arg, assign = assign)
 }
 
-vectbl_as_row_location2 <- function(i, n, i_arg, assign = FALSE, call = my_caller_call()) {
+vectbl_as_row_location2 <- function(i, n, i_arg, assign = FALSE, call = my_caller_env()) {
   subclass_row_index_errors(vec_as_location2(i, n, call = call), i_arg = i_arg, assign = assign)
 }
 

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -685,7 +685,7 @@ tbl_expand_to_nrow <- function(x, i) {
   x
 }
 
-tbl_subassign_row <- function(x, i, value, i_arg, value_arg, call = my_caller_call()) {
+tbl_subassign_row <- function(x, i, value, i_arg, value_arg, call = my_caller_env()) {
   recycled_value <- vectbl_recycle_rhs_cols(value, length(x))
 
   withCallingHandlers(

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -798,6 +798,52 @@ vectbl_restore <- function(xo, x) {
 
 # Errors ------------------------------------------------------------------
 
+error_assign_incompatible_size <- function(nrow, value, j, i_arg, value_arg) {
+  if (is.null(i_arg)) {
+    target <- "existing data"
+    existing <- pluralise_count("Existing data has ", nrow, " row(s)")
+  } else {
+    target <- paste0("row subscript ", tick(as_label(i_arg)))
+    existing <- pluralise_count("", nrow, " row(s) must be assigned")
+  }
+
+  new <- paste0(pluralise_count("has ", vec_size(value[[j]]), " row(s)"))
+  if (length(value) != 1) {
+    new <- paste0("Element ", j, " of assigned data ", new)
+  } else {
+    new <- paste0("Assigned data ", new)
+  }
+
+  tibble_error(
+    bullets(
+      paste0("Assigned data ", tick(as_label(value_arg)), " must be compatible with ", target, ":"),
+      x = existing,
+      x = new,
+      i = if (nrow != 1) "Only vectors of size 1 are recycled",
+      i = if (nrow == 1 && vec_size(value[[j]]) != 1) "Row updates require a list value. Do you need `list()` or `as.list()`?"
+    ),
+    expected = nrow,
+    actual = vec_size(value[[j]]),
+    j = j
+  )
+}
+
+error_assign_incompatible_type <- function(x, value, j, value_arg, message) {
+  name <- names(x)[[j]]
+
+  tibble_error(
+    bullets(
+      paste0("Assigned data ", tick(as_label(value_arg)), " must be compatible with existing data:"),
+      i = paste0("Error occurred for column ", tick(name)),
+      x = message
+    ),
+    expected = x[[j]],
+    actual = value[[j]],
+    name = name,
+    j = j
+  )
+}
+
 abort_need_rhs_vector <- function(value_arg) {
   tibble_abort(paste0(tick(as_label(value_arg)), " must be a vector, a bare list, a data frame or a matrix."))
 }

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -615,7 +615,7 @@ vectbl_as_col_location <- function(j,
                                    names = NULL,
                                    j_arg,
                                    assign = FALSE,
-                                   call = my_caller_call()) {
+                                   call = my_caller_env()) {
   subclass_col_index_errors(
     vec_as_location(j, n, names, call = call),
     j_arg = j_arg,

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -685,7 +685,7 @@ tbl_expand_to_nrow <- function(x, i) {
   x
 }
 
-tbl_subassign_row <- function(x, i, value, i_arg, value_arg) {
+tbl_subassign_row <- function(x, i, value, i_arg, value_arg, call = my_caller_call()) {
   recycled_value <- vectbl_recycle_rhs_cols(value, length(x))
 
   withCallingHandlers(
@@ -696,7 +696,7 @@ tbl_subassign_row <- function(x, i, value, i_arg, value_arg) {
       # Side effect: check if `value` can be recycled
       vectbl_recycle_rhs_rows(value, length(i), i_arg, value_arg)
 
-      abort_assign_incompatible_type(x, recycled_value, j, value_arg, cnd_message(cnd))
+      abort_assign_incompatible_type(x, recycled_value, j, value_arg, cnd, call = call)
     }
   )
 
@@ -828,22 +828,6 @@ error_assign_incompatible_size <- function(nrow, value, j, i_arg, value_arg) {
   )
 }
 
-error_assign_incompatible_type <- function(x, value, j, value_arg, message) {
-  name <- names(x)[[j]]
-
-  tibble_error(
-    bullets(
-      paste0("Assigned data ", tick(as_label(value_arg)), " must be compatible with existing data:"),
-      i = paste0("Error occurred for column ", tick(name)),
-      x = message
-    ),
-    expected = x[[j]],
-    actual = value[[j]],
-    name = name,
-    j = j
-  )
-}
-
 abort_need_rhs_vector <- function(value_arg) {
   tibble_abort(paste0(tick(as_label(value_arg)), " must be a vector, a bare list, a data frame or a matrix."))
 }
@@ -917,19 +901,20 @@ abort_assign_incompatible_size <- function(nrow, value, j, i_arg, value_arg) {
   )
 }
 
-abort_assign_incompatible_type <- function(x, value, j, value_arg, message) {
+abort_assign_incompatible_type <- function(x, value, j, value_arg, parent = NULL, call = my_caller_call()) {
   name <- names(x)[[j]]
 
   tibble_abort(
     bullets(
       paste0("Assigned data ", tick(as_label(value_arg)), " must be compatible with existing data:"),
-      i = paste0("Error occurred for column ", tick(name)),
-      x = message
+      i = paste0("Error occurred for column ", tick(name))
     ),
     expected = x[[j]],
     actual = value[[j]],
     name = name,
-    j = j
+    j = j,
+    parent = parent,
+    call = call
   )
 }
 

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -575,7 +575,7 @@ vectbl_as_new_col_index <- function(j, x, j_arg, names = "", value_arg = NULL) {
   j
 }
 
-numtbl_as_row_location_assign <- function(i, n, i_arg, call = my_caller_call()) {
+numtbl_as_row_location_assign <- function(i, n, i_arg, call = my_caller_env()) {
   subclass_row_index_errors(
     num_as_location(i, n, missing = "error", oob = "extend", zero = "error", call = call),
     i_arg = i_arg, assign = TRUE

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -773,7 +773,7 @@ vectbl_recycle_rhs_rows <- function(value, nrow, i_arg, value_arg) {
         }
       },
       vctrs_error_recycle_incompatible_size = function(cnd) {
-        cnd_signal(error_assign_incompatible_size(nrow, value, j, i_arg, value_arg))
+        abort_assign_incompatible_size(nrow, value, j, i_arg, value_arg, cnd)
       }
     )
   }
@@ -797,36 +797,6 @@ vectbl_restore <- function(xo, x) {
 }
 
 # Errors ------------------------------------------------------------------
-
-error_assign_incompatible_size <- function(nrow, value, j, i_arg, value_arg) {
-  if (is.null(i_arg)) {
-    target <- "existing data"
-    existing <- pluralise_count("Existing data has ", nrow, " row(s)")
-  } else {
-    target <- paste0("row subscript ", tick(as_label(i_arg)))
-    existing <- pluralise_count("", nrow, " row(s) must be assigned")
-  }
-
-  new <- paste0(pluralise_count("has ", vec_size(value[[j]]), " row(s)"))
-  if (length(value) != 1) {
-    new <- paste0("Element ", j, " of assigned data ", new)
-  } else {
-    new <- paste0("Assigned data ", new)
-  }
-
-  tibble_error(
-    bullets(
-      paste0("Assigned data ", tick(as_label(value_arg)), " must be compatible with ", target, ":"),
-      x = existing,
-      x = new,
-      i = if (nrow != 1) "Only vectors of size 1 are recycled",
-      i = if (nrow == 1 && vec_size(value[[j]]) != 1) "Row updates require a list value. Do you need `list()` or `as.list()`?"
-    ),
-    expected = nrow,
-    actual = vec_size(value[[j]]),
-    j = j
-  )
-}
 
 abort_need_rhs_vector <- function(value_arg) {
   tibble_abort(paste0(tick(as_label(value_arg)), " must be a vector, a bare list, a data frame or a matrix."))
@@ -871,7 +841,7 @@ abort_duplicate_row_subscript_for_assignment <- function(i) {
   tibble_abort(pluralise_commas("Row index(es) ", i, " [is](are) used more than once for assignment."), i = i)
 }
 
-abort_assign_incompatible_size <- function(nrow, value, j, i_arg, value_arg) {
+abort_assign_incompatible_size <- function(nrow, value, j, i_arg, value_arg, parent = NULL) {
   if (is.null(i_arg)) {
     target <- "existing data"
     existing <- pluralise_count("Existing data has ", nrow, " row(s)")
@@ -897,7 +867,8 @@ abort_assign_incompatible_size <- function(nrow, value, j, i_arg, value_arg) {
     ),
     expected = nrow,
     actual = vec_size(value[[j]]),
-    j = j
+    j = j,
+    parent = parent
   )
 }
 

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -118,11 +118,11 @@ NULL
   # Column subsetting if nargs() == 2L
   if (n_real_args <= 2L) {
     if (missing(i)) {
-      cnd_signal(error_subset_columns_non_missing_only())
+      abort_subset_columns_non_missing_only()
     }
     tbl_subset2(x, j = i, j_arg = substitute(i))
   } else if (missing(j) || missing(i)) {
-    cnd_signal(error_subset_columns_non_missing_only())
+    abort_subset_columns_non_missing_only()
   } else {
     i_arg <- substitute(i)
     i <- vectbl_as_row_location2(i, fast_nrow(x), i_arg)
@@ -145,7 +145,7 @@ NULL
   value_arg <- substitute(value)
 
   if (missing(i)) {
-    cnd_signal(error_assign_columns_non_missing_only())
+    abort_assign_columns_non_missing_only()
   }
 
   if (missing(j)) {
@@ -155,7 +155,7 @@ NULL
       j_arg <- i_arg
       i_arg <- NULL
     } else {
-      cnd_signal(error_assign_columns_non_missing_only())
+      abort_assign_columns_non_missing_only()
     }
   }
 
@@ -238,7 +238,7 @@ NULL
     j <- vectbl_as_col_location(j, length(x), names(x), j_arg = j_arg, assign = FALSE)
 
     if (anyNA(j)) {
-      cnd_signal(error_na_column_index(which(is.na(j))))
+      abort_na_column_index(which(is.na(j)))
     }
 
     xo <- .subset(x, j)
@@ -477,7 +477,7 @@ vectbl_as_new_row_index <- function(i, x, i_arg) {
     i
   } else if (is_bare_numeric(i)) {
     if (anyDuplicated.default(i)) {
-      cnd_signal(error_duplicate_row_subscript_for_assignment(i))
+      abort_duplicate_row_subscript_for_assignment(i)
     }
 
     nr <- fast_nrow(x)
@@ -490,7 +490,7 @@ vectbl_as_new_row_index <- function(i, x, i_arg) {
   } else {
     i <- vectbl_as_row_index(i, x, i_arg, assign = TRUE)
     if (anyDuplicated.default(i, incomparables = NA)) {
-      cnd_signal(error_duplicate_row_subscript_for_assignment(i))
+      abort_duplicate_row_subscript_for_assignment(i)
     }
     i
   }
@@ -503,7 +503,7 @@ vectbl_as_new_col_index <- function(j, x, j_arg, names = "", value_arg = NULL) {
 
   if (is_bare_character(j)) {
     if (anyNA(j)) {
-      cnd_signal(error_assign_columns_non_na_only())
+      abort_assign_columns_non_na_only()
     }
 
     names <- j
@@ -518,7 +518,7 @@ vectbl_as_new_col_index <- function(j, x, j_arg, names = "", value_arg = NULL) {
     }
   } else if (is_bare_numeric(j)) {
     if (anyNA(j)) {
-      cnd_signal(error_assign_columns_non_na_only())
+      abort_assign_columns_non_na_only()
     }
 
     j <- numtbl_as_col_location_assign(j, length(x), j_arg = j_arg)
@@ -549,7 +549,7 @@ vectbl_as_new_col_index <- function(j, x, j_arg, names = "", value_arg = NULL) {
     j <- vectbl_as_col_location(j, length(x), names(x), j_arg = j_arg, assign = TRUE)
 
     if (anyNA(j)) {
-      cnd_signal(error_na_column_index(which(is.na(j))))
+      abort_na_column_index(which(is.na(j)))
     }
 
     if (length(names) != 1L) {
@@ -567,7 +567,7 @@ vectbl_as_new_col_index <- function(j, x, j_arg, names = "", value_arg = NULL) {
   }
 
   if (anyDuplicated.default(j)) {
-    cnd_signal(error_duplicate_column_subscript_for_assignment(j))
+    abort_duplicate_column_subscript_for_assignment(j)
   }
 
   names(j) <- names
@@ -673,7 +673,7 @@ tbl_expand_to_nrow <- function(x, i) {
   new_nrow <- max(i, nrow)
 
   if (is.na(new_nrow)) {
-    cnd_signal(error_assign_rows_non_na_only())
+    abort_assign_rows_non_na_only()
   }
 
   if (new_nrow != nrow) {
@@ -696,7 +696,7 @@ tbl_subassign_row <- function(x, i, value, i_arg, value_arg) {
       # Side effect: check if `value` can be recycled
       vectbl_recycle_rhs_rows(value, length(i), i_arg, value_arg)
 
-      cnd_signal(error_assign_incompatible_type(x, recycled_value, j, value_arg, cnd_message(cnd)))
+      abort_assign_incompatible_type(x, recycled_value, j, value_arg, cnd_message(cnd))
     }
   )
 
@@ -732,7 +732,7 @@ vectbl_wrap_rhs_col <- function(value, value_arg) {
 
   value <- result_vectbl_wrap_rhs(value)
   if (is.null(value)) {
-    cnd_signal(error_need_rhs_vector_or_null(value_arg))
+    abort_need_rhs_vector_or_null(value_arg)
   }
 
   value
@@ -741,7 +741,7 @@ vectbl_wrap_rhs_col <- function(value, value_arg) {
 vectbl_wrap_rhs_row <- function(value, value_arg) {
   value <- result_vectbl_wrap_rhs(value)
   if (is.null(value)) {
-    cnd_signal(error_need_rhs_vector(value_arg))
+    abort_need_rhs_vector(value_arg)
   }
 
   value
@@ -798,50 +798,50 @@ vectbl_restore <- function(xo, x) {
 
 # Errors ------------------------------------------------------------------
 
-error_need_rhs_vector <- function(value_arg) {
-  tibble_error(paste0(tick(as_label(value_arg)), " must be a vector, a bare list, a data frame or a matrix."))
+abort_need_rhs_vector <- function(value_arg) {
+  tibble_abort(paste0(tick(as_label(value_arg)), " must be a vector, a bare list, a data frame or a matrix."))
 }
 
-error_need_rhs_vector_or_null <- function(value_arg) {
-  tibble_error(paste0(tick(as_label(value_arg)), " must be a vector, a bare list, a data frame, a matrix, or NULL."))
+abort_need_rhs_vector_or_null <- function(value_arg) {
+  tibble_abort(paste0(tick(as_label(value_arg)), " must be a vector, a bare list, a data frame, a matrix, or NULL."))
 }
 
-error_na_column_index <- function(j) {
-  tibble_error(pluralise_commas("Can't use NA as column index with `[` at position(s) ", j, "."), j = j)
+abort_na_column_index <- function(j) {
+  tibble_abort(pluralise_commas("Can't use NA as column index with `[` at position(s) ", j, "."), j = j)
 }
 
-error_dim_column_index <- function(j) {
+abort_dim_column_index <- function(j) {
   # friendly_type_of() doesn't distinguish between matrices and arrays
-  tibble_error(paste0("Must use a vector in `[`, not an object of class ", class(j)[[1]], "."))
+  tibble_abort(paste0("Must use a vector in `[`, not an object of class ", class(j)[[1]], "."))
 }
 
-error_assign_columns_non_na_only <- function() {
-  tibble_error("Can't use NA as column index in a tibble for assignment.")
+abort_assign_columns_non_na_only <- function() {
+  tibble_abort("Can't use NA as column index in a tibble for assignment.")
 }
 
-error_subset_columns_non_missing_only <- function() {
-  tibble_error("Subscript can't be missing for tibbles in `[[`.")
+abort_subset_columns_non_missing_only <- function() {
+  tibble_abort("Subscript can't be missing for tibbles in `[[`.")
 }
 
-error_assign_columns_non_missing_only <- function() {
-  tibble_error("Subscript can't be missing for tibbles in `[[<-`.")
+abort_assign_columns_non_missing_only <- function() {
+  tibble_abort("Subscript can't be missing for tibbles in `[[<-`.")
 }
 
-error_duplicate_column_subscript_for_assignment <- function(j) {
+abort_duplicate_column_subscript_for_assignment <- function(j) {
   j <- unique(j[duplicated(j)])
-  tibble_error(pluralise_commas("Column index(es) ", j, " [is](are) used more than once for assignment."), j = j)
+  tibble_abort(pluralise_commas("Column index(es) ", j, " [is](are) used more than once for assignment."), j = j)
 }
 
-error_assign_rows_non_na_only <- function() {
-  tibble_error("Can't use NA as row index in a tibble for assignment.")
+abort_assign_rows_non_na_only <- function() {
+  tibble_abort("Can't use NA as row index in a tibble for assignment.")
 }
 
-error_duplicate_row_subscript_for_assignment <- function(i) {
+abort_duplicate_row_subscript_for_assignment <- function(i) {
   i <- unique(i[duplicated(i)])
-  tibble_error(pluralise_commas("Row index(es) ", i, " [is](are) used more than once for assignment."), i = i)
+  tibble_abort(pluralise_commas("Row index(es) ", i, " [is](are) used more than once for assignment."), i = i)
 }
 
-error_assign_incompatible_size <- function(nrow, value, j, i_arg, value_arg) {
+abort_assign_incompatible_size <- function(nrow, value, j, i_arg, value_arg) {
   if (is.null(i_arg)) {
     target <- "existing data"
     existing <- pluralise_count("Existing data has ", nrow, " row(s)")
@@ -857,7 +857,7 @@ error_assign_incompatible_size <- function(nrow, value, j, i_arg, value_arg) {
     new <- paste0("Assigned data ", new)
   }
 
-  tibble_error(
+  tibble_abort(
     bullets(
       paste0("Assigned data ", tick(as_label(value_arg)), " must be compatible with ", target, ":"),
       x = existing,
@@ -871,10 +871,10 @@ error_assign_incompatible_size <- function(nrow, value, j, i_arg, value_arg) {
   )
 }
 
-error_assign_incompatible_type <- function(x, value, j, value_arg, message) {
+abort_assign_incompatible_type <- function(x, value, j, value_arg, message) {
   name <- names(x)[[j]]
 
-  tibble_error(
+  tibble_abort(
     bullets(
       paste0("Assigned data ", tick(as_label(value_arg)), " must be compatible with existing data:"),
       i = paste0("Error occurred for column ", tick(name)),

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -603,9 +603,9 @@ vectbl_as_row_location2 <- function(i, n, i_arg, assign = FALSE, call = my_calle
   subclass_row_index_errors(vec_as_location2(i, n, call = call), i_arg = i_arg, assign = assign)
 }
 
-numtbl_as_col_location_assign <- function(j, n, j_arg) {
+numtbl_as_col_location_assign <- function(j, n, j_arg, call = my_caller_env()) {
   subclass_col_index_errors(
-    num_as_location(j, n, missing = "error", oob = "extend", zero = "error"),
+    num_as_location(j, n, missing = "error", oob = "extend", zero = "error", call = call),
     j_arg = j_arg, assign = TRUE
   )
 }

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -531,7 +531,7 @@ vectbl_as_new_col_index <- function(j, x, j_arg, names = "", value_arg = NULL) {
     # FIXME: Hard-coded name repair
     if (length(names) != 1L) {
       # Side effect: check compatibility
-      vec_recycle(names, length(j), x_arg = as_label(value_arg))
+      vec_recycle(names, length(j), x_arg = as_label(value_arg), call = my_caller_env())
     } else if (length(j) != 1L) {
       # length(names) == 1
       names <- vec_recycle(names, length(j), x_arg = as_label(value_arg))
@@ -554,7 +554,7 @@ vectbl_as_new_col_index <- function(j, x, j_arg, names = "", value_arg = NULL) {
 
     if (length(names) != 1L) {
       # Side effect: check compatibility
-      vec_recycle(names, length(j), x_arg = as_label(value_arg))
+      vec_recycle(names, length(j), x_arg = as_label(value_arg), call = my_caller_env())
     } else if (length(j) != 1L) {
       # length(names) == 1
       names <- vec_recycle(names, length(j), x_arg = as_label(value_arg))

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -774,6 +774,9 @@ vectbl_recycle_rhs_rows <- function(value, nrow, i_arg, value_arg, call = my_cal
       },
       vctrs_error_recycle_incompatible_size = function(cnd) {
         abort_assign_incompatible_size(nrow, value, j, i_arg, value_arg, cnd, call = call)
+      },
+      vctrs_error_scalar_type = function(cnd) {
+        abort_assign_vector(value, j, value_arg, cnd, call = call)
       }
     )
   }
@@ -884,6 +887,16 @@ abort_assign_incompatible_type <- function(x, value, j, value_arg, parent = NULL
     expected = x[[j]],
     actual = value[[j]],
     name = name,
+    j = j,
+    parent = parent,
+    call = call
+  )
+}
+
+abort_assign_vector <- function(value, j, value_arg, parent = NULL, call = my_caller_env()) {
+  tibble_abort(
+    paste0("Assigned data ", tick(as_label(value_arg)), " must be a vector."),
+    actual = value[[j]],
     j = j,
     parent = parent,
     call = call

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -623,8 +623,8 @@ vectbl_as_col_location <- function(j,
   )
 }
 
-vectbl_as_col_location2 <- function(j, n, names = NULL, j_arg, assign = FALSE) {
-  subclass_col_index_errors(vec_as_location2(j, n, names), j_arg = j_arg, assign = assign)
+vectbl_as_col_location2 <- function(j, n, names = NULL, j_arg, assign = FALSE, call = my_caller_env()) {
+  subclass_col_index_errors(vec_as_location2(j, n, names, call = call), j_arg = j_arg, assign = assign)
 }
 
 vectbl_as_col_subscript2 <- function(j, j_arg, assign = FALSE) {

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -615,7 +615,7 @@ vectbl_as_col_location <- function(j,
                                    names = NULL,
                                    j_arg,
                                    assign = FALSE,
-                                   call = caller_env()) {
+                                   call = my_caller_call()) {
   subclass_col_index_errors(
     vec_as_location(j, n, names, call = call),
     j_arg = j_arg,

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -575,14 +575,14 @@ vectbl_as_new_col_index <- function(j, x, j_arg, names = "", value_arg = NULL) {
   j
 }
 
-numtbl_as_row_location_assign <- function(i, n, i_arg) {
+numtbl_as_row_location_assign <- function(i, n, i_arg, call = my_caller_call()) {
   subclass_row_index_errors(
-    num_as_location(i, n, missing = "error", oob = "extend", zero = "error"),
+    num_as_location(i, n, missing = "error", oob = "extend", zero = "error", call = call),
     i_arg = i_arg, assign = TRUE
   )
 }
 
-vectbl_as_row_location <- function(i, n, i_arg, assign = FALSE) {
+vectbl_as_row_location <- function(i, n, i_arg, assign = FALSE, call = my_caller_call()) {
   if (is_bare_atomic(i) && is.matrix(i) && ncol(i) == 1) {
     what <- paste0(
       "tibble::", if (assign) "`[<-`" else "`[`",
@@ -596,11 +596,11 @@ vectbl_as_row_location <- function(i, n, i_arg, assign = FALSE) {
     i <- i[, 1]
   }
 
-  subclass_row_index_errors(vec_as_location(i, n), i_arg = i_arg, assign = assign)
+  subclass_row_index_errors(vec_as_location(i, n, call = call), i_arg = i_arg, assign = assign)
 }
 
-vectbl_as_row_location2 <- function(i, n, i_arg, assign = FALSE) {
-  subclass_row_index_errors(vec_as_location2(i, n), i_arg = i_arg, assign = assign)
+vectbl_as_row_location2 <- function(i, n, i_arg, assign = FALSE, call = my_caller_call()) {
+  subclass_row_index_errors(vec_as_location2(i, n, call = call), i_arg = i_arg, assign = assign)
 }
 
 numtbl_as_col_location_assign <- function(j, n, j_arg) {

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -627,8 +627,8 @@ vectbl_as_col_location2 <- function(j, n, names = NULL, j_arg, assign = FALSE, c
   subclass_col_index_errors(vec_as_location2(j, n, names, call = call), j_arg = j_arg, assign = assign)
 }
 
-vectbl_as_col_subscript2 <- function(j, j_arg, assign = FALSE) {
-  subclass_col_index_errors(vec_as_subscript2(j, logical = "error"), j_arg = j_arg, assign = assign)
+vectbl_as_col_subscript2 <- function(j, j_arg, assign = FALSE, call = my_caller_env()) {
+  subclass_col_index_errors(vec_as_subscript2(j, logical = "error", call = call), j_arg = j_arg, assign = assign)
 }
 
 is_tight_sequence_at_end <- function(i_new, n) {

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -582,7 +582,7 @@ numtbl_as_row_location_assign <- function(i, n, i_arg, call = my_caller_env()) {
   )
 }
 
-vectbl_as_row_location <- function(i, n, i_arg, assign = FALSE, call = my_caller_call()) {
+vectbl_as_row_location <- function(i, n, i_arg, assign = FALSE, call = my_caller_env()) {
   if (is_bare_atomic(i) && is.matrix(i) && ncol(i) == 1) {
     what <- paste0(
       "tibble::", if (assign) "`[<-`" else "`[`",

--- a/R/subsetting.R
+++ b/R/subsetting.R
@@ -694,7 +694,7 @@ tbl_subassign_row <- function(x, i, value, i_arg, value_arg, call = my_caller_en
     },
     vctrs_error = function(cnd) {
       # Side effect: check if `value` can be recycled
-      vectbl_recycle_rhs_rows(value, length(i), i_arg, value_arg)
+      vectbl_recycle_rhs_rows(value, length(i), i_arg, value_arg, call = call)
 
       abort_assign_incompatible_type(x, recycled_value, j, value_arg, cnd, call = call)
     }
@@ -764,7 +764,7 @@ result_vectbl_wrap_rhs <- function(value) {
   }
 }
 
-vectbl_recycle_rhs_rows <- function(value, nrow, i_arg, value_arg) {
+vectbl_recycle_rhs_rows <- function(value, nrow, i_arg, value_arg, call = my_caller_env()) {
   if (length(value) > 0L) {
     withCallingHandlers(
       for (j in seq_along(value)) {
@@ -773,7 +773,7 @@ vectbl_recycle_rhs_rows <- function(value, nrow, i_arg, value_arg) {
         }
       },
       vctrs_error_recycle_incompatible_size = function(cnd) {
-        abort_assign_incompatible_size(nrow, value, j, i_arg, value_arg, cnd)
+        abort_assign_incompatible_size(nrow, value, j, i_arg, value_arg, cnd, call = call)
       }
     )
   }
@@ -841,7 +841,7 @@ abort_duplicate_row_subscript_for_assignment <- function(i) {
   tibble_abort(pluralise_commas("Row index(es) ", i, " [is](are) used more than once for assignment."), i = i)
 }
 
-abort_assign_incompatible_size <- function(nrow, value, j, i_arg, value_arg, parent = NULL) {
+abort_assign_incompatible_size <- function(nrow, value, j, i_arg, value_arg, parent = NULL, call = my_caller_env()) {
   if (is.null(i_arg)) {
     target <- "existing data"
     existing <- pluralise_count("Existing data has ", nrow, " row(s)")
@@ -868,7 +868,8 @@ abort_assign_incompatible_size <- function(nrow, value, j, i_arg, value_arg, par
     expected = nrow,
     actual = vec_size(value[[j]]),
     j = j,
-    parent = parent
+    parent = parent,
+    call = call
   )
 }
 

--- a/R/tbl_df.R
+++ b/R/tbl_df.R
@@ -121,12 +121,12 @@ as.data.frame.tbl_df <- function(x, row.names = NULL, optional = FALSE, ...) {
 
 # Errors ------------------------------------------------------------------
 
-error_names_must_be_non_null <- function() {
-  tibble_error("`names` must not be `NULL`.")
+abort_names_must_be_non_null <- function() {
+  tibble_abort("`names` must not be `NULL`.")
 }
 
-error_names_must_have_length <- function(length, n) {
-  tibble_error(
+abort_names_must_have_length <- function(length, n) {
+  tibble_abort(
     paste0("`names` must have length ", n, ", not ", length, "."),
     expected = n,
     actual = length

--- a/R/tbl_df.R
+++ b/R/tbl_df.R
@@ -121,13 +121,17 @@ as.data.frame.tbl_df <- function(x, row.names = NULL, optional = FALSE, ...) {
 
 # Errors ------------------------------------------------------------------
 
+msg_names_must_have_length <- function(length, n) {
+  paste0("`names` must have length ", n, ", not ", length, ".")
+}
+
 abort_names_must_be_non_null <- function() {
   tibble_abort("`names` must not be `NULL`.")
 }
 
 abort_names_must_have_length <- function(length, n) {
   tibble_abort(
-    paste0("`names` must have length ", n, ", not ", length, "."),
+    msg_names_must_have_length(length, n),
     expected = n,
     actual = length
   )

--- a/R/tbl_df.R
+++ b/R/tbl_df.R
@@ -119,23 +119,6 @@ as.data.frame.tbl_df <- function(x, row.names = NULL, optional = FALSE, ...) {
   x
 }
 
-cnd_names_non_null <- function(name) {
-  if (is.null(name)) {
-    error_names_must_be_non_null()
-  } else {
-    invisible()
-  }
-}
-
-cnd_names_non_na <- function(name) {
-  bad_name <- which(is.na(name))
-  if (has_length(bad_name)) {
-    error_column_names_cannot_be_empty(bad_name, repair_hint = FALSE)
-  } else {
-    invisible()
-  }
-}
-
 # Errors ------------------------------------------------------------------
 
 error_names_must_be_non_null <- function() {

--- a/R/tbl_df.R
+++ b/R/tbl_df.R
@@ -121,12 +121,16 @@ as.data.frame.tbl_df <- function(x, row.names = NULL, optional = FALSE, ...) {
 
 # Errors ------------------------------------------------------------------
 
+msg_names_must_be_non_null <- function() {
+  "`names` must not be `NULL`."
+}
+
 msg_names_must_have_length <- function(length, n) {
   paste0("`names` must have length ", n, ", not ", length, ".")
 }
 
 abort_names_must_be_non_null <- function() {
-  tibble_abort("`names` must not be `NULL`.")
+  tibble_abort(msg_names_must_be_non_null())
 }
 
 abort_names_must_have_length <- function(length, n) {

--- a/R/tibble.R
+++ b/R/tibble.R
@@ -234,7 +234,7 @@ tibble_quos <- function(xs, .rows, .name_repair, single_row = FALSE) {
       if (single_row) {
         if (vec_is(res)) {
           if (vec_size(res) != 1) {
-            cnd_signal(error_tibble_row_size_one(j, given_col_names[[j]], vec_size(res)))
+            abort_tibble_row_size_one(j, given_col_names[[j]], vec_size(res))
           }
         } else {
           res <- list(res)
@@ -327,25 +327,25 @@ vectbl_recycle_rows <- function(x, n, j, name) {
     name <- j
   }
 
-  cnd_signal(error_incompatible_size(n, name, size, "Existing data"))
+  abort_incompatible_size(n, name, size, "Existing data")
 }
 
 # Errors ------------------------------------------------------------------
 
-error_tibble_row_size_one <- function(j, name, size) {
+abort_tibble_row_size_one <- function(j, name, size) {
   if (name != "") {
     desc <- tick(name)
   } else {
     desc <- paste0("at position ", j)
   }
 
-  tibble_error(problems(
+  tibble_abort(problems(
     "All vectors must be size one, use `list()` to wrap.",
     paste0("Column ", desc, " is of size ", size, ".")
   ))
 }
 
-error_incompatible_size <- function(.rows, vars, vars_len, rows_source) {
+abort_incompatible_size <- function(.rows, vars, vars_len, rows_source) {
   vars_split <- split(vars, vars_len)
 
   vars_split[["1"]] <- NULL
@@ -364,7 +364,7 @@ error_incompatible_size <- function(.rows, vars, vars_len, rows_source) {
     paste0("Size ", x, ": ", pluralise_commas(text, y))
   })
 
-  tibble_error(bullets(
+  tibble_abort(bullets(
     "Tibble columns must have compatible sizes:",
     if (!is.null(.rows)) paste0("Size ", .rows, ": ", rows_source),
     problems,

--- a/R/tribble.R
+++ b/R/tribble.R
@@ -83,11 +83,11 @@ extract_frame_data_from_dots <- function(...) {
 
   # Extract the data
   if (length(frame_names) == 0 && length(dots) != 0) {
-    cnd_signal(error_tribble_needs_columns())
+    abort_tribble_needs_columns()
   }
   frame_rest <- dots[-seq_along(frame_names)]
   if (!is.null(names(frame_rest))) {
-    cnd_signal(error_tribble_named_after_tilde())
+    abort_tribble_named_after_tilde()
   }
   if (length(frame_rest) == 0L) {
     # Can't decide on type in absence of data -- use logical which is
@@ -114,12 +114,12 @@ extract_frame_names_from_dots <- function(dots) {
     }
 
     if (length(el) != 2) {
-      cnd_signal(error_tribble_lhs_column_syntax(el[[2]]))
+      abort_tribble_lhs_column_syntax(el[[2]])
     }
 
     candidate <- el[[2]]
     if (!(is.symbol(candidate) || is.character(candidate))) {
-      cnd_signal(error_tribble_rhs_column_syntax(candidate))
+      abort_tribble_rhs_column_syntax(candidate)
     }
 
     frame_names <- c(frame_names, as.character(candidate))
@@ -135,10 +135,7 @@ validate_rectangular_shape <- function(frame_names, frame_rest) {
   # and validate that the supplied formula produces a rectangular
   # structure.
   if (length(frame_rest) %% length(frame_names) != 0) {
-    cnd_signal(error_tribble_non_rectangular(
-      length(frame_names),
-      length(frame_rest)
-    ))
+    abort_tribble_non_rectangular(length(frame_names), length(frame_rest))
   }
 }
 
@@ -178,7 +175,7 @@ turn_matrix_into_column_list <- function(frame_mat) {
 turn_frame_data_into_frame_matrix <- function(names, rest) {
   list_cols <- which(map_lgl(rest, needs_list_col))
   if (has_length(list_cols)) {
-    cnd_signal(error_frame_matrix_list(list_cols))
+    abort_frame_matrix_list(list_cols)
   }
 
   frame_ncol <- length(names)
@@ -192,37 +189,37 @@ subclass_tribble_c_errors <- function(name, code) {
   withCallingHandlers(
     code,
     vctrs_error = function(cnd) {
-      cnd_signal(error_tribble_c(name, cnd))
+      abort_tribble_c(name, cnd)
     }
   )
 }
 
 # Errors ------------------------------------------------------------------
 
-error_tribble_needs_columns <- function() {
-  tibble_error("Must specify at least one column using the `~name` syntax.")
+abort_tribble_needs_columns <- function() {
+  tibble_abort("Must specify at least one column using the `~name` syntax.")
 }
 
-error_tribble_named_after_tilde <- function() {
-  tibble_error("When using the `~name` syntax, subsequent values must not have names.")
+abort_tribble_named_after_tilde <- function() {
+  tibble_abort("When using the `~name` syntax, subsequent values must not have names.")
 }
 
-error_tribble_lhs_column_syntax <- function(lhs) {
-  tibble_error(problems(
+abort_tribble_lhs_column_syntax <- function(lhs) {
+  tibble_abort(problems(
     "All column specifications must use the `~name` syntax.",
     paste0("Found ", expr_label(lhs), " on the left-hand side of `~`.")
   ))
 }
 
-error_tribble_rhs_column_syntax <- function(rhs) {
-  tibble_error(problems(
+abort_tribble_rhs_column_syntax <- function(rhs) {
+  tibble_abort(problems(
     'All column specifications must use the `~name` or `~"name"` syntax.',
     paste0("Found ", expr_label(rhs), " on the right-hand side of `~`.")
   ))
 }
 
-error_tribble_non_rectangular <- function(cols, cells) {
-  tibble_error(bullets(
+abort_tribble_non_rectangular <- function(cols, cells) {
+  tibble_abort(bullets(
     "Data must be rectangular:",
     paste0("Found ", cols, " columns."),
     paste0("Found ", cells, " cells."),
@@ -230,15 +227,15 @@ error_tribble_non_rectangular <- function(cols, cells) {
   ))
 }
 
-error_frame_matrix_list <- function(pos) {
-  tibble_error(problems(
+abort_frame_matrix_list <- function(pos) {
+  tibble_abort(problems(
     "All values must be atomic:",
     pluralise_commas("Found list-valued element(s) at position(s) ", pos, ".")
   ))
 }
 
-error_tribble_c <- function(name, cnd) {
+abort_tribble_c <- function(name, cnd) {
   cnd$message <- paste0("Can't create column ", tick(name), ": ", cnd_header(cnd))
-  cnd$class <- c(tibble_error_class("tribble_c"), class(cnd))
+  cnd$class <- c(tibble_abort_class("tribble_c"), class(cnd))
   cnd
 }

--- a/R/tribble.R
+++ b/R/tribble.R
@@ -185,11 +185,11 @@ turn_frame_data_into_frame_matrix <- function(names, rest) {
   frame_mat
 }
 
-subclass_tribble_c_errors <- function(name, code) {
+subclass_tribble_c_errors <- function(name, code, call = my_caller_env()) {
   withCallingHandlers(
     code,
     vctrs_error = function(cnd) {
-      abort_tribble_c(name, cnd)
+      abort_tribble_c(name, cnd, call)
     }
   )
 }
@@ -234,8 +234,10 @@ abort_frame_matrix_list <- function(pos) {
   ))
 }
 
-abort_tribble_c <- function(name, cnd) {
-  cnd$message <- paste0("Can't create column ", tick(name), ": ", cnd_header(cnd))
-  cnd$class <- c(tibble_abort_class("tribble_c"), class(cnd))
-  cnd
+abort_tribble_c <- function(name, cnd, call = my_caller_env()) {
+  tibble_abort(
+    paste0("Can't create column ", tick(name)),
+    parent = cnd,
+    call = call
+  )
 }

--- a/tests/testthat/_snaps/add.md
+++ b/tests/testthat/_snaps/add.md
@@ -3,18 +3,21 @@
     Code
       add_row(tibble(), a = 1)
     Condition
-      Error in `error_unknown_column_names()`:
-      ! could not find function "error_unknown_column_names"
+      Error in `add_row()`:
+      ! New rows can't add columns.
+      x Can't find column `a` in `.data`.
     Code
       add_row(tibble(), a = 1, b = 2)
     Condition
-      Error in `error_unknown_column_names()`:
-      ! could not find function "error_unknown_column_names"
+      Error in `add_row()`:
+      ! New rows can't add columns.
+      x Can't find columns `a` and `b` in `.data`.
     Code
       add_row(tibble(), !!!set_names(letters))
     Condition
-      Error in `error_unknown_column_names()`:
-      ! could not find function "error_unknown_column_names"
+      Error in `add_row()`:
+      ! New rows can't add columns.
+      x Can't find columns `a`, `b`, `c`, `d`, `e`, and 21 more in `.data`.
     Code
       add_row(dplyr::group_by(tibble(a = 1), a))
     Condition

--- a/tests/testthat/_snaps/add.md
+++ b/tests/testthat/_snaps/add.md
@@ -28,18 +28,36 @@
     Code
       add_column(tibble(a = 1), a = 1)
     Condition
-      Error in `error_column_names_must_be_unique()`:
-      ! could not find function "error_column_names_must_be_unique"
+      Error:
+      ! Column name `a` must not be duplicated.Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 2.
     Code
       add_column(tibble(a = 1, b = 2), a = 1, b = 2)
     Condition
-      Error in `error_column_names_must_be_unique()`:
-      ! could not find function "error_column_names_must_be_unique"
+      Error:
+      ! Column names `a` and `b` must not be duplicated.Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 3.
+        * "b" at locations 2 and 4.
     Code
       add_column(tibble(!!!set_names(letters)), !!!set_names(letters))
     Condition
-      Error in `error_column_names_must_be_unique()`:
-      ! could not find function "error_column_names_must_be_unique"
+      Error:
+      ! Column names `a`, `b`, `c`, `d`, `e`, and 21 more must not be duplicated.Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 27.
+        * "b" at locations 2 and 28.
+        * "c" at locations 3 and 29.
+        * "d" at locations 4 and 30.
+        * "e" at locations 5 and 31.
+        * ...
     Code
       add_column(tibble(a = 2:3), b = 4:6)
     Condition

--- a/tests/testthat/_snaps/add.md
+++ b/tests/testthat/_snaps/add.md
@@ -28,8 +28,9 @@
     Code
       add_column(tibble(a = 1), a = 1)
     Condition
-      Error:
-      ! Column name `a` must not be duplicated.Use `.name_repair` to specify repair.
+      Error in `add_column()`:
+      ! Column name `a` must not be duplicated.
+      Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
       ! Names must be unique.
       x These names are duplicated:
@@ -37,8 +38,9 @@
     Code
       add_column(tibble(a = 1, b = 2), a = 1, b = 2)
     Condition
-      Error:
-      ! Column names `a` and `b` must not be duplicated.Use `.name_repair` to specify repair.
+      Error in `add_column()`:
+      ! Column names `a` and `b` must not be duplicated.
+      Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
       ! Names must be unique.
       x These names are duplicated:
@@ -47,8 +49,9 @@
     Code
       add_column(tibble(!!!set_names(letters)), !!!set_names(letters))
     Condition
-      Error:
-      ! Column names `a`, `b`, `c`, `d`, `e`, and 21 more must not be duplicated.Use `.name_repair` to specify repair.
+      Error in `add_column()`:
+      ! Column names `a`, `b`, `c`, `d`, `e`, and 21 more must not be duplicated.
+      Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
       ! Names must be unique.
       x These names are duplicated:

--- a/tests/testthat/_snaps/add.md
+++ b/tests/testthat/_snaps/add.md
@@ -3,77 +3,53 @@
     Code
       add_row(tibble(), a = 1)
     Condition
-      Error:
-      ! New rows can't add columns.
-      x Can't find column `a` in `.data`.
+      Error in `error_unknown_column_names()`:
+      ! could not find function "error_unknown_column_names"
     Code
       add_row(tibble(), a = 1, b = 2)
     Condition
-      Error:
-      ! New rows can't add columns.
-      x Can't find columns `a` and `b` in `.data`.
+      Error in `error_unknown_column_names()`:
+      ! could not find function "error_unknown_column_names"
     Code
       add_row(tibble(), !!!set_names(letters))
     Condition
-      Error:
-      ! New rows can't add columns.
-      x Can't find columns `a`, `b`, `c`, `d`, `e`, and 21 more in `.data`.
+      Error in `error_unknown_column_names()`:
+      ! could not find function "error_unknown_column_names"
     Code
       add_row(dplyr::group_by(tibble(a = 1), a))
     Condition
-      Error:
+      Error in `add_row()`:
       ! Can't add rows to grouped data frames.
     Code
       add_row(tibble(a = 1), a = 2, .before = 1, .after = 1)
     Condition
-      Error:
+      Error in `add_row()`:
       ! Can't specify both `.before` and `.after`.
     Code
       add_column(tibble(a = 1), a = 1)
     Condition
-      Error:
-      ! Column name `a` must not be duplicated.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names must be unique.
-      x These names are duplicated:
-        * "a" at locations 1 and 2.
+      Error in `error_column_names_must_be_unique()`:
+      ! could not find function "error_column_names_must_be_unique"
     Code
       add_column(tibble(a = 1, b = 2), a = 1, b = 2)
     Condition
-      Error:
-      ! Column names `a` and `b` must not be duplicated.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names must be unique.
-      x These names are duplicated:
-        * "a" at locations 1 and 3.
-        * "b" at locations 2 and 4.
+      Error in `error_column_names_must_be_unique()`:
+      ! could not find function "error_column_names_must_be_unique"
     Code
       add_column(tibble(!!!set_names(letters)), !!!set_names(letters))
     Condition
-      Error:
-      ! Column names `a`, `b`, `c`, `d`, `e`, and 21 more must not be duplicated.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names must be unique.
-      x These names are duplicated:
-        * "a" at locations 1 and 27.
-        * "b" at locations 2 and 28.
-        * "c" at locations 3 and 29.
-        * "d" at locations 4 and 30.
-        * "e" at locations 5 and 31.
-        * ...
+      Error in `error_column_names_must_be_unique()`:
+      ! could not find function "error_column_names_must_be_unique"
     Code
       add_column(tibble(a = 2:3), b = 4:6)
     Condition
-      Error:
+      Error in `add_column()`:
       ! New columns must be compatible with `.data`.
       x New column has 3 rows.
       i `.data` has 2 rows.
     Code
       add_column(tibble(a = 1), b = 1, .before = 1, .after = 1)
     Condition
-      Error:
+      Error in `add_column()`:
       ! Can't specify both `.before` and `.after`.
 

--- a/tests/testthat/_snaps/as_tibble.md
+++ b/tests/testthat/_snaps/as_tibble.md
@@ -215,7 +215,7 @@
     Code
       as_tibble(list(a = new_environment()))
     Condition
-      Error in `as_tibble.list()`:
+      Error in `as_tibble()`:
       ! All columns in a tibble must be vectors.
       x Column `a` is an environment.
     Code

--- a/tests/testthat/_snaps/as_tibble.md
+++ b/tests/testthat/_snaps/as_tibble.md
@@ -50,13 +50,21 @@
     Code
       as_tibble(table(a = c(1, 1, 1, 2, 2, 2), a = c(3, 4, 5, 3, 4, 5)))
     Condition
-      Error in `error_column_names_must_be_unique()`:
-      ! could not find function "error_column_names_must_be_unique"
+      Error:
+      ! Column name `a` must not be duplicated.Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 2.
     Code
       as_tibble(table(c(1, 1, 1, 2, 2, 2), c(3, 4, 5, 3, 4, 5)))
     Condition
-      Error in `error_column_names_cannot_be_empty()`:
-      ! could not find function "error_column_names_cannot_be_empty"
+      Error:
+      ! Columns 1 and 2 must be named.
+      Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names can't be empty.
+      x Empty names found at locations 1 and 2.
 
 ---
 
@@ -124,28 +132,49 @@
     Code
       as_tibble(list(1))
     Condition
-      Error in `error_column_names_cannot_be_empty()`:
-      ! could not find function "error_column_names_cannot_be_empty"
+      Error:
+      ! Column 1 must be named.
+      Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names can't be empty.
+      x Empty name found at location 1.
     Code
       as_tibble(list(1, 2))
     Condition
-      Error in `error_column_names_cannot_be_empty()`:
-      ! could not find function "error_column_names_cannot_be_empty"
+      Error:
+      ! Columns 1 and 2 must be named.
+      Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names can't be empty.
+      x Empty names found at locations 1 and 2.
     Code
       as_tibble(list(a = 1, 2))
     Condition
-      Error in `error_column_names_cannot_be_empty()`:
-      ! could not find function "error_column_names_cannot_be_empty"
+      Error:
+      ! Column 2 must be named.
+      Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names can't be empty.
+      x Empty name found at location 2.
     Code
       as_tibble(as.list(1:26))
     Condition
-      Error in `error_column_names_cannot_be_empty()`:
-      ! could not find function "error_column_names_cannot_be_empty"
+      Error:
+      ! Columns 1, 2, 3, 4, 5, and 21 more must be named.
+      Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names can't be empty.
+      x Empty names found at locations 1, 2, 3, 4, 5, etc.
     Code
       as_tibble(set_names(list(1), "..1"))
     Condition
-      Error in `error_column_names_cannot_be_dot_dot()`:
-      ! could not find function "error_column_names_cannot_be_dot_dot"
+      Error:
+      ! Column 1 must not have names of the form ... or ..j.
+      Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names can't be of the form `...` or `..j`.
+      x These names are invalid:
+        * "..1" at location 1.
     Code
       as_tibble(set_names(as.list(1:26), paste0("..", 1:26)))
     Condition
@@ -164,13 +193,22 @@
     Code
       as_tibble(list(a = 1, a = 1))
     Condition
-      Error in `error_column_names_must_be_unique()`:
-      ! could not find function "error_column_names_must_be_unique"
+      Error:
+      ! Column name `a` must not be duplicated.Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 2.
     Code
       as_tibble(list(a = 1, a = 1, b = 1, b = 1))
     Condition
-      Error in `error_column_names_must_be_unique()`:
-      ! could not find function "error_column_names_must_be_unique"
+      Error:
+      ! Column names `a` and `b` must not be duplicated.Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 2.
+        * "b" at locations 3 and 4.
     Code
       as_tibble(list(a = new_environment()))
     Condition
@@ -180,28 +218,49 @@
     Code
       as_tibble_row(list(1))
     Condition
-      Error in `error_column_names_cannot_be_empty()`:
-      ! could not find function "error_column_names_cannot_be_empty"
+      Error:
+      ! Column 1 must be named.
+      Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names can't be empty.
+      x Empty name found at location 1.
     Code
       as_tibble_row(list(1, 2))
     Condition
-      Error in `error_column_names_cannot_be_empty()`:
-      ! could not find function "error_column_names_cannot_be_empty"
+      Error:
+      ! Columns 1 and 2 must be named.
+      Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names can't be empty.
+      x Empty names found at locations 1 and 2.
     Code
       as_tibble_row(list(a = 1, 2))
     Condition
-      Error in `error_column_names_cannot_be_empty()`:
-      ! could not find function "error_column_names_cannot_be_empty"
+      Error:
+      ! Column 2 must be named.
+      Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names can't be empty.
+      x Empty name found at location 2.
     Code
       as_tibble_row(as.list(1:26))
     Condition
-      Error in `error_column_names_cannot_be_empty()`:
-      ! could not find function "error_column_names_cannot_be_empty"
+      Error:
+      ! Columns 1, 2, 3, 4, 5, and 21 more must be named.
+      Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names can't be empty.
+      x Empty names found at locations 1, 2, 3, 4, 5, etc.
     Code
       as_tibble_row(set_names(list(1), "..1"))
     Condition
-      Error in `error_column_names_cannot_be_dot_dot()`:
-      ! could not find function "error_column_names_cannot_be_dot_dot"
+      Error:
+      ! Column 1 must not have names of the form ... or ..j.
+      Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names can't be of the form `...` or `..j`.
+      x These names are invalid:
+        * "..1" at location 1.
     Code
       as_tibble_row(set_names(as.list(1:26), paste0("..", 1:26)))
     Condition
@@ -220,13 +279,22 @@
     Code
       as_tibble_row(list(a = 1, a = 1))
     Condition
-      Error in `error_column_names_must_be_unique()`:
-      ! could not find function "error_column_names_must_be_unique"
+      Error:
+      ! Column name `a` must not be duplicated.Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 2.
     Code
       as_tibble_row(list(a = 1, a = 1, b = 1, b = 1))
     Condition
-      Error in `error_column_names_must_be_unique()`:
-      ! could not find function "error_column_names_must_be_unique"
+      Error:
+      ! Column names `a` and `b` must not be duplicated.Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 2.
+        * "b" at locations 3 and 4.
     Code
       as_tibble_row(list(a = new_environment()))
     Condition

--- a/tests/testthat/_snaps/as_tibble.md
+++ b/tests/testthat/_snaps/as_tibble.md
@@ -50,8 +50,9 @@
     Code
       as_tibble(table(a = c(1, 1, 1, 2, 2, 2), a = c(3, 4, 5, 3, 4, 5)))
     Condition
-      Error:
-      ! Column name `a` must not be duplicated.Use `.name_repair` to specify repair.
+      Error in `as_tibble.table()`:
+      ! Column name `a` must not be duplicated.
+      Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
       ! Names must be unique.
       x These names are duplicated:
@@ -59,7 +60,7 @@
     Code
       as_tibble(table(c(1, 1, 1, 2, 2, 2), c(3, 4, 5, 3, 4, 5)))
     Condition
-      Error:
+      Error in `abort_column_names_cannot_be_empty()`:
       ! Columns 1 and 2 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -132,7 +133,7 @@
     Code
       as_tibble(list(1))
     Condition
-      Error:
+      Error in `abort_column_names_cannot_be_empty()`:
       ! Column 1 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -141,7 +142,7 @@
     Code
       as_tibble(list(1, 2))
     Condition
-      Error:
+      Error in `abort_column_names_cannot_be_empty()`:
       ! Columns 1 and 2 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -150,7 +151,7 @@
     Code
       as_tibble(list(a = 1, 2))
     Condition
-      Error:
+      Error in `abort_column_names_cannot_be_empty()`:
       ! Column 2 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -159,7 +160,7 @@
     Code
       as_tibble(as.list(1:26))
     Condition
-      Error:
+      Error in `abort_column_names_cannot_be_empty()`:
       ! Columns 1, 2, 3, 4, 5, and 21 more must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -168,7 +169,7 @@
     Code
       as_tibble(set_names(list(1), "..1"))
     Condition
-      Error:
+      Error in `abort_column_names_cannot_be_dot_dot()`:
       ! Column 1 must not have names of the form ... or ..j.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -193,8 +194,9 @@
     Code
       as_tibble(list(a = 1, a = 1))
     Condition
-      Error:
-      ! Column name `a` must not be duplicated.Use `.name_repair` to specify repair.
+      Error in `as_tibble.list()`:
+      ! Column name `a` must not be duplicated.
+      Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
       ! Names must be unique.
       x These names are duplicated:
@@ -202,8 +204,9 @@
     Code
       as_tibble(list(a = 1, a = 1, b = 1, b = 1))
     Condition
-      Error:
-      ! Column names `a` and `b` must not be duplicated.Use `.name_repair` to specify repair.
+      Error in `as_tibble.list()`:
+      ! Column names `a` and `b` must not be duplicated.
+      Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
       ! Names must be unique.
       x These names are duplicated:
@@ -218,7 +221,7 @@
     Code
       as_tibble_row(list(1))
     Condition
-      Error:
+      Error in `abort_column_names_cannot_be_empty()`:
       ! Column 1 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -227,7 +230,7 @@
     Code
       as_tibble_row(list(1, 2))
     Condition
-      Error:
+      Error in `abort_column_names_cannot_be_empty()`:
       ! Columns 1 and 2 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -236,7 +239,7 @@
     Code
       as_tibble_row(list(a = 1, 2))
     Condition
-      Error:
+      Error in `abort_column_names_cannot_be_empty()`:
       ! Column 2 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -245,7 +248,7 @@
     Code
       as_tibble_row(as.list(1:26))
     Condition
-      Error:
+      Error in `abort_column_names_cannot_be_empty()`:
       ! Columns 1, 2, 3, 4, 5, and 21 more must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -254,7 +257,7 @@
     Code
       as_tibble_row(set_names(list(1), "..1"))
     Condition
-      Error:
+      Error in `abort_column_names_cannot_be_dot_dot()`:
       ! Column 1 must not have names of the form ... or ..j.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -279,8 +282,9 @@
     Code
       as_tibble_row(list(a = 1, a = 1))
     Condition
-      Error:
-      ! Column name `a` must not be duplicated.Use `.name_repair` to specify repair.
+      Error in `as_tibble_row()`:
+      ! Column name `a` must not be duplicated.
+      Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
       ! Names must be unique.
       x These names are duplicated:
@@ -288,8 +292,9 @@
     Code
       as_tibble_row(list(a = 1, a = 1, b = 1, b = 1))
     Condition
-      Error:
-      ! Column names `a` and `b` must not be duplicated.Use `.name_repair` to specify repair.
+      Error in `as_tibble_row()`:
+      ! Column names `a` and `b` must not be duplicated.
+      Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
       ! Names must be unique.
       x These names are duplicated:

--- a/tests/testthat/_snaps/as_tibble.md
+++ b/tests/testthat/_snaps/as_tibble.md
@@ -50,22 +50,13 @@
     Code
       as_tibble(table(a = c(1, 1, 1, 2, 2, 2), a = c(3, 4, 5, 3, 4, 5)))
     Condition
-      Error:
-      ! Column name `a` must not be duplicated.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names must be unique.
-      x These names are duplicated:
-        * "a" at locations 1 and 2.
+      Error in `error_column_names_must_be_unique()`:
+      ! could not find function "error_column_names_must_be_unique"
     Code
       as_tibble(table(c(1, 1, 1, 2, 2, 2), c(3, 4, 5, 3, 4, 5)))
     Condition
-      Error:
-      ! Columns 1 and 2 must be named.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names can't be empty.
-      x Empty names found at locations 1 and 2.
+      Error in `error_column_names_cannot_be_empty()`:
+      ! could not find function "error_column_names_cannot_be_empty"
 
 ---
 
@@ -133,49 +124,28 @@
     Code
       as_tibble(list(1))
     Condition
-      Error:
-      ! Column 1 must be named.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names can't be empty.
-      x Empty name found at location 1.
+      Error in `error_column_names_cannot_be_empty()`:
+      ! could not find function "error_column_names_cannot_be_empty"
     Code
       as_tibble(list(1, 2))
     Condition
-      Error:
-      ! Columns 1 and 2 must be named.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names can't be empty.
-      x Empty names found at locations 1 and 2.
+      Error in `error_column_names_cannot_be_empty()`:
+      ! could not find function "error_column_names_cannot_be_empty"
     Code
       as_tibble(list(a = 1, 2))
     Condition
-      Error:
-      ! Column 2 must be named.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names can't be empty.
-      x Empty name found at location 2.
+      Error in `error_column_names_cannot_be_empty()`:
+      ! could not find function "error_column_names_cannot_be_empty"
     Code
       as_tibble(as.list(1:26))
     Condition
-      Error:
-      ! Columns 1, 2, 3, 4, 5, and 21 more must be named.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names can't be empty.
-      x Empty names found at locations 1, 2, 3, 4, 5, etc.
+      Error in `error_column_names_cannot_be_empty()`:
+      ! could not find function "error_column_names_cannot_be_empty"
     Code
       as_tibble(set_names(list(1), "..1"))
     Condition
-      Error:
-      ! Column 1 must not have names of the form ... or ..j.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names can't be of the form `...` or `..j`.
-      x These names are invalid:
-        * "..1" at location 1.
+      Error in `error_column_names_cannot_be_dot_dot()`:
+      ! could not find function "error_column_names_cannot_be_dot_dot"
     Code
       as_tibble(set_names(as.list(1:26), paste0("..", 1:26)))
     Condition
@@ -194,76 +164,44 @@
     Code
       as_tibble(list(a = 1, a = 1))
     Condition
-      Error:
-      ! Column name `a` must not be duplicated.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names must be unique.
-      x These names are duplicated:
-        * "a" at locations 1 and 2.
+      Error in `error_column_names_must_be_unique()`:
+      ! could not find function "error_column_names_must_be_unique"
     Code
       as_tibble(list(a = 1, a = 1, b = 1, b = 1))
     Condition
-      Error:
-      ! Column names `a` and `b` must not be duplicated.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names must be unique.
-      x These names are duplicated:
-        * "a" at locations 1 and 2.
-        * "b" at locations 3 and 4.
+      Error in `error_column_names_must_be_unique()`:
+      ! could not find function "error_column_names_must_be_unique"
     Code
       as_tibble(list(a = new_environment()))
     Condition
-      Error:
+      Error in `as_tibble.list()`:
       ! All columns in a tibble must be vectors.
       x Column `a` is an environment.
     Code
       as_tibble_row(list(1))
     Condition
-      Error:
-      ! Column 1 must be named.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names can't be empty.
-      x Empty name found at location 1.
+      Error in `error_column_names_cannot_be_empty()`:
+      ! could not find function "error_column_names_cannot_be_empty"
     Code
       as_tibble_row(list(1, 2))
     Condition
-      Error:
-      ! Columns 1 and 2 must be named.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names can't be empty.
-      x Empty names found at locations 1 and 2.
+      Error in `error_column_names_cannot_be_empty()`:
+      ! could not find function "error_column_names_cannot_be_empty"
     Code
       as_tibble_row(list(a = 1, 2))
     Condition
-      Error:
-      ! Column 2 must be named.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names can't be empty.
-      x Empty name found at location 2.
+      Error in `error_column_names_cannot_be_empty()`:
+      ! could not find function "error_column_names_cannot_be_empty"
     Code
       as_tibble_row(as.list(1:26))
     Condition
-      Error:
-      ! Columns 1, 2, 3, 4, 5, and 21 more must be named.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names can't be empty.
-      x Empty names found at locations 1, 2, 3, 4, 5, etc.
+      Error in `error_column_names_cannot_be_empty()`:
+      ! could not find function "error_column_names_cannot_be_empty"
     Code
       as_tibble_row(set_names(list(1), "..1"))
     Condition
-      Error:
-      ! Column 1 must not have names of the form ... or ..j.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names can't be of the form `...` or `..j`.
-      x These names are invalid:
-        * "..1" at location 1.
+      Error in `error_column_names_cannot_be_dot_dot()`:
+      ! could not find function "error_column_names_cannot_be_dot_dot"
     Code
       as_tibble_row(set_names(as.list(1:26), paste0("..", 1:26)))
     Condition
@@ -282,24 +220,13 @@
     Code
       as_tibble_row(list(a = 1, a = 1))
     Condition
-      Error:
-      ! Column name `a` must not be duplicated.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names must be unique.
-      x These names are duplicated:
-        * "a" at locations 1 and 2.
+      Error in `error_column_names_must_be_unique()`:
+      ! could not find function "error_column_names_must_be_unique"
     Code
       as_tibble_row(list(a = 1, a = 1, b = 1, b = 1))
     Condition
-      Error:
-      ! Column names `a` and `b` must not be duplicated.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names must be unique.
-      x These names are duplicated:
-        * "a" at locations 1 and 2.
-        * "b" at locations 3 and 4.
+      Error in `error_column_names_must_be_unique()`:
+      ! could not find function "error_column_names_must_be_unique"
     Code
       as_tibble_row(list(a = new_environment()))
     Condition
@@ -308,13 +235,13 @@
     Code
       as_tibble_row(list(a = 1:3))
     Condition
-      Error:
+      Error in `as_tibble_row()`:
       ! All elements must be size one, use `list()` to wrap.
       x Element `a` is of size 3.
     Code
       as_tibble_row(list(a = 1:3, b = 1:3))
     Condition
-      Error:
+      Error in `as_tibble_row()`:
       ! All elements must be size one, use `list()` to wrap.
       x Element `a` is of size 3.
       x Element `b` is of size 3.

--- a/tests/testthat/_snaps/as_tibble.md
+++ b/tests/testthat/_snaps/as_tibble.md
@@ -60,7 +60,7 @@
     Code
       as_tibble(table(c(1, 1, 1, 2, 2, 2), c(3, 4, 5, 3, 4, 5)))
     Condition
-      Error in `abort_column_names_cannot_be_empty()`:
+      Error in `as_tibble.table()`:
       ! Columns 1 and 2 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -133,7 +133,7 @@
     Code
       as_tibble(list(1))
     Condition
-      Error in `abort_column_names_cannot_be_empty()`:
+      Error in `as_tibble.list()`:
       ! Column 1 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -142,7 +142,7 @@
     Code
       as_tibble(list(1, 2))
     Condition
-      Error in `abort_column_names_cannot_be_empty()`:
+      Error in `as_tibble.list()`:
       ! Columns 1 and 2 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -151,7 +151,7 @@
     Code
       as_tibble(list(a = 1, 2))
     Condition
-      Error in `abort_column_names_cannot_be_empty()`:
+      Error in `as_tibble.list()`:
       ! Column 2 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -160,7 +160,7 @@
     Code
       as_tibble(as.list(1:26))
     Condition
-      Error in `abort_column_names_cannot_be_empty()`:
+      Error in `as_tibble.list()`:
       ! Columns 1, 2, 3, 4, 5, and 21 more must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -169,7 +169,7 @@
     Code
       as_tibble(set_names(list(1), "..1"))
     Condition
-      Error in `abort_column_names_cannot_be_dot_dot()`:
+      Error in `as_tibble.list()`:
       ! Column 1 must not have names of the form ... or ..j.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -221,7 +221,7 @@
     Code
       as_tibble_row(list(1))
     Condition
-      Error in `abort_column_names_cannot_be_empty()`:
+      Error in `as_tibble_row()`:
       ! Column 1 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -230,7 +230,7 @@
     Code
       as_tibble_row(list(1, 2))
     Condition
-      Error in `abort_column_names_cannot_be_empty()`:
+      Error in `as_tibble_row()`:
       ! Columns 1 and 2 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -239,7 +239,7 @@
     Code
       as_tibble_row(list(a = 1, 2))
     Condition
-      Error in `abort_column_names_cannot_be_empty()`:
+      Error in `as_tibble_row()`:
       ! Column 2 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -248,7 +248,7 @@
     Code
       as_tibble_row(as.list(1:26))
     Condition
-      Error in `abort_column_names_cannot_be_empty()`:
+      Error in `as_tibble_row()`:
       ! Columns 1, 2, 3, 4, 5, and 21 more must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -257,7 +257,7 @@
     Code
       as_tibble_row(set_names(list(1), "..1"))
     Condition
-      Error in `abort_column_names_cannot_be_dot_dot()`:
+      Error in `as_tibble_row()`:
       ! Column 1 must not have names of the form ... or ..j.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:

--- a/tests/testthat/_snaps/as_tibble.md
+++ b/tests/testthat/_snaps/as_tibble.md
@@ -50,7 +50,7 @@
     Code
       as_tibble(table(a = c(1, 1, 1, 2, 2, 2), a = c(3, 4, 5, 3, 4, 5)))
     Condition
-      Error in `as_tibble.table()`:
+      Error in `as_tibble()`:
       ! Column name `a` must not be duplicated.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -60,7 +60,7 @@
     Code
       as_tibble(table(c(1, 1, 1, 2, 2, 2), c(3, 4, 5, 3, 4, 5)))
     Condition
-      Error in `as_tibble.table()`:
+      Error in `as_tibble()`:
       ! Columns 1 and 2 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -133,7 +133,7 @@
     Code
       as_tibble(list(1))
     Condition
-      Error in `as_tibble.list()`:
+      Error in `as_tibble()`:
       ! Column 1 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -142,7 +142,7 @@
     Code
       as_tibble(list(1, 2))
     Condition
-      Error in `as_tibble.list()`:
+      Error in `as_tibble()`:
       ! Columns 1 and 2 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -151,7 +151,7 @@
     Code
       as_tibble(list(a = 1, 2))
     Condition
-      Error in `as_tibble.list()`:
+      Error in `as_tibble()`:
       ! Column 2 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -160,7 +160,7 @@
     Code
       as_tibble(as.list(1:26))
     Condition
-      Error in `as_tibble.list()`:
+      Error in `as_tibble()`:
       ! Columns 1, 2, 3, 4, 5, and 21 more must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -169,7 +169,7 @@
     Code
       as_tibble(set_names(list(1), "..1"))
     Condition
-      Error in `as_tibble.list()`:
+      Error in `as_tibble()`:
       ! Column 1 must not have names of the form ... or ..j.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -194,7 +194,7 @@
     Code
       as_tibble(list(a = 1, a = 1))
     Condition
-      Error in `as_tibble.list()`:
+      Error in `as_tibble()`:
       ! Column name `a` must not be duplicated.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -204,7 +204,7 @@
     Code
       as_tibble(list(a = 1, a = 1, b = 1, b = 1))
     Condition
-      Error in `as_tibble.list()`:
+      Error in `as_tibble()`:
       ! Column names `a` and `b` must not be duplicated.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:

--- a/tests/testthat/_snaps/as_tibble.md
+++ b/tests/testthat/_snaps/as_tibble.md
@@ -179,7 +179,7 @@
     Code
       as_tibble(set_names(as.list(1:26), paste0("..", 1:26)))
     Condition
-      Error:
+      Error in `as_tibble()`:
       ! Columns 1, 2, 3, 4, 5, and 21 more must not have names of the form ... or ..j.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -267,7 +267,7 @@
     Code
       as_tibble_row(set_names(as.list(1:26), paste0("..", 1:26)))
     Condition
-      Error:
+      Error in `as_tibble_row()`:
       ! Columns 1, 2, 3, 4, 5, and 21 more must not have names of the form ... or ..j.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:

--- a/tests/testthat/_snaps/enframe.md
+++ b/tests/testthat/_snaps/enframe.md
@@ -3,7 +3,7 @@
     Code
       enframe(1:3, value = NULL)
     Condition
-      Error:
+      Error in `enframe()`:
       ! `value` can't be NULL.
     Code
       nrow(enframe(Titanic))

--- a/tests/testthat/_snaps/msg.md
+++ b/tests/testthat/_snaps/msg.md
@@ -2,100 +2,92 @@
 
     Code
       # # add
-      error_add_rows_to_grouped_df()
+      print_error(abort_add_rows_to_grouped_df())
     Output
       <error/tibble_error_add_rows_to_grouped_df>
-      Error:
+      Error in `abort_add_rows_to_grouped_df()`:
       ! Can't add rows to grouped data frames.
     Code
-      error_incompatible_new_rows("a")
+      print_error(abort_incompatible_new_rows("a"))
     Output
-      <error/tibble_error_incompatible_new_rows>
-      Error:
-      ! New rows can't add columns.
-      x Can't find column `a` in `.data`.
+      <simpleError in error_unknown_column_names(names): could not find function "error_unknown_column_names">
     Code
-      error_incompatible_new_rows(letters[2:3])
+      print_error(abort_incompatible_new_rows(letters[2:3]))
     Output
-      <error/tibble_error_incompatible_new_rows>
-      Error:
-      ! New rows can't add columns.
-      x Can't find columns `b` and `c` in `.data`.
+      <simpleError in error_unknown_column_names(names): could not find function "error_unknown_column_names">
     Code
-      error_incompatible_new_rows(LETTERS)
+      print_error(abort_incompatible_new_rows(LETTERS))
     Output
-      <error/tibble_error_incompatible_new_rows>
-      Error:
-      ! New rows can't add columns.
-      x Can't find columns `A`, `B`, `C`, `D`, `E`, and 21 more in `.data`.
+      <simpleError in error_unknown_column_names(names): could not find function "error_unknown_column_names">
     Code
-      error_both_before_after()
+      print_error(abort_both_before_after())
     Output
       <error/tibble_error_both_before_after>
-      Error:
+      Error in `abort_both_before_after()`:
       ! Can't specify both `.before` and `.after`.
     Code
-      error_unknown_column_names("a")
+      print_error(abort_unknown_column_names("a"))
     Output
       <error/tibble_error_unknown_column_names>
-      Error:
+      Error in `abort_unknown_column_names()`:
       ! Can't find column `a` in `.data`.
     Code
-      error_unknown_column_names(c("b", "c"))
+      print_error(abort_unknown_column_names(c("b", "c")))
     Output
       <error/tibble_error_unknown_column_names>
-      Error:
+      Error in `abort_unknown_column_names()`:
       ! Can't find columns `b` and `c` in `.data`.
     Code
-      error_unknown_column_names(LETTERS)
+      print_error(abort_unknown_column_names(LETTERS))
     Output
       <error/tibble_error_unknown_column_names>
-      Error:
+      Error in `abort_unknown_column_names()`:
       ! Can't find columns `A`, `B`, `C`, `D`, `E`, and 21 more in `.data`.
     Code
-      error_incompatible_new_cols(10, data.frame(a = 1:2))
+      print_error(abort_incompatible_new_cols(10, data.frame(a = 1:2)))
     Output
       <error/tibble_error_incompatible_new_cols>
-      Error:
+      Error in `abort_incompatible_new_cols()`:
       ! New columns must be compatible with `.data`.
       x New column has 2 rows.
       i `.data` has 10 rows.
     Code
-      error_incompatible_new_cols(1, data.frame(a = 1:3, b = 2:4))
+      print_error(abort_incompatible_new_cols(1, data.frame(a = 1:3, b = 2:4)))
     Output
       <error/tibble_error_incompatible_new_cols>
-      Error:
+      Error in `abort_incompatible_new_cols()`:
       ! New columns must be compatible with `.data`.
       x New columns have 3 rows.
       i `.data` has 1 row.
     Code
       # # as_tibble
-      error_column_scalar_type("a", 3, "environment")
+      print_error(abort_column_scalar_type("a", 3, "environment"))
     Output
       <error/tibble_error_column_scalar_type>
-      Error:
+      Error in `abort_column_scalar_type()`:
       ! All columns in a tibble must be vectors.
       x Column `a` is environment.
     Code
-      error_column_scalar_type("", 3, "environment")
+      print_error(abort_column_scalar_type("", 3, "environment"))
     Output
       <error/tibble_error_column_scalar_type>
-      Error:
+      Error in `abort_column_scalar_type()`:
       ! All columns in a tibble must be vectors.
       x Column 3 is environment.
     Code
-      error_column_scalar_type(letters[2:3], 3:4, c("name", "NULL"))
+      print_error(abort_column_scalar_type(letters[2:3], 3:4, c("name", "NULL")))
     Output
       <error/tibble_error_column_scalar_type>
-      Error:
+      Error in `abort_column_scalar_type()`:
       ! All columns in a tibble must be vectors.
       x Column `b` is name.
       x Column `c` is NULL.
     Code
-      error_column_scalar_type(c("", "", LETTERS), 1:28, c("QQ", "VV", letters))
+      print_error(abort_column_scalar_type(c("", "", LETTERS), 1:28, c("QQ", "VV",
+        letters)))
     Output
       <error/tibble_error_column_scalar_type>
-      Error:
+      Error in `abort_column_scalar_type()`:
       ! All columns in a tibble must be vectors.
       x Column 1 is QQ.
       x Column 2 is VV.
@@ -104,361 +96,366 @@
       x Column `C` is c.
       x ... and 23 more problems.
     Code
-      error_as_tibble_row_vector(new_environment())
+      print_error(abort_as_tibble_row_vector(new_environment()))
     Output
       <error/tibble_error_as_tibble_row_vector>
-      Error:
+      Error in `abort_as_tibble_row_vector()`:
       ! `x` must be a vector in `as_tibble_row()`, not environment.
     Code
-      error_as_tibble_row_size_one(3, "foo", 7)
+      print_error(abort_as_tibble_row_size_one(3, "foo", 7))
     Output
       <error/tibble_error_as_tibble_row_size_one>
-      Error:
+      Error in `abort_as_tibble_row_size_one()`:
       ! All elements must be size one, use `list()` to wrap.
       x Element `foo` is of size 7.
     Code
       # # class-tbl_df
-      error_names_must_be_non_null()
+      print_error(abort_names_must_be_non_null())
     Output
       <error/tibble_error_names_must_be_non_null>
-      Error:
+      Error in `abort_names_must_be_non_null()`:
       ! `names` must not be `NULL`.
     Code
-      error_names_must_have_length(length = 5, n = 3)
+      print_error(abort_names_must_have_length(length = 5, n = 3))
     Output
       <error/tibble_error_names_must_have_length>
-      Error:
+      Error in `abort_names_must_have_length()`:
       ! `names` must have length 3, not 5.
     Code
       # #enframe
-      error_enframe_value_null()
+      print_error(abort_enframe_value_null())
     Output
       <error/tibble_error_enframe_value_null>
-      Error:
+      Error in `abort_enframe_value_null()`:
       ! `value` can't be NULL.
     Code
-      error_enframe_must_be_vector(lm(speed ~ ., cars))
+      print_error(abort_enframe_must_be_vector(lm(speed ~ ., cars)))
     Output
       <error/tibble_error_enframe_must_be_vector>
-      Error:
+      Error in `abort_enframe_must_be_vector()`:
       ! The `x` argument to `enframe()` must be a vector, not lm.
     Code
       # # names
-      error_column_names_cannot_be_empty(1, repair_hint = TRUE)
+      print_error(abort_column_names_cannot_be_empty(1, repair_hint = TRUE))
     Output
       <error/tibble_error_column_names_cannot_be_empty>
-      Error:
+      Error in `abort_column_names_cannot_be_empty()`:
       ! Column 1 must be named.
       Use `.name_repair` to specify repair.
     Code
-      error_column_names_cannot_be_empty(2:3, repair_hint = TRUE)
+      print_error(abort_column_names_cannot_be_empty(2:3, repair_hint = TRUE))
     Output
       <error/tibble_error_column_names_cannot_be_empty>
-      Error:
+      Error in `abort_column_names_cannot_be_empty()`:
       ! Columns 2 and 3 must be named.
       Use `.name_repair` to specify repair.
     Code
-      error_column_names_cannot_be_empty(seq_along(letters), repair_hint = TRUE)
+      print_error(abort_column_names_cannot_be_empty(seq_along(letters), repair_hint = TRUE))
     Output
       <error/tibble_error_column_names_cannot_be_empty>
-      Error:
+      Error in `abort_column_names_cannot_be_empty()`:
       ! Columns 1, 2, 3, 4, 5, and 21 more must be named.
       Use `.name_repair` to specify repair.
     Code
-      error_column_names_cannot_be_empty(4:6, repair_hint = FALSE)
+      print_error(abort_column_names_cannot_be_empty(4:6, repair_hint = FALSE))
     Output
       <error/tibble_error_column_names_cannot_be_empty>
-      Error:
+      Error in `abort_column_names_cannot_be_empty()`:
       ! Columns 4, 5, and 6 must be named.
     Code
-      error_column_names_cannot_be_dot_dot(1, repair_hint = FALSE)
+      print_error(abort_column_names_cannot_be_dot_dot(1, repair_hint = FALSE))
     Output
       <error/tibble_error_column_names_cannot_be_dot_dot>
-      Error:
+      Error in `abort_column_names_cannot_be_dot_dot()`:
       ! Column 1 must not have names of the form ... or ..j.
     Code
-      error_column_names_cannot_be_dot_dot(2:3, repair_hint = TRUE)
+      print_error(abort_column_names_cannot_be_dot_dot(2:3, repair_hint = TRUE))
     Output
       <error/tibble_error_column_names_cannot_be_dot_dot>
-      Error:
+      Error in `abort_column_names_cannot_be_dot_dot()`:
       ! Columns 2 and 3 must not have names of the form ... or ..j.
       Use `.name_repair` to specify repair.
     Code
-      error_column_names_cannot_be_dot_dot(1:26, repair_hint = TRUE)
+      print_error(abort_column_names_cannot_be_dot_dot(1:26, repair_hint = TRUE))
     Output
       <error/tibble_error_column_names_cannot_be_dot_dot>
-      Error:
+      Error in `abort_column_names_cannot_be_dot_dot()`:
       ! Columns 1, 2, 3, 4, 5, and 21 more must not have names of the form ... or ..j.
       Use `.name_repair` to specify repair.
     Code
-      error_column_names_must_be_unique("a", repair_hint = FALSE)
+      print_error(abort_column_names_must_be_unique("a", repair_hint = FALSE))
     Output
       <error/tibble_error_column_names_must_be_unique>
-      Error:
+      Error in `abort_column_names_must_be_unique()`:
       ! Column name `a` must not be duplicated.
     Code
-      error_column_names_must_be_unique(letters[2:3], repair_hint = TRUE)
+      print_error(abort_column_names_must_be_unique(letters[2:3], repair_hint = TRUE))
     Output
       <error/tibble_error_column_names_must_be_unique>
-      Error:
+      Error in `abort_column_names_must_be_unique()`:
       ! Column names `b` and `c` must not be duplicated.
       Use `.name_repair` to specify repair.
     Code
-      error_column_names_must_be_unique(LETTERS, repair_hint = TRUE)
+      print_error(abort_column_names_must_be_unique(LETTERS, repair_hint = TRUE))
     Output
       <error/tibble_error_column_names_must_be_unique>
-      Error:
+      Error in `abort_column_names_must_be_unique()`:
       ! Column names `A`, `B`, `C`, `D`, `E`, and 21 more must not be duplicated.
       Use `.name_repair` to specify repair.
     Code
       # # new
-      error_new_tibble_must_be_list()
+      print_error(abort_new_tibble_must_be_list())
     Output
       <error/tibble_error_new_tibble_must_be_list>
-      Error:
+      Error in `abort_new_tibble_must_be_list()`:
       ! `x` must be a list.
     Code
-      error_new_tibble_nrow_must_be_nonnegative()
+      print_error(abort_new_tibble_nrow_must_be_nonnegative())
     Output
       <error/tibble_error_new_tibble_nrow_must_be_nonnegative>
-      Error:
+      Error in `abort_new_tibble_nrow_must_be_nonnegative()`:
       ! `nrow` must be a nonnegative whole number smaller than 2^31.
     Code
       # # rownames
-      error_already_has_rownames()
+      print_error(abort_already_has_rownames())
     Output
       <error/tibble_error_already_has_rownames>
-      Error:
+      Error in `abort_already_has_rownames()`:
       ! `.data` must be a data frame without row names.
     Code
       # # subsetting
-      error_need_rhs_vector(quote(RHS))
+      print_error(abort_need_rhs_vector(quote(RHS)))
     Output
       <error/tibble_error_need_rhs_vector>
-      Error:
+      Error in `abort_need_rhs_vector()`:
       ! `RHS` must be a vector, a bare list, a data frame or a matrix.
     Code
-      error_need_rhs_vector_or_null(quote(RHS))
+      print_error(abort_need_rhs_vector_or_null(quote(RHS)))
     Output
       <error/tibble_error_need_rhs_vector_or_null>
-      Error:
+      Error in `abort_need_rhs_vector_or_null()`:
       ! `RHS` must be a vector, a bare list, a data frame, a matrix, or NULL.
     Code
-      error_na_column_index(1:3)
+      print_error(abort_na_column_index(1:3))
     Output
       <error/tibble_error_na_column_index>
-      Error:
+      Error in `abort_na_column_index()`:
       ! Can't use NA as column index with `[` at positions 1, 2, and 3.
     Code
-      error_dim_column_index(as.matrix("x"))
+      print_error(abort_dim_column_index(as.matrix("x")))
     Output
       <error/tibble_error_dim_column_index>
-      Error:
+      Error in `abort_dim_column_index()`:
       ! Must use a vector in `[`, not an object of class matrix.
     Code
-      error_assign_columns_non_na_only()
+      print_error(abort_assign_columns_non_na_only())
     Output
       <error/tibble_error_assign_columns_non_na_only>
-      Error:
+      Error in `abort_assign_columns_non_na_only()`:
       ! Can't use NA as column index in a tibble for assignment.
     Code
-      error_subset_columns_non_missing_only()
+      print_error(abort_subset_columns_non_missing_only())
     Output
       <error/tibble_error_subset_columns_non_missing_only>
-      Error:
+      Error in `abort_subset_columns_non_missing_only()`:
       ! Subscript can't be missing for tibbles in `[[`.
     Code
-      error_assign_columns_non_missing_only()
+      print_error(abort_assign_columns_non_missing_only())
     Output
       <error/tibble_error_assign_columns_non_missing_only>
-      Error:
+      Error in `abort_assign_columns_non_missing_only()`:
       ! Subscript can't be missing for tibbles in `[[<-`.
     Code
-      error_duplicate_column_subscript_for_assignment(c(1, 1))
+      print_error(abort_duplicate_column_subscript_for_assignment(c(1, 1)))
     Output
       <error/tibble_error_duplicate_column_subscript_for_assignment>
-      Error:
+      Error in `abort_duplicate_column_subscript_for_assignment()`:
       ! Column index 1 is used more than once for assignment.
     Code
-      error_duplicate_column_subscript_for_assignment(c(1, 1, 2, 2))
+      print_error(abort_duplicate_column_subscript_for_assignment(c(1, 1, 2, 2)))
     Output
       <error/tibble_error_duplicate_column_subscript_for_assignment>
-      Error:
+      Error in `abort_duplicate_column_subscript_for_assignment()`:
       ! Column indexes 1 and 2 are used more than once for assignment.
     Code
-      error_assign_rows_non_na_only()
+      print_error(abort_assign_rows_non_na_only())
     Output
       <error/tibble_error_assign_rows_non_na_only>
-      Error:
+      Error in `abort_assign_rows_non_na_only()`:
       ! Can't use NA as row index in a tibble for assignment.
     Code
-      error_duplicate_row_subscript_for_assignment(c(1, 1))
+      print_error(abort_duplicate_row_subscript_for_assignment(c(1, 1)))
     Output
       <error/tibble_error_duplicate_row_subscript_for_assignment>
-      Error:
+      Error in `abort_duplicate_row_subscript_for_assignment()`:
       ! Row index 1 is used more than once for assignment.
     Code
-      error_duplicate_row_subscript_for_assignment(c(1, 1, 2, 2))
+      print_error(abort_duplicate_row_subscript_for_assignment(c(1, 1, 2, 2)))
     Output
       <error/tibble_error_duplicate_row_subscript_for_assignment>
-      Error:
+      Error in `abort_duplicate_row_subscript_for_assignment()`:
       ! Row indexes 1 and 2 are used more than once for assignment.
     Code
-      error_assign_incompatible_size(3, list(1:2), 1, NULL, quote(rhs))
+      print_error(abort_assign_incompatible_size(3, list(1:2), 1, NULL, quote(rhs)))
     Output
       <error/tibble_error_assign_incompatible_size>
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `rhs` must be compatible with existing data.
       x Existing data has 3 rows.
       x Assigned data has 2 rows.
       i Only vectors of size 1 are recycled.
     Code
-      error_assign_incompatible_size(4, list(1:4, 3:4), 2, quote(4:1), quote(rhs))
+      print_error(abort_assign_incompatible_size(4, list(1:4, 3:4), 2, quote(4:1),
+      quote(rhs)))
     Output
       <error/tibble_error_assign_incompatible_size>
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `rhs` must be compatible with row subscript `4:1`.
       x 4 rows must be assigned.
       x Element 2 of assigned data has 2 rows.
       i Only vectors of size 1 are recycled.
     Code
-      error_assign_incompatible_type(tibble(a = 1), list("c"), 1, quote(rhs),
-      "Can't frobnicate.")
+      print_error(abort_assign_incompatible_type(tibble(a = 1), list("c"), 1, quote(
+        rhs), "Can't frobnicate."))
     Output
       <error/tibble_error_assign_incompatible_type>
-      Error:
+      Error in `abort_assign_incompatible_type()`:
       ! Assigned data `rhs` must be compatible with existing data.
       i Error occurred for column `a`.
       x Can't frobnicate.
     Code
       # # subsetting-matrix
-      error_subset_matrix_must_be_logical(quote(is.na(x) + 1))
+      print_error(abort_subset_matrix_must_be_logical(quote(is.na(x) + 1)))
     Output
       <error/tibble_error_subset_matrix_must_be_logical>
-      Error:
+      Error in `abort_subset_matrix_must_be_logical()`:
       ! Subscript `is.na(x) + 1` is a matrix, it must be of type logical.
     Code
-      error_subset_matrix_must_have_same_dimensions(quote(t(is.na(x))))
+      print_error(abort_subset_matrix_must_have_same_dimensions(quote(t(is.na(x)))))
     Output
       <error/tibble_error_subset_matrix_must_have_same_dimensions>
-      Error:
+      Error in `abort_subset_matrix_must_have_same_dimensions()`:
       ! Subscript `t(is.na(x))` is a matrix, it must have the same dimensions as the input.
     Code
-      error_subset_matrix_scalar_type(quote(is.na(x)), quote(new_environment()))
+      print_error(abort_subset_matrix_scalar_type(quote(is.na(x)), quote(
+        new_environment())))
     Output
       <error/tibble_error_subset_matrix_scalar_type>
-      Error:
+      Error in `abort_subset_matrix_scalar_type()`:
       ! Subscript `is.na(x)` is a matrix, the data `new_environment()` must be a vector of size 1.
     Code
-      error_subset_matrix_must_be_scalar(quote(is.na(x)), quote(1:3))
+      print_error(abort_subset_matrix_must_be_scalar(quote(is.na(x)), quote(1:3)))
     Output
       <error/tibble_error_subset_matrix_must_be_scalar>
-      Error:
+      Error in `abort_subset_matrix_must_be_scalar()`:
       ! Subscript `is.na(x)` is a matrix, the data `1:3` must have size 1.
     Code
       # # tibble
-      error_tibble_row_size_one(3, "foo", 7)
+      print_error(abort_tibble_row_size_one(3, "foo", 7))
     Output
       <error/tibble_error_tibble_row_size_one>
-      Error:
+      Error in `abort_tibble_row_size_one()`:
       ! All vectors must be size one, use `list()` to wrap.
       x Column `foo` is of size 7.
     Code
-      error_incompatible_size(10, letters[1:3], c(4, 4, 3),
-      "Requested with `uvw` argument")
+      print_error(abort_incompatible_size(10, letters[1:3], c(4, 4, 3),
+      "Requested with `uvw` argument"))
     Output
       <error/tibble_error_incompatible_size>
-      Error:
+      Error in `abort_incompatible_size()`:
       ! Tibble columns must have compatible sizes.
       * Size 10: Requested with `uvw` argument.
       * Size 3: Column `c`.
       * Size 4: Columns `a` and `b`.
       i Only values of size one are recycled.
     Code
-      error_incompatible_size(10, letters[1:3], c(2, 2, 3),
-      "Requested with `xyz` argument")
+      print_error(abort_incompatible_size(10, letters[1:3], c(2, 2, 3),
+      "Requested with `xyz` argument"))
     Output
       <error/tibble_error_incompatible_size>
-      Error:
+      Error in `abort_incompatible_size()`:
       ! Tibble columns must have compatible sizes.
       * Size 10: Requested with `xyz` argument.
       * Size 2: Columns `a` and `b`.
       * Size 3: Column `c`.
       i Only values of size one are recycled.
     Code
-      error_incompatible_size(NULL, letters[1:3], c(2, 2, 3),
-      "Requested with `xyz` argument")
+      print_error(abort_incompatible_size(NULL, letters[1:3], c(2, 2, 3),
+      "Requested with `xyz` argument"))
     Output
       <error/tibble_error_incompatible_size>
-      Error:
+      Error in `abort_incompatible_size()`:
       ! Tibble columns must have compatible sizes.
       * Size 2: Columns `a` and `b`.
       * Size 3: Column `c`.
       i Only values of size one are recycled.
     Code
-      error_incompatible_size(10, 1:3, c(4, 4, 3), "Requested with `uvw` argument")
+      print_error(abort_incompatible_size(10, 1:3, c(4, 4, 3),
+      "Requested with `uvw` argument"))
     Output
       <error/tibble_error_incompatible_size>
-      Error:
+      Error in `abort_incompatible_size()`:
       ! Tibble columns must have compatible sizes.
       * Size 10: Requested with `uvw` argument.
       * Size 3: Column at position 3.
       * Size 4: Columns at positions 1 and 2.
       i Only values of size one are recycled.
     Code
-      error_incompatible_size(10, 1:3, c(2, 2, 3), "Requested with `xyz` argument")
+      print_error(abort_incompatible_size(10, 1:3, c(2, 2, 3),
+      "Requested with `xyz` argument"))
     Output
       <error/tibble_error_incompatible_size>
-      Error:
+      Error in `abort_incompatible_size()`:
       ! Tibble columns must have compatible sizes.
       * Size 10: Requested with `xyz` argument.
       * Size 2: Columns at positions 1 and 2.
       * Size 3: Column at position 3.
       i Only values of size one are recycled.
     Code
-      error_incompatible_size(NULL, 1:3, c(2, 2, 3), "Requested with `xyz` argument")
+      print_error(abort_incompatible_size(NULL, 1:3, c(2, 2, 3),
+      "Requested with `xyz` argument"))
     Output
       <error/tibble_error_incompatible_size>
-      Error:
+      Error in `abort_incompatible_size()`:
       ! Tibble columns must have compatible sizes.
       * Size 2: Columns at positions 1 and 2.
       * Size 3: Column at position 3.
       i Only values of size one are recycled.
     Code
       # # tribble
-      error_tribble_needs_columns()
+      print_error(abort_tribble_needs_columns())
     Output
       <error/tibble_error_tribble_needs_columns>
-      Error:
+      Error in `abort_tribble_needs_columns()`:
       ! Must specify at least one column using the `~name` syntax.
     Code
-      error_tribble_lhs_column_syntax(quote(lhs))
+      print_error(abort_tribble_lhs_column_syntax(quote(lhs)))
     Output
       <error/tibble_error_tribble_lhs_column_syntax>
-      Error:
+      Error in `abort_tribble_lhs_column_syntax()`:
       ! All column specifications must use the `~name` syntax.
       x Found `lhs` on the left-hand side of `~`.
     Code
-      error_tribble_rhs_column_syntax(quote(a + b))
+      print_error(abort_tribble_rhs_column_syntax(quote(a + b)))
     Output
       <error/tibble_error_tribble_rhs_column_syntax>
-      Error:
+      Error in `abort_tribble_rhs_column_syntax()`:
       ! All column specifications must use the `~name` or `~"name"` syntax.
       x Found `a + b` on the right-hand side of `~`.
     Code
-      error_tribble_non_rectangular(5, 17)
+      print_error(abort_tribble_non_rectangular(5, 17))
     Output
       <error/tibble_error_tribble_non_rectangular>
-      Error:
+      Error in `abort_tribble_non_rectangular()`:
       ! Data must be rectangular.
       * Found 5 columns.
       * Found 17 cells.
       i 17 is not an integer multiple of 5.
     Code
-      error_frame_matrix_list(2:4)
+      print_error(abort_frame_matrix_list(2:4))
     Output
       <error/tibble_error_frame_matrix_list>
-      Error:
+      Error in `abort_frame_matrix_list()`:
       ! All values must be atomic.
       x Found list-valued elements at positions 2, 3, and 4.
 

--- a/tests/testthat/_snaps/msg.md
+++ b/tests/testthat/_snaps/msg.md
@@ -10,15 +10,24 @@
     Code
       print_error(abort_incompatible_new_rows("a"))
     Output
-      <simpleError in error_unknown_column_names(names): could not find function "error_unknown_column_names">
+      <error/tibble_error_incompatible_new_rows>
+      Error in `abort_incompatible_new_rows()`:
+      ! New rows can't add columns.
+      x Can't find column `a` in `.data`.
     Code
       print_error(abort_incompatible_new_rows(letters[2:3]))
     Output
-      <simpleError in error_unknown_column_names(names): could not find function "error_unknown_column_names">
+      <error/tibble_error_incompatible_new_rows>
+      Error in `abort_incompatible_new_rows()`:
+      ! New rows can't add columns.
+      x Can't find columns `b` and `c` in `.data`.
     Code
       print_error(abort_incompatible_new_rows(LETTERS))
     Output
-      <simpleError in error_unknown_column_names(names): could not find function "error_unknown_column_names">
+      <error/tibble_error_incompatible_new_rows>
+      Error in `abort_incompatible_new_rows()`:
+      ! New rows can't add columns.
+      x Can't find columns `A`, `B`, `C`, `D`, `E`, and 21 more in `.data`.
     Code
       print_error(abort_both_before_after())
     Output

--- a/tests/testthat/_snaps/msg.md
+++ b/tests/testthat/_snaps/msg.md
@@ -316,13 +316,12 @@
       i Only vectors of size 1 are recycled.
     Code
       print_error(abort_assign_incompatible_type(tibble(a = 1), list("c"), 1, quote(
-        rhs), "Can't frobnicate."))
+        rhs)))
     Output
       <error/tibble_error_assign_incompatible_type>
       Error in `abort_assign_incompatible_type()`:
       ! Assigned data `rhs` must be compatible with existing data.
       i Error occurred for column `a`.
-      x Can't frobnicate.
     Code
       # # subsetting-matrix
       print_error(abort_subset_matrix_must_be_logical(quote(is.na(x) + 1)))

--- a/tests/testthat/_snaps/msg.md
+++ b/tests/testthat/_snaps/msg.md
@@ -332,6 +332,12 @@
       ! Assigned data `rhs` must be compatible with existing data.
       i Error occurred for column `a`.
     Code
+      print_error(abort_assign_vector(list("c"), 1, quote(rhs)))
+    Output
+      <error/tibble_error_assign_vector>
+      Error in `abort_assign_vector()`:
+      ! Assigned data `rhs` must be a vector.
+    Code
       # # subsetting-matrix
       print_error(abort_subset_matrix_must_be_logical(quote(is.na(x) + 1)))
     Output

--- a/tests/testthat/_snaps/names.md
+++ b/tests/testthat/_snaps/names.md
@@ -7,7 +7,7 @@
     Code
       repaired_names("", repair_hint = FALSE)
     Condition
-      Error in `abort_column_names_cannot_be_empty()`:
+      Error in `repaired_names()`:
       ! Column 1 must be named.
       Caused by error in `repaired_names()`:
       ! Names can't be empty.
@@ -15,7 +15,7 @@
     Code
       repaired_names("", repair_hint = TRUE)
     Condition
-      Error in `abort_column_names_cannot_be_empty()`:
+      Error in `repaired_names()`:
       ! Column 1 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -33,7 +33,7 @@
     Code
       repaired_names("..1", repair_hint = FALSE)
     Condition
-      Error in `abort_column_names_cannot_be_dot_dot()`:
+      Error in `repaired_names()`:
       ! Column 1 must not have names of the form ... or ..j.
       Caused by error in `repaired_names()`:
       ! Names can't be of the form `...` or `..j`.

--- a/tests/testthat/_snaps/names.md
+++ b/tests/testthat/_snaps/names.md
@@ -7,38 +7,23 @@
     Code
       repaired_names("", repair_hint = FALSE)
     Condition
-      Error:
-      ! Column 1 must be named.
-      Caused by error in `repaired_names()`:
-      ! Names can't be empty.
-      x Empty name found at location 1.
+      Error in `error_column_names_cannot_be_empty()`:
+      ! could not find function "error_column_names_cannot_be_empty"
     Code
       repaired_names("", repair_hint = TRUE)
     Condition
-      Error:
-      ! Column 1 must be named.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names can't be empty.
-      x Empty name found at location 1.
+      Error in `error_column_names_cannot_be_empty()`:
+      ! could not find function "error_column_names_cannot_be_empty"
     Code
       repaired_names(c("a", "a"), repair_hint = FALSE)
     Condition
-      Error:
-      ! Column name `a` must not be duplicated.
-      Caused by error in `repaired_names()`:
-      ! Names must be unique.
-      x These names are duplicated:
-        * "a" at locations 1 and 2.
+      Error in `error_column_names_must_be_unique()`:
+      ! could not find function "error_column_names_must_be_unique"
     Code
       repaired_names("..1", repair_hint = FALSE)
     Condition
-      Error:
-      ! Column 1 must not have names of the form ... or ..j.
-      Caused by error in `repaired_names()`:
-      ! Names can't be of the form `...` or `..j`.
-      x These names are invalid:
-        * "..1" at location 1.
+      Error in `error_column_names_cannot_be_dot_dot()`:
+      ! could not find function "error_column_names_cannot_be_dot_dot"
     Code
       repaired_names(c("a", "a"), repair_hint = FALSE, .name_repair = "universal")
     Message

--- a/tests/testthat/_snaps/names.md
+++ b/tests/testthat/_snaps/names.md
@@ -7,7 +7,7 @@
     Code
       repaired_names("", repair_hint = FALSE)
     Condition
-      Error:
+      Error in `abort_column_names_cannot_be_empty()`:
       ! Column 1 must be named.
       Caused by error in `repaired_names()`:
       ! Names can't be empty.
@@ -15,7 +15,7 @@
     Code
       repaired_names("", repair_hint = TRUE)
     Condition
-      Error:
+      Error in `abort_column_names_cannot_be_empty()`:
       ! Column 1 must be named.
       Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
@@ -24,7 +24,7 @@
     Code
       repaired_names(c("a", "a"), repair_hint = FALSE)
     Condition
-      Error:
+      Error in `repaired_names()`:
       ! Column name `a` must not be duplicated.
       Caused by error in `repaired_names()`:
       ! Names must be unique.
@@ -33,7 +33,7 @@
     Code
       repaired_names("..1", repair_hint = FALSE)
     Condition
-      Error:
+      Error in `abort_column_names_cannot_be_dot_dot()`:
       ! Column 1 must not have names of the form ... or ..j.
       Caused by error in `repaired_names()`:
       ! Names can't be of the form `...` or `..j`.

--- a/tests/testthat/_snaps/names.md
+++ b/tests/testthat/_snaps/names.md
@@ -7,23 +7,38 @@
     Code
       repaired_names("", repair_hint = FALSE)
     Condition
-      Error in `error_column_names_cannot_be_empty()`:
-      ! could not find function "error_column_names_cannot_be_empty"
+      Error:
+      ! Column 1 must be named.
+      Caused by error in `repaired_names()`:
+      ! Names can't be empty.
+      x Empty name found at location 1.
     Code
       repaired_names("", repair_hint = TRUE)
     Condition
-      Error in `error_column_names_cannot_be_empty()`:
-      ! could not find function "error_column_names_cannot_be_empty"
+      Error:
+      ! Column 1 must be named.
+      Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names can't be empty.
+      x Empty name found at location 1.
     Code
       repaired_names(c("a", "a"), repair_hint = FALSE)
     Condition
-      Error in `error_column_names_must_be_unique()`:
-      ! could not find function "error_column_names_must_be_unique"
+      Error:
+      ! Column name `a` must not be duplicated.
+      Caused by error in `repaired_names()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 2.
     Code
       repaired_names("..1", repair_hint = FALSE)
     Condition
-      Error in `error_column_names_cannot_be_dot_dot()`:
-      ! could not find function "error_column_names_cannot_be_dot_dot"
+      Error:
+      ! Column 1 must not have names of the form ... or ..j.
+      Caused by error in `repaired_names()`:
+      ! Names can't be of the form `...` or `..j`.
+      x These names are invalid:
+        * "..1" at location 1.
     Code
       repaired_names(c("a", "a"), repair_hint = FALSE, .name_repair = "universal")
     Message

--- a/tests/testthat/_snaps/new.md
+++ b/tests/testthat/_snaps/new.md
@@ -3,11 +3,11 @@
     Code
       new_tibble(1:3, nrow = 1)
     Condition
-      Error:
+      Error in `new_tibble()`:
       ! `x` must be a list.
     Code
       new_tibble(as.list(1:3))
     Condition
-      Error:
+      Error in `new_tibble()`:
       ! `names` must not be `NULL`.
 

--- a/tests/testthat/_snaps/rownames.md
+++ b/tests/testthat/_snaps/rownames.md
@@ -3,13 +3,21 @@
     Code
       rownames_to_column(mtcars, "cyl")
     Condition
-      Error in `error_column_names_must_be_unique()`:
-      ! could not find function "error_column_names_must_be_unique"
+      Error:
+      ! Column name `cyl` must not be duplicated.
+      Caused by error in `repaired_names()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "cyl" at locations 2 and 12.
     Code
       rowid_to_column(trees, "Volume")
     Condition
-      Error in `error_column_names_must_be_unique()`:
-      ! could not find function "error_column_names_must_be_unique"
+      Error:
+      ! Column name `Volume` must not be duplicated.
+      Caused by error in `repaired_names()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "Volume" at locations 3 and 4.
     Code
       column_to_rownames(mtcars, "cyl")
     Condition

--- a/tests/testthat/_snaps/rownames.md
+++ b/tests/testthat/_snaps/rownames.md
@@ -3,7 +3,7 @@
     Code
       rownames_to_column(mtcars, "cyl")
     Condition
-      Error:
+      Error in `rownames_to_column()`:
       ! Column name `cyl` must not be duplicated.
       Caused by error in `repaired_names()`:
       ! Names must be unique.
@@ -12,7 +12,7 @@
     Code
       rowid_to_column(trees, "Volume")
     Condition
-      Error:
+      Error in `rowid_to_column()`:
       ! Column name `Volume` must not be duplicated.
       Caused by error in `repaired_names()`:
       ! Names must be unique.

--- a/tests/testthat/_snaps/rownames.md
+++ b/tests/testthat/_snaps/rownames.md
@@ -3,29 +3,21 @@
     Code
       rownames_to_column(mtcars, "cyl")
     Condition
-      Error:
-      ! Column name `cyl` must not be duplicated.
-      Caused by error in `repaired_names()`:
-      ! Names must be unique.
-      x These names are duplicated:
-        * "cyl" at locations 2 and 12.
+      Error in `error_column_names_must_be_unique()`:
+      ! could not find function "error_column_names_must_be_unique"
     Code
       rowid_to_column(trees, "Volume")
     Condition
-      Error:
-      ! Column name `Volume` must not be duplicated.
-      Caused by error in `repaired_names()`:
-      ! Names must be unique.
-      x These names are duplicated:
-        * "Volume" at locations 3 and 4.
+      Error in `error_column_names_must_be_unique()`:
+      ! could not find function "error_column_names_must_be_unique"
     Code
       column_to_rownames(mtcars, "cyl")
     Condition
-      Error:
+      Error in `column_to_rownames()`:
       ! `.data` must be a data frame without row names.
     Code
       column_to_rownames(trees, "foo")
     Condition
-      Error:
+      Error in `column_to_rownames()`:
       ! Can't find column `foo` in `.data`.
 

--- a/tests/testthat/_snaps/subsetting-matrix.md
+++ b/tests/testthat/_snaps/subsetting-matrix.md
@@ -3,8 +3,6 @@
     Code
       foo[m] <- 1
     Condition
-      Error:
-      ! Assigned data `1` must be compatible with existing data.
-      i Error occurred for column `z`.
-      x Can't convert <double> to <character>.
+      Error in `error_assign_incompatible_type()`:
+      ! could not find function "error_assign_incompatible_type"
 

--- a/tests/testthat/_snaps/subsetting-matrix.md
+++ b/tests/testthat/_snaps/subsetting-matrix.md
@@ -3,6 +3,8 @@
     Code
       foo[m] <- 1
     Condition
-      Error in `error_assign_incompatible_type()`:
-      ! could not find function "error_assign_incompatible_type"
+      Error:
+      ! Assigned data `1` must be compatible with existing data.
+      i Error occurred for column `z`.
+      x Can't convert <double> to <character>.
 

--- a/tests/testthat/_snaps/subsetting-matrix.md
+++ b/tests/testthat/_snaps/subsetting-matrix.md
@@ -3,8 +3,9 @@
     Code
       foo[m] <- 1
     Condition
-      Error:
+      Error in `[<-.tbl_df`:
       ! Assigned data `1` must be compatible with existing data.
       i Error occurred for column `z`.
-      x Can't convert <double> to <character>.
+      Caused by error in `vec_assign()`:
+      ! Can't convert <double> to <character>.
 

--- a/tests/testthat/_snaps/subsetting-matrix.md
+++ b/tests/testthat/_snaps/subsetting-matrix.md
@@ -3,7 +3,7 @@
     Code
       foo[m] <- 1
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Assigned data `1` must be compatible with existing data.
       i Error occurred for column `z`.
       Caused by error in `vec_assign()`:

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -725,31 +725,35 @@
       df <- tibble(x = 1:3, y = letters[1:3], z = as.list(1:3))
       df[1:3, 1:2] <- df[2:3]
     Condition
-      Error in `abort_assign_incompatible_type()`:
+      Error in `[<-.tbl_df`:
       ! Assigned data `df[2:3]` must be compatible with existing data.
       i Error occurred for column `x`.
-      x Can't convert <character> to <integer>.
+      Caused by error in `vec_assign()`:
+      ! Can't convert <character> to <integer>.
     Code
       df[1:3, 1:2] <- df[1]
     Condition
-      Error in `abort_assign_incompatible_type()`:
+      Error in `[<-.tbl_df`:
       ! Assigned data `df[1]` must be compatible with existing data.
       i Error occurred for column `y`.
-      x Can't convert <integer> to <character>.
+      Caused by error in `vec_assign()`:
+      ! Can't convert <integer> to <character>.
     Code
       df[1:3, 1:2] <- df[[1]]
     Condition
-      Error in `abort_assign_incompatible_type()`:
+      Error in `[<-.tbl_df`:
       ! Assigned data `df[[1]]` must be compatible with existing data.
       i Error occurred for column `y`.
-      x Can't convert <integer> to <character>.
+      Caused by error in `vec_assign()`:
+      ! Can't convert <integer> to <character>.
     Code
       df[1:3, 1:3] <- df[3:1]
     Condition
-      Error in `abort_assign_incompatible_type()`:
+      Error in `[<-.tbl_df`:
       ! Assigned data `df[3:1]` must be compatible with existing data.
       i Error occurred for column `x`.
-      x Can't convert <list> to <integer>.
+      Caused by error in `vec_assign()`:
+      ! Can't convert <list> to <integer>.
     Code
       df[1:3, 1:3] <- NULL
     Condition
@@ -822,10 +826,11 @@
       foo <- tibble(a = 1:3, b = letters[1:3])
       foo[!is.na(foo)] <- "bogus"
     Condition
-      Error:
+      Error in `[<-.tbl_df`:
       ! Assigned data `"bogus"` must be compatible with existing data.
       i Error occurred for column `a`.
-      x Can't convert <character> to <integer>.
+      Caused by error in `vec_assign()`:
+      ! Can't convert <character> to <integer>.
     Code
       foo[as.matrix("x")] <- NA
     Condition

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -936,27 +936,27 @@
     Code
       foo[[1:3, 1]] <- 1
     Condition
-      Error in `[[<-.tbl_df`:
+      Error in `[[<-`:
       ! Must assign to row with a single valid subscript.
       x Subscript `1:3` has size 3 but must be size 1.
     Code
       foo[[TRUE, 1]] <- 1
     Condition
-      Error in `[[<-.tbl_df`:
+      Error in `[[<-`:
       ! Must assign to row with a single valid subscript.
       x Subscript `TRUE` has the wrong type `logical`.
       i It must be numeric or character.
     Code
       foo[[mean, 1]] <- 1
     Condition
-      Error in `[[<-.tbl_df`:
+      Error in `[[<-`:
       ! Must assign to row with a single valid subscript.
       x Subscript `mean` has the wrong type `function`.
       i It must be numeric or character.
     Code
       foo[[foo, 1]] <- 1
     Condition
-      Error in `[[<-.tbl_df`:
+      Error in `[[<-`:
       ! Must assign to row with a single valid subscript.
       x Subscript `foo` has the wrong type `tbl_df<
         x: integer

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -5,13 +5,13 @@
       foo <- tibble(x = 1:10, y = 1:10)
       foo[c("x", "y", "z")]
     Condition
-      Error in `foo[c("x", "y", "z")]`:
+      Error in `[.tbl_df`:
       ! Can't subset columns that don't exist.
       x Column `z` doesn't exist.
     Code
       foo[c("w", "x", "y", "z")]
     Condition
-      Error in `foo[c("w", "x", "y", "z")]`:
+      Error in `[.tbl_df`:
       ! Can't subset columns that don't exist.
       x Columns `w` and `z` don't exist.
     Code
@@ -22,7 +22,7 @@
     Code
       foo[array("x", dim = c(1, 1, 1))]
     Condition
-      Error in `foo[array("x", dim = c(1, 1, 1))]`:
+      Error in `[.tbl_df`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `array("x", dim = c(1, 1, 1))` must be a simple vector, not an array.
     Code
@@ -30,41 +30,41 @@
       foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
       foo[0.5]
     Condition
-      Error in `foo[0.5]`:
+      Error in `[.tbl_df`:
       ! Must subset columns with a valid subscript vector.
       x Can't convert from `j` <double> to <integer> due to loss of precision.
     Code
       foo[1:5]
     Condition
-      Error in `foo[1:5]`:
+      Error in `[.tbl_df`:
       ! Can't subset columns past the end.
       i Locations 4 and 5 don't exist.
       i There are only 3 columns.
     Code
       foo[-1:1]
     Condition
-      Error in `foo[-1:1]`:
+      Error in `[.tbl_df`:
       ! Must subset columns with a valid subscript vector.
       x Negative and positive locations can't be mixed.
       i Subscript `-1:1` has a positive value at location 3.
     Code
       foo[c(-1, 1)]
     Condition
-      Error in `foo[c(-1, 1)]`:
+      Error in `[.tbl_df`:
       ! Must subset columns with a valid subscript vector.
       x Negative and positive locations can't be mixed.
       i Subscript `c(-1, 1)` has a positive value at location 2.
     Code
       foo[c(-1, NA)]
     Condition
-      Error in `foo[c(-1, NA)]`:
+      Error in `[.tbl_df`:
       ! Must subset columns with a valid subscript vector.
       x Negative locations can't have missing values.
       i Subscript `c(-1, NA)` has a missing value at location 2.
     Code
       foo[-4]
     Condition
-      Error in `foo[-4]`:
+      Error in `[.tbl_df`:
       ! Can't negate columns past the end.
       i Location 4 doesn't exist.
       i There are only 3 columns.
@@ -81,20 +81,20 @@
     Code
       foo[array(1, dim = c(1, 1, 1))]
     Condition
-      Error in `foo[array(1, dim = c(1, 1, 1))]`:
+      Error in `[.tbl_df`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `array(1, dim = c(1, 1, 1))` must be a simple vector, not an array.
     Code
       foo[mean]
     Condition
-      Error in `foo[mean]`:
+      Error in `[.tbl_df`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `mean` has the wrong type `function`.
       i It must be logical, numeric, or character.
     Code
       foo[foo]
     Condition
-      Error in `foo[foo]`:
+      Error in `[.tbl_df`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `foo` has the wrong type `tbl_df<
         x: integer
@@ -172,14 +172,14 @@
       foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
       foo[c(TRUE, TRUE)]
     Condition
-      Error in `foo[c(TRUE, TRUE)]`:
+      Error in `[.tbl_df`:
       ! Must subset columns with a valid subscript vector.
       i Logical subscripts must match the size of the indexed input.
       x Input has size 3 but subscript `c(TRUE, TRUE)` has size 2.
     Code
       foo[c(TRUE, TRUE, FALSE, FALSE)]
     Condition
-      Error in `foo[c(TRUE, TRUE, FALSE, FALSE)]`:
+      Error in `[.tbl_df`:
       ! Must subset columns with a valid subscript vector.
       i Logical subscripts must match the size of the indexed input.
       x Input has size 3 but subscript `c(TRUE, TRUE, FALSE, FALSE)` has size 4.
@@ -196,7 +196,7 @@
     Code
       foo[array(TRUE, dim = c(1, 1, 1))]
     Condition
-      Error in `foo[array(TRUE, dim = c(1, 1, 1))]`:
+      Error in `[.tbl_df`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `array(TRUE, dim = c(1, 1, 1))` must be a simple vector, not an array.
     Code
@@ -226,27 +226,27 @@
       foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
       foo[list(1:3)]
     Condition
-      Error in `foo[list(1:3)]`:
+      Error in `[.tbl_df`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
     Code
       foo[as.list(1:3)]
     Condition
-      Error in `foo[as.list(1:3)]`:
+      Error in `[.tbl_df`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `as.list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
     Code
       foo[factor(1:3)]
     Condition
-      Error in `foo[factor(1:3)]`:
+      Error in `[.tbl_df`:
       ! Can't subset columns that don't exist.
       x Columns `1`, `2`, and `3` don't exist.
     Code
       foo[Sys.Date()]
     Condition
-      Error in `foo[Sys.Date()]`:
+      Error in `[.tbl_df`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `Sys.Date()` has the wrong type `date`.
       i It must be logical, numeric, or character.
@@ -297,7 +297,7 @@
     Code
       foo[array("x", dim = c(1, 1, 1))]
     Condition
-      Error in `foo[array("x", dim = c(1, 1, 1))]`:
+      Error in `[.tbl_df`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `array("x", dim = c(1, 1, 1))` must be a simple vector, not an array.
     Code
@@ -354,32 +354,32 @@
     Code
       foo[[1:3]]
     Condition
-      Error in `vectbl_as_col_location2()`:
+      Error in `foo[[1:3]]`:
       ! Must extract column with a single valid subscript.
       x Subscript `1:3` has size 3 but must be size 1.
     Code
       foo[[letters[1:3]]]
     Condition
-      Error in `vectbl_as_col_location2()`:
+      Error in `foo[[letters[1:3]]]`:
       ! Must extract column with a single valid subscript.
       x Subscript `letters[1:3]` has size 3 but must be size 1.
     Code
       foo[[TRUE]]
     Condition
-      Error in `vectbl_as_col_location2()`:
+      Error in `foo[[TRUE]]`:
       ! Must extract column with a single valid subscript.
       x Subscript `TRUE` has the wrong type `logical`.
       i It must be numeric or character.
     Code
       foo[[-1]]
     Condition
-      Error in `vectbl_as_col_location2()`:
+      Error in `foo[[-1]]`:
       ! Must extract column with a single valid subscript.
       x Subscript `-1` has value -1 but must be a positive location.
     Code
       foo[[1.5]]
     Condition
-      Error in `vectbl_as_col_location2()`:
+      Error in `foo[[1.5]]`:
       ! Must extract column with a single valid subscript.
       x Subscript `1.5` has the wrong type `double`.
       i It must be numeric or character.
@@ -393,14 +393,14 @@
     Code
       foo[[Inf]]
     Condition
-      Error in `vectbl_as_col_location2()`:
+      Error in `foo[[Inf]]`:
       ! Must extract column with a single valid subscript.
       x Subscript `Inf` has the wrong type `double`.
       i It must be numeric or character.
     Code
       foo[[mean]]
     Condition
-      Error in `vectbl_as_col_location2()`:
+      Error in `foo[[mean]]`:
       ! Must extract column with a single valid subscript.
       x Subscript `mean` has the wrong type `function`.
       i It must be numeric or character.
@@ -419,7 +419,7 @@
       foo <- tibble(x = 1:10, y = 1:10)
       foo[[NA]]
     Condition
-      Error in `vectbl_as_col_location2()`:
+      Error in `foo[[NA]]`:
       ! Must extract column with a single valid subscript.
       x Subscript `NA` can't be `NA`.
     Code
@@ -443,27 +443,27 @@
       foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
       foo[list(1:3)] <- 1
     Condition
-      Error in `[<-`:
+      Error in `[<-.tbl_df`:
       ! Must assign to columns with a valid subscript vector.
       x Subscript `list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
     Code
       foo[as.list(1:3)] <- 1
     Condition
-      Error in `[<-`:
+      Error in `[<-.tbl_df`:
       ! Must assign to columns with a valid subscript vector.
       x Subscript `as.list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
     Code
       foo[factor(1:3)] <- 1
     Condition
-      Error in `[<-`:
+      Error in `[<-.tbl_df`:
       ! Can't assign to columns that don't exist.
       x Columns `1`, `2`, and `3` don't exist.
     Code
       foo[Sys.Date()] <- 1
     Condition
-      Error in `[<-`:
+      Error in `[<-.tbl_df`:
       ! Must assign to columns with a valid subscript vector.
       x Subscript `Sys.Date()` has the wrong type `date`.
       i It must be logical, numeric, or character.
@@ -894,32 +894,32 @@
     Code
       foo[[1:3]] <- 1
     Condition
-      Error in `vectbl_as_col_location2()`:
+      Error in `[[<-`:
       ! Must assign to column with a single valid subscript.
       x Subscript `1:3` has size 3 but must be size 1.
     Code
       foo[[letters[1:3]]] <- 1
     Condition
-      Error in `vectbl_as_col_location2()`:
+      Error in `[[<-`:
       ! Must assign to column with a single valid subscript.
       x Subscript `letters[1:3]` has size 3 but must be size 1.
     Code
       foo[[TRUE]] <- 1
     Condition
-      Error in `vectbl_as_col_location2()`:
+      Error in `[[<-`:
       ! Must assign to column with a single valid subscript.
       x Subscript `TRUE` has the wrong type `logical`.
       i It must be numeric or character.
     Code
       foo[[NA_integer_]] <- 1
     Condition
-      Error in `vectbl_as_col_location2()`:
+      Error in `[[<-`:
       ! Must assign to column with a single valid subscript.
       x Subscript `NA_integer_` can't be `NA`.
     Code
       foo[[mean]] <- 1
     Condition
-      Error in `vectbl_as_col_location2()`:
+      Error in `[[<-`:
       ! Must assign to column with a single valid subscript.
       x Subscript `mean` has the wrong type `function`.
       i It must be numeric or character.

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -17,7 +17,7 @@
     Code
       foo[as.matrix("x")]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[as.matrix("x")]`:
       ! Subscript `as.matrix("x")` is a matrix, it must be of type logical.
     Code
       foo[array("x", dim = c(1, 1, 1))]
@@ -71,12 +71,12 @@
     Code
       foo[c(1:3, NA)]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[c(1:3, NA)]`:
       ! Can't use NA as column index with `[` at position 4.
     Code
       foo[as.matrix(1)]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[as.matrix(1)]`:
       ! Subscript `as.matrix(1)` is a matrix, it must be of type logical.
     Code
       foo[array(1, dim = c(1, 1, 1))]
@@ -186,12 +186,12 @@
     Code
       foo[c(TRUE, TRUE, NA)]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[c(TRUE, TRUE, NA)]`:
       ! Can't use NA as column index with `[` at position 3.
     Code
       foo[as.matrix(TRUE)]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[as.matrix(TRUE)]`:
       ! Subscript `as.matrix(TRUE)` is a matrix, it must have the same dimensions as the input.
     Code
       foo[array(TRUE, dim = c(1, 1, 1))]
@@ -292,7 +292,7 @@
     Code
       foo[as.matrix("x")]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[as.matrix("x")]`:
       ! Subscript `as.matrix("x")` is a matrix, it must be of type logical.
     Code
       foo[array("x", dim = c(1, 1, 1))]
@@ -334,22 +334,22 @@
       foo <- tibble(x = 1:10, y = 1:10)
       foo[[]]
     Condition
-      Error in `[[.tbl_df`:
+      Error in `foo[[]]`:
       ! Subscript can't be missing for tibbles in `[[`.
     Code
       foo[[, 1]]
     Condition
-      Error in `[[.tbl_df`:
+      Error in `foo[[, 1]]`:
       ! Subscript can't be missing for tibbles in `[[`.
     Code
       foo[[1, ]]
     Condition
-      Error in `[[.tbl_df`:
+      Error in `foo[[1, ]]`:
       ! Subscript can't be missing for tibbles in `[[`.
     Code
       foo[[, ]]
     Condition
-      Error in `[[.tbl_df`:
+      Error in `foo[[, ]]`:
       ! Subscript can't be missing for tibbles in `[[`.
     Code
       foo[[1:3]]
@@ -514,29 +514,29 @@
       df <- tibble(x = 1:2, y = x)
       df[c(1, 1)] <- 3
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Column index 1 is used more than once for assignment.
     Code
       df[, c(1, 1)] <- 3
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Column index 1 is used more than once for assignment.
     Code
       df[c(1, 1), ] <- 3
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Row index 1 is used more than once for assignment.
     Code
       # # [<-.tbl_df throws an error with NA indexes
       df <- tibble(x = 1:2, y = x)
       df[NA] <- 3
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Can't use NA as column index with `[` at positions 1 and 2.
     Code
       df[NA, ] <- 3
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Can't use NA as row index in a tibble for assignment.
     Code
       # # [<-.tbl_df and logical indexes
@@ -563,12 +563,12 @@
       df <- tibble(x = 1:2, y = x)
       df[] <- mean
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! `mean` must be a vector, a bare list, a data frame, a matrix, or NULL.
     Code
       df[] <- lm(y ~ x, df)
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! `lm(y ~ x, df)` must be a vector, a bare list, a data frame, a matrix, or NULL.
     Code
       # # [<-.tbl_df throws an error with OOB assignment
@@ -779,7 +779,7 @@
     Code
       df[1:3, 1:3] <- NULL
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! `NULL` must be a vector, a bare list, a data frame or a matrix.
     Code
       # # [<-.tbl_df and overwriting NA
@@ -856,40 +856,40 @@
     Code
       foo[as.matrix("x")] <- NA
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Subscript `as.matrix("x")` is a matrix, it must be of type logical.
     Code
       foo[array("x", dim = c(1, 1, 1))] <- NA
       foo[is.na(foo)] <- 1:3
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Subscript `is.na(foo)` is a matrix, the data `1:3` must have size 1.
     Code
       foo[is.na(foo)] <- lm(a ~ b, foo)
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Subscript `is.na(foo)` is a matrix, the data `lm(a ~ b, foo)` must be a vector of size 1.
     Code
       # # [[<-.tbl_df rejects invalid column indexes
       foo <- tibble(x = 1:10, y = 1:10)
       foo[[]] <- 1
     Condition
-      Error in `[[<-.tbl_df`:
+      Error in `[[<-`:
       ! Subscript can't be missing for tibbles in `[[<-`.
     Code
       foo[[, 1]] <- 1
     Condition
-      Error in `[[<-.tbl_df`:
+      Error in `[[<-`:
       ! Subscript can't be missing for tibbles in `[[<-`.
     Code
       foo[[1, ]] <- 1
     Condition
-      Error in `[[<-.tbl_df`:
+      Error in `[[<-`:
       ! Subscript can't be missing for tibbles in `[[<-`.
     Code
       foo[[, ]] <- 1
     Condition
-      Error in `[[<-.tbl_df`:
+      Error in `[[<-`:
       ! Subscript can't be missing for tibbles in `[[<-`.
     Code
       foo[[1:3]] <- 1
@@ -1021,12 +1021,12 @@
       df <- tibble(x = 1:2, y = x)
       df[1] <- lm(y ~ x, df)
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! `lm(y ~ x, df)` must be a vector, a bare list, a data frame, a matrix, or NULL.
     Code
       df[1:2, 1] <- NULL
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! `NULL` must be a vector, a bare list, a data frame or a matrix.
     Code
       # # $<- recycles only values of length one

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -386,7 +386,7 @@
     Code
       foo[[3]]
     Condition
-      Error in `vectbl_as_col_location2()`:
+      Error in `foo[[3]]`:
       ! Can't subset columns past the end.
       i Location 3 doesn't exist.
       i There are only 2 columns.
@@ -407,7 +407,7 @@
     Code
       foo[[foo]]
     Condition
-      Error in `vectbl_as_col_subscript2()`:
+      Error in `foo[[foo]]`:
       ! Must extract column with a single valid subscript.
       x Subscript `foo` has the wrong type `tbl_df<
         x: integer
@@ -926,7 +926,7 @@
     Code
       foo[[foo]] <- 1
     Condition
-      Error in `vectbl_as_col_subscript2()`:
+      Error in `[[<-`:
       ! Must assign to column with a single valid subscript.
       x Subscript `foo` has the wrong type `tbl_df<
         x: integer

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -615,18 +615,27 @@
     Code
       df[1, ] <- 1:3
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `1:3` must be compatible with row subscript `1`.
+      x 1 row must be assigned.
+      x Assigned data has 3 rows.
+      i Row updates require a list value. Do you need `list()` or `as.list()`?
     Code
       df[1:2, ] <- 1:3
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `1:3` must be compatible with row subscript `1:2`.
+      x 2 rows must be assigned.
+      x Assigned data has 3 rows.
+      i Only vectors of size 1 are recycled.
     Code
       df[, ] <- 1:2
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `1:2` must be compatible with existing data.
+      x Existing data has 3 rows.
+      x Assigned data has 2 rows.
+      i Only vectors of size 1 are recycled.
     Code
       df[1, ] <- list(a = 1:3, b = 1)
     Condition
@@ -650,43 +659,67 @@
     Code
       df[1, 1:2] <- list(a = 1:3, b = 1)
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `list(a = 1:3, b = 1)` must be compatible with row subscript `1`.
+      x 1 row must be assigned.
+      x Element 1 of assigned data has 3 rows.
+      i Row updates require a list value. Do you need `list()` or `as.list()`?
     Code
       df[1, 1:2] <- list(a = 1, b = 1:3)
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `list(a = 1, b = 1:3)` must be compatible with row subscript `1`.
+      x 1 row must be assigned.
+      x Element 2 of assigned data has 3 rows.
+      i Row updates require a list value. Do you need `list()` or `as.list()`?
     Code
       df[1:2, 1:2] <- list(a = 1:3, b = 1)
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `list(a = 1:3, b = 1)` must be compatible with row subscript `1:2`.
+      x 2 rows must be assigned.
+      x Element 1 of assigned data has 3 rows.
+      i Only vectors of size 1 are recycled.
     Code
       df[1:2, 1:2] <- list(a = 1, b = 1:3)
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `list(a = 1, b = 1:3)` must be compatible with row subscript `1:2`.
+      x 2 rows must be assigned.
+      x Element 2 of assigned data has 3 rows.
+      i Only vectors of size 1 are recycled.
     Code
       df[1, ] <- list(a = 1:3, b = 1, c = 1:3)
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `list(a = 1:3, b = 1, c = 1:3)` must be compatible with row subscript `1`.
+      x 1 row must be assigned.
+      x Element 1 of assigned data has 3 rows.
+      i Row updates require a list value. Do you need `list()` or `as.list()`?
     Code
       df[1, ] <- list(a = 1, b = 1:3, c = 1:3)
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `list(a = 1, b = 1:3, c = 1:3)` must be compatible with row subscript `1`.
+      x 1 row must be assigned.
+      x Element 2 of assigned data has 3 rows.
+      i Row updates require a list value. Do you need `list()` or `as.list()`?
     Code
       df[1:2, ] <- list(a = 1:3, b = 1, c = 1:3)
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `list(a = 1:3, b = 1, c = 1:3)` must be compatible with row subscript `1:2`.
+      x 2 rows must be assigned.
+      x Element 1 of assigned data has 3 rows.
+      i Only vectors of size 1 are recycled.
     Code
       df[1:2, ] <- list(a = 1, b = 1:3, c = 1:3)
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `list(a = 1, b = 1:3, c = 1:3)` must be compatible with row subscript `1:2`.
+      x 2 rows must be assigned.
+      x Element 2 of assigned data has 3 rows.
+      i Only vectors of size 1 are recycled.
     Code
       # # [<-.tbl_df and coercion
       df <- tibble(x = 1:3, y = letters[1:3], z = as.list(1:3))
@@ -789,8 +822,10 @@
       foo <- tibble(a = 1:3, b = letters[1:3])
       foo[!is.na(foo)] <- "bogus"
     Condition
-      Error in `error_assign_incompatible_type()`:
-      ! could not find function "error_assign_incompatible_type"
+      Error:
+      ! Assigned data `"bogus"` must be compatible with existing data.
+      i Error occurred for column `a`.
+      x Can't convert <character> to <integer>.
     Code
       foo[as.matrix("x")] <- NA
     Condition
@@ -927,18 +962,27 @@
       df <- tibble(x = 1:3)
       df[["x"]] <- 8:9
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `8:9` must be compatible with existing data.
+      x Existing data has 3 rows.
+      x Assigned data has 2 rows.
+      i Only vectors of size 1 are recycled.
     Code
       df[["w"]] <- 8:9
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `8:9` must be compatible with existing data.
+      x Existing data has 3 rows.
+      x Assigned data has 2 rows.
+      i Only vectors of size 1 are recycled.
     Code
       df[["a"]] <- character()
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `character()` must be compatible with existing data.
+      x Existing data has 3 rows.
+      x Assigned data has 0 rows.
+      i Only vectors of size 1 are recycled.
     Code
       # # [<-.tbl_df throws an error with invalid values
       df <- tibble(x = 1:2, y = x)
@@ -956,16 +1000,25 @@
       df <- tibble(x = 1:3)
       df$x <- 8:9
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `8:9` must be compatible with existing data.
+      x Existing data has 3 rows.
+      x Assigned data has 2 rows.
+      i Only vectors of size 1 are recycled.
     Code
       df$w <- 8:9
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `8:9` must be compatible with existing data.
+      x Existing data has 3 rows.
+      x Assigned data has 2 rows.
+      i Only vectors of size 1 are recycled.
     Code
       df$a <- character()
     Condition
-      Error in `error_assign_incompatible_size()`:
-      ! could not find function "error_assign_incompatible_size"
+      Error:
+      ! Assigned data `character()` must be compatible with existing data.
+      x Existing data has 3 rows.
+      x Assigned data has 0 rows.
+      i Only vectors of size 1 are recycled.
 

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -582,21 +582,21 @@
     Code
       df[4:5, ] <- 3
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Can't assign to rows beyond the end with non-consecutive locations.
       i Input has size 2.
       x Subscript `4:5` contains non-consecutive location 4.
     Code
       df[-4, ] <- 3
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Can't negate rows past the end.
       i Location 4 doesn't exist.
       i There are only 2 rows.
     Code
       df[-(4:5), ] <- 3
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Can't negate rows past the end.
       i Locations 4 and 5 don't exist.
       i There are only 2 rows.

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -17,7 +17,7 @@
     Code
       foo[as.matrix("x")]
     Condition
-      Error:
+      Error in `[.tbl_df`:
       ! Subscript `as.matrix("x")` is a matrix, it must be of type logical.
     Code
       foo[array("x", dim = c(1, 1, 1))]
@@ -71,12 +71,12 @@
     Code
       foo[c(1:3, NA)]
     Condition
-      Error:
+      Error in `[.tbl_df`:
       ! Can't use NA as column index with `[` at position 4.
     Code
       foo[as.matrix(1)]
     Condition
-      Error:
+      Error in `[.tbl_df`:
       ! Subscript `as.matrix(1)` is a matrix, it must be of type logical.
     Code
       foo[array(1, dim = c(1, 1, 1))]
@@ -186,12 +186,12 @@
     Code
       foo[c(TRUE, TRUE, NA)]
     Condition
-      Error:
+      Error in `[.tbl_df`:
       ! Can't use NA as column index with `[` at position 3.
     Code
       foo[as.matrix(TRUE)]
     Condition
-      Error:
+      Error in `[.tbl_df`:
       ! Subscript `as.matrix(TRUE)` is a matrix, it must have the same dimensions as the input.
     Code
       foo[array(TRUE, dim = c(1, 1, 1))]
@@ -292,7 +292,7 @@
     Code
       foo[as.matrix("x")]
     Condition
-      Error:
+      Error in `[.tbl_df`:
       ! Subscript `as.matrix("x")` is a matrix, it must be of type logical.
     Code
       foo[array("x", dim = c(1, 1, 1))]
@@ -334,22 +334,22 @@
       foo <- tibble(x = 1:10, y = 1:10)
       foo[[]]
     Condition
-      Error:
+      Error in `[[.tbl_df`:
       ! Subscript can't be missing for tibbles in `[[`.
     Code
       foo[[, 1]]
     Condition
-      Error:
+      Error in `[[.tbl_df`:
       ! Subscript can't be missing for tibbles in `[[`.
     Code
       foo[[1, ]]
     Condition
-      Error:
+      Error in `[[.tbl_df`:
       ! Subscript can't be missing for tibbles in `[[`.
     Code
       foo[[, ]]
     Condition
-      Error:
+      Error in `[[.tbl_df`:
       ! Subscript can't be missing for tibbles in `[[`.
     Code
       foo[[1:3]]
@@ -514,29 +514,29 @@
       df <- tibble(x = 1:2, y = x)
       df[c(1, 1)] <- 3
     Condition
-      Error:
+      Error in `[<-.tbl_df`:
       ! Column index 1 is used more than once for assignment.
     Code
       df[, c(1, 1)] <- 3
     Condition
-      Error:
+      Error in `[<-.tbl_df`:
       ! Column index 1 is used more than once for assignment.
     Code
       df[c(1, 1), ] <- 3
     Condition
-      Error:
+      Error in `[<-.tbl_df`:
       ! Row index 1 is used more than once for assignment.
     Code
       # # [<-.tbl_df throws an error with NA indexes
       df <- tibble(x = 1:2, y = x)
       df[NA] <- 3
     Condition
-      Error:
+      Error in `[<-.tbl_df`:
       ! Can't use NA as column index with `[` at positions 1 and 2.
     Code
       df[NA, ] <- 3
     Condition
-      Error:
+      Error in `[<-.tbl_df`:
       ! Can't use NA as row index in a tibble for assignment.
     Code
       # # [<-.tbl_df and logical indexes
@@ -563,12 +563,12 @@
       df <- tibble(x = 1:2, y = x)
       df[] <- mean
     Condition
-      Error:
+      Error in `[<-.tbl_df`:
       ! `mean` must be a vector, a bare list, a data frame, a matrix, or NULL.
     Code
       df[] <- lm(y ~ x, df)
     Condition
-      Error:
+      Error in `[<-.tbl_df`:
       ! `lm(y ~ x, df)` must be a vector, a bare list, a data frame, a matrix, or NULL.
     Code
       # # [<-.tbl_df throws an error with OOB assignment
@@ -615,27 +615,18 @@
     Code
       df[1, ] <- 1:3
     Condition
-      Error:
-      ! Assigned data `1:3` must be compatible with row subscript `1`.
-      x 1 row must be assigned.
-      x Assigned data has 3 rows.
-      i Row updates require a list value. Do you need `list()` or `as.list()`?
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       df[1:2, ] <- 1:3
     Condition
-      Error:
-      ! Assigned data `1:3` must be compatible with row subscript `1:2`.
-      x 2 rows must be assigned.
-      x Assigned data has 3 rows.
-      i Only vectors of size 1 are recycled.
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       df[, ] <- 1:2
     Condition
-      Error:
-      ! Assigned data `1:2` must be compatible with existing data.
-      x Existing data has 3 rows.
-      x Assigned data has 2 rows.
-      i Only vectors of size 1 are recycled.
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       df[1, ] <- list(a = 1:3, b = 1)
     Condition
@@ -659,101 +650,77 @@
     Code
       df[1, 1:2] <- list(a = 1:3, b = 1)
     Condition
-      Error:
-      ! Assigned data `list(a = 1:3, b = 1)` must be compatible with row subscript `1`.
-      x 1 row must be assigned.
-      x Element 1 of assigned data has 3 rows.
-      i Row updates require a list value. Do you need `list()` or `as.list()`?
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       df[1, 1:2] <- list(a = 1, b = 1:3)
     Condition
-      Error:
-      ! Assigned data `list(a = 1, b = 1:3)` must be compatible with row subscript `1`.
-      x 1 row must be assigned.
-      x Element 2 of assigned data has 3 rows.
-      i Row updates require a list value. Do you need `list()` or `as.list()`?
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       df[1:2, 1:2] <- list(a = 1:3, b = 1)
     Condition
-      Error:
-      ! Assigned data `list(a = 1:3, b = 1)` must be compatible with row subscript `1:2`.
-      x 2 rows must be assigned.
-      x Element 1 of assigned data has 3 rows.
-      i Only vectors of size 1 are recycled.
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       df[1:2, 1:2] <- list(a = 1, b = 1:3)
     Condition
-      Error:
-      ! Assigned data `list(a = 1, b = 1:3)` must be compatible with row subscript `1:2`.
-      x 2 rows must be assigned.
-      x Element 2 of assigned data has 3 rows.
-      i Only vectors of size 1 are recycled.
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       df[1, ] <- list(a = 1:3, b = 1, c = 1:3)
     Condition
-      Error:
-      ! Assigned data `list(a = 1:3, b = 1, c = 1:3)` must be compatible with row subscript `1`.
-      x 1 row must be assigned.
-      x Element 1 of assigned data has 3 rows.
-      i Row updates require a list value. Do you need `list()` or `as.list()`?
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       df[1, ] <- list(a = 1, b = 1:3, c = 1:3)
     Condition
-      Error:
-      ! Assigned data `list(a = 1, b = 1:3, c = 1:3)` must be compatible with row subscript `1`.
-      x 1 row must be assigned.
-      x Element 2 of assigned data has 3 rows.
-      i Row updates require a list value. Do you need `list()` or `as.list()`?
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       df[1:2, ] <- list(a = 1:3, b = 1, c = 1:3)
     Condition
-      Error:
-      ! Assigned data `list(a = 1:3, b = 1, c = 1:3)` must be compatible with row subscript `1:2`.
-      x 2 rows must be assigned.
-      x Element 1 of assigned data has 3 rows.
-      i Only vectors of size 1 are recycled.
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       df[1:2, ] <- list(a = 1, b = 1:3, c = 1:3)
     Condition
-      Error:
-      ! Assigned data `list(a = 1, b = 1:3, c = 1:3)` must be compatible with row subscript `1:2`.
-      x 2 rows must be assigned.
-      x Element 2 of assigned data has 3 rows.
-      i Only vectors of size 1 are recycled.
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       # # [<-.tbl_df and coercion
       df <- tibble(x = 1:3, y = letters[1:3], z = as.list(1:3))
       df[1:3, 1:2] <- df[2:3]
     Condition
-      Error:
+      Error in `abort_assign_incompatible_type()`:
       ! Assigned data `df[2:3]` must be compatible with existing data.
       i Error occurred for column `x`.
       x Can't convert <character> to <integer>.
     Code
       df[1:3, 1:2] <- df[1]
     Condition
-      Error:
+      Error in `abort_assign_incompatible_type()`:
       ! Assigned data `df[1]` must be compatible with existing data.
       i Error occurred for column `y`.
       x Can't convert <integer> to <character>.
     Code
       df[1:3, 1:2] <- df[[1]]
     Condition
-      Error:
+      Error in `abort_assign_incompatible_type()`:
       ! Assigned data `df[[1]]` must be compatible with existing data.
       i Error occurred for column `y`.
       x Can't convert <integer> to <character>.
     Code
       df[1:3, 1:3] <- df[3:1]
     Condition
-      Error:
+      Error in `abort_assign_incompatible_type()`:
       ! Assigned data `df[3:1]` must be compatible with existing data.
       i Error occurred for column `x`.
       x Can't convert <list> to <integer>.
     Code
       df[1:3, 1:3] <- NULL
     Condition
-      Error:
+      Error in `[<-.tbl_df`:
       ! `NULL` must be a vector, a bare list, a data frame or a matrix.
     Code
       # # [<-.tbl_df and overwriting NA
@@ -822,47 +789,45 @@
       foo <- tibble(a = 1:3, b = letters[1:3])
       foo[!is.na(foo)] <- "bogus"
     Condition
-      Error:
-      ! Assigned data `"bogus"` must be compatible with existing data.
-      i Error occurred for column `a`.
-      x Can't convert <character> to <integer>.
+      Error in `error_assign_incompatible_type()`:
+      ! could not find function "error_assign_incompatible_type"
     Code
       foo[as.matrix("x")] <- NA
     Condition
-      Error:
+      Error in `[<-.tbl_df`:
       ! Subscript `as.matrix("x")` is a matrix, it must be of type logical.
     Code
       foo[array("x", dim = c(1, 1, 1))] <- NA
       foo[is.na(foo)] <- 1:3
     Condition
-      Error:
+      Error in `[<-.tbl_df`:
       ! Subscript `is.na(foo)` is a matrix, the data `1:3` must have size 1.
     Code
       foo[is.na(foo)] <- lm(a ~ b, foo)
     Condition
-      Error:
+      Error in `[<-.tbl_df`:
       ! Subscript `is.na(foo)` is a matrix, the data `lm(a ~ b, foo)` must be a vector of size 1.
     Code
       # # [[<-.tbl_df rejects invalid column indexes
       foo <- tibble(x = 1:10, y = 1:10)
       foo[[]] <- 1
     Condition
-      Error:
+      Error in `[[<-.tbl_df`:
       ! Subscript can't be missing for tibbles in `[[<-`.
     Code
       foo[[, 1]] <- 1
     Condition
-      Error:
+      Error in `[[<-.tbl_df`:
       ! Subscript can't be missing for tibbles in `[[<-`.
     Code
       foo[[1, ]] <- 1
     Condition
-      Error:
+      Error in `[[<-.tbl_df`:
       ! Subscript can't be missing for tibbles in `[[<-`.
     Code
       foo[[, ]] <- 1
     Condition
-      Error:
+      Error in `[[<-.tbl_df`:
       ! Subscript can't be missing for tibbles in `[[<-`.
     Code
       foo[[1:3]] <- 1
@@ -962,63 +927,45 @@
       df <- tibble(x = 1:3)
       df[["x"]] <- 8:9
     Condition
-      Error:
-      ! Assigned data `8:9` must be compatible with existing data.
-      x Existing data has 3 rows.
-      x Assigned data has 2 rows.
-      i Only vectors of size 1 are recycled.
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       df[["w"]] <- 8:9
     Condition
-      Error:
-      ! Assigned data `8:9` must be compatible with existing data.
-      x Existing data has 3 rows.
-      x Assigned data has 2 rows.
-      i Only vectors of size 1 are recycled.
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       df[["a"]] <- character()
     Condition
-      Error:
-      ! Assigned data `character()` must be compatible with existing data.
-      x Existing data has 3 rows.
-      x Assigned data has 0 rows.
-      i Only vectors of size 1 are recycled.
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       # # [<-.tbl_df throws an error with invalid values
       df <- tibble(x = 1:2, y = x)
       df[1] <- lm(y ~ x, df)
     Condition
-      Error:
+      Error in `[<-.tbl_df`:
       ! `lm(y ~ x, df)` must be a vector, a bare list, a data frame, a matrix, or NULL.
     Code
       df[1:2, 1] <- NULL
     Condition
-      Error:
+      Error in `[<-.tbl_df`:
       ! `NULL` must be a vector, a bare list, a data frame or a matrix.
     Code
       # # $<- recycles only values of length one
       df <- tibble(x = 1:3)
       df$x <- 8:9
     Condition
-      Error:
-      ! Assigned data `8:9` must be compatible with existing data.
-      x Existing data has 3 rows.
-      x Assigned data has 2 rows.
-      i Only vectors of size 1 are recycled.
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       df$w <- 8:9
     Condition
-      Error:
-      ! Assigned data `8:9` must be compatible with existing data.
-      x Existing data has 3 rows.
-      x Assigned data has 2 rows.
-      i Only vectors of size 1 are recycled.
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
     Code
       df$a <- character()
     Condition
-      Error:
-      ! Assigned data `character()` must be compatible with existing data.
-      x Existing data has 3 rows.
-      x Assigned data has 0 rows.
-      i Only vectors of size 1 are recycled.
+      Error in `error_assign_incompatible_size()`:
+      ! could not find function "error_assign_incompatible_size"
 

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -977,12 +977,16 @@
       df <- tibble(x = 1:2, y = x)
       df[[1]] <- mean
     Condition
-      Error in `vec_size()`:
+      Error in `[[<-`:
+      ! Assigned data `mean` must be a vector.
+      Caused by error in `vec_size()`:
       ! `x` must be a vector, not a function.
     Code
       df[[1]] <- lm(y ~ x, df)
     Condition
-      Error in `vec_size()`:
+      Error in `[[<-`:
+      ! Assigned data `lm(y ~ x, df)` must be a vector.
+      Caused by error in `vec_size()`:
       ! `x` must be a vector, not a <lm> object.
     Code
       # # [[<-.tbl_df recycles only values of length one

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -610,7 +610,7 @@
     Code
       df[] <- list(0, 0)
     Condition
-      Error in `vectbl_recycle_rhs_cols()`:
+      Error in `[<-`:
       ! Can't recycle input of size 2 to size 3.
     Code
       df[1, ] <- 1:3
@@ -645,22 +645,22 @@
     Code
       df[1, ] <- list(a = 1:3, b = 1)
     Condition
-      Error in `vectbl_recycle_rhs_cols()`:
+      Error in `[<-`:
       ! Can't recycle input of size 2 to size 3.
     Code
       df[1, ] <- list(a = 1, b = 1:3)
     Condition
-      Error in `vectbl_recycle_rhs_cols()`:
+      Error in `[<-`:
       ! Can't recycle input of size 2 to size 3.
     Code
       df[1:2, ] <- list(a = 1:3, b = 1)
     Condition
-      Error in `vectbl_recycle_rhs_cols()`:
+      Error in `[<-`:
       ! Can't recycle input of size 2 to size 3.
     Code
       df[1:2, ] <- list(a = 1, b = 1:3)
     Condition
-      Error in `vectbl_recycle_rhs_cols()`:
+      Error in `[<-`:
       ! Can't recycle input of size 2 to size 3.
     Code
       df[1, 1:2] <- list(a = 1:3, b = 1)

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -107,7 +107,7 @@
       foo <- tibble(x = 1:3, y = 1:3, z = 1:3)
       foo[0.5, ]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[0.5, ]`:
       ! Must subset rows with a valid subscript vector.
       x Can't convert from `i` <double> to <integer> due to loss of precision.
     Code
@@ -119,21 +119,21 @@
     Code
       foo[-1:1, ]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[-1:1, ]`:
       ! Must subset rows with a valid subscript vector.
       x Negative and positive locations can't be mixed.
       i Subscript `-1:1` has a positive value at location 3.
     Code
       foo[c(-1, 1), ]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[c(-1, 1), ]`:
       ! Must subset rows with a valid subscript vector.
       x Negative and positive locations can't be mixed.
       i Subscript `c(-1, 1)` has a positive value at location 2.
     Code
       foo[c(-1, NA), ]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[c(-1, NA), ]`:
       ! Must subset rows with a valid subscript vector.
       x Negative locations can't have missing values.
       i Subscript `c(-1, NA)` has a missing value at location 2.
@@ -146,20 +146,20 @@
     Code
       foo[array(1, dim = c(1, 1, 1)), ]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[array(1, dim = c(1, 1, 1)), ]`:
       ! Must subset rows with a valid subscript vector.
       x Subscript `array(1, dim = c(1, 1, 1))` must be a simple vector, not an array.
     Code
       foo[mean, ]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[mean, ]`:
       ! Must subset rows with a valid subscript vector.
       x Subscript `mean` has the wrong type `function`.
       i It must be logical, numeric, or character.
     Code
       foo[foo, ]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[foo, ]`:
       ! Must subset rows with a valid subscript vector.
       x Subscript `foo` has the wrong type `tbl_df<
         x: integer
@@ -204,21 +204,21 @@
       foo <- tibble(x = 1:3, y = 1:3, z = 1:3)
       foo[c(TRUE, TRUE), ]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[c(TRUE, TRUE), ]`:
       ! Must subset rows with a valid subscript vector.
       i Logical subscripts must match the size of the indexed input.
       x Input has size 3 but subscript `c(TRUE, TRUE)` has size 2.
     Code
       foo[c(TRUE, TRUE, FALSE, FALSE), ]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[c(TRUE, TRUE, FALSE, FALSE), ]`:
       ! Must subset rows with a valid subscript vector.
       i Logical subscripts must match the size of the indexed input.
       x Input has size 3 but subscript `c(TRUE, TRUE, FALSE, FALSE)` has size 4.
     Code
       foo[array(TRUE, dim = c(1, 1, 1)), ]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[array(TRUE, dim = c(1, 1, 1)), ]`:
       ! Must subset rows with a valid subscript vector.
       x Subscript `array(TRUE, dim = c(1, 1, 1))` must be a simple vector, not an array.
     Code
@@ -255,14 +255,14 @@
       foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
       foo[list(1:3), ]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[list(1:3), ]`:
       ! Must subset rows with a valid subscript vector.
       x Subscript `list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
     Code
       foo[as.list(1:3), ]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[as.list(1:3), ]`:
       ! Must subset rows with a valid subscript vector.
       x Subscript `as.list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
@@ -274,7 +274,7 @@
     Code
       foo[Sys.Date(), ]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[Sys.Date(), ]`:
       ! Must subset rows with a valid subscript vector.
       x Subscript `Sys.Date()` has the wrong type `date`.
       i It must be logical, numeric, or character.
@@ -325,7 +325,7 @@
       foo <- tibble(a = 1:4, b = a)
       foo[c(TRUE, FALSE), ]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[c(TRUE, FALSE), ]`:
       ! Must subset rows with a valid subscript vector.
       i Logical subscripts must match the size of the indexed input.
       x Input has size 4 but subscript `c(TRUE, FALSE)` has size 2.
@@ -486,14 +486,14 @@
       foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
       foo[list(1:3), ] <- 1
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Must assign to rows with a valid subscript vector.
       x Subscript `list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
     Code
       foo[as.list(1:3), ] <- 1
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Must assign to rows with a valid subscript vector.
       x Subscript `as.list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
@@ -505,7 +505,7 @@
     Code
       foo[Sys.Date(), ] <- 1
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Must assign to rows with a valid subscript vector.
       x Subscript `Sys.Date()` has the wrong type `date`.
       i It must be logical, numeric, or character.

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -107,7 +107,7 @@
       foo <- tibble(x = 1:3, y = 1:3, z = 1:3)
       foo[0.5, ]
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[.tbl_df`:
       ! Must subset rows with a valid subscript vector.
       x Can't convert from `i` <double> to <integer> due to loss of precision.
     Code
@@ -119,21 +119,21 @@
     Code
       foo[-1:1, ]
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[.tbl_df`:
       ! Must subset rows with a valid subscript vector.
       x Negative and positive locations can't be mixed.
       i Subscript `-1:1` has a positive value at location 3.
     Code
       foo[c(-1, 1), ]
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[.tbl_df`:
       ! Must subset rows with a valid subscript vector.
       x Negative and positive locations can't be mixed.
       i Subscript `c(-1, 1)` has a positive value at location 2.
     Code
       foo[c(-1, NA), ]
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[.tbl_df`:
       ! Must subset rows with a valid subscript vector.
       x Negative locations can't have missing values.
       i Subscript `c(-1, NA)` has a missing value at location 2.
@@ -146,20 +146,20 @@
     Code
       foo[array(1, dim = c(1, 1, 1)), ]
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[.tbl_df`:
       ! Must subset rows with a valid subscript vector.
       x Subscript `array(1, dim = c(1, 1, 1))` must be a simple vector, not an array.
     Code
       foo[mean, ]
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[.tbl_df`:
       ! Must subset rows with a valid subscript vector.
       x Subscript `mean` has the wrong type `function`.
       i It must be logical, numeric, or character.
     Code
       foo[foo, ]
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[.tbl_df`:
       ! Must subset rows with a valid subscript vector.
       x Subscript `foo` has the wrong type `tbl_df<
         x: integer
@@ -204,21 +204,21 @@
       foo <- tibble(x = 1:3, y = 1:3, z = 1:3)
       foo[c(TRUE, TRUE), ]
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[.tbl_df`:
       ! Must subset rows with a valid subscript vector.
       i Logical subscripts must match the size of the indexed input.
       x Input has size 3 but subscript `c(TRUE, TRUE)` has size 2.
     Code
       foo[c(TRUE, TRUE, FALSE, FALSE), ]
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[.tbl_df`:
       ! Must subset rows with a valid subscript vector.
       i Logical subscripts must match the size of the indexed input.
       x Input has size 3 but subscript `c(TRUE, TRUE, FALSE, FALSE)` has size 4.
     Code
       foo[array(TRUE, dim = c(1, 1, 1)), ]
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[.tbl_df`:
       ! Must subset rows with a valid subscript vector.
       x Subscript `array(TRUE, dim = c(1, 1, 1))` must be a simple vector, not an array.
     Code
@@ -255,14 +255,14 @@
       foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
       foo[list(1:3), ]
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[.tbl_df`:
       ! Must subset rows with a valid subscript vector.
       x Subscript `list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
     Code
       foo[as.list(1:3), ]
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[.tbl_df`:
       ! Must subset rows with a valid subscript vector.
       x Subscript `as.list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
@@ -274,7 +274,7 @@
     Code
       foo[Sys.Date(), ]
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[.tbl_df`:
       ! Must subset rows with a valid subscript vector.
       x Subscript `Sys.Date()` has the wrong type `date`.
       i It must be logical, numeric, or character.
@@ -325,7 +325,7 @@
       foo <- tibble(a = 1:4, b = a)
       foo[c(TRUE, FALSE), ]
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[.tbl_df`:
       ! Must subset rows with a valid subscript vector.
       i Logical subscripts must match the size of the indexed input.
       x Input has size 4 but subscript `c(TRUE, FALSE)` has size 2.
@@ -486,14 +486,14 @@
       foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
       foo[list(1:3), ] <- 1
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[<-.tbl_df`:
       ! Must assign to rows with a valid subscript vector.
       x Subscript `list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
     Code
       foo[as.list(1:3), ] <- 1
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[<-.tbl_df`:
       ! Must assign to rows with a valid subscript vector.
       x Subscript `as.list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
@@ -505,7 +505,7 @@
     Code
       foo[Sys.Date(), ] <- 1
     Condition
-      Error in `vectbl_as_row_location()`:
+      Error in `[<-.tbl_df`:
       ! Must assign to rows with a valid subscript vector.
       x Subscript `Sys.Date()` has the wrong type `date`.
       i It must be logical, numeric, or character.
@@ -582,21 +582,21 @@
     Code
       df[4:5, ] <- 3
     Condition
-      Error in `numtbl_as_row_location_assign()`:
+      Error in `[<-.tbl_df`:
       ! Can't assign to rows beyond the end with non-consecutive locations.
       i Input has size 2.
       x Subscript `4:5` contains non-consecutive location 4.
     Code
       df[-4, ] <- 3
     Condition
-      Error in `numtbl_as_row_location_assign()`:
+      Error in `[<-.tbl_df`:
       ! Can't negate rows past the end.
       i Location 4 doesn't exist.
       i There are only 2 rows.
     Code
       df[-(4:5), ] <- 3
     Condition
-      Error in `numtbl_as_row_location_assign()`:
+      Error in `[<-.tbl_df`:
       ! Can't negate rows past the end.
       i Locations 4 and 5 don't exist.
       i There are only 2 rows.
@@ -936,27 +936,27 @@
     Code
       foo[[1:3, 1]] <- 1
     Condition
-      Error in `vectbl_as_row_location2()`:
+      Error in `[[<-.tbl_df`:
       ! Must assign to row with a single valid subscript.
       x Subscript `1:3` has size 3 but must be size 1.
     Code
       foo[[TRUE, 1]] <- 1
     Condition
-      Error in `vectbl_as_row_location2()`:
+      Error in `[[<-.tbl_df`:
       ! Must assign to row with a single valid subscript.
       x Subscript `TRUE` has the wrong type `logical`.
       i It must be numeric or character.
     Code
       foo[[mean, 1]] <- 1
     Condition
-      Error in `vectbl_as_row_location2()`:
+      Error in `[[<-.tbl_df`:
       ! Must assign to row with a single valid subscript.
       x Subscript `mean` has the wrong type `function`.
       i It must be numeric or character.
     Code
       foo[[foo, 1]] <- 1
     Condition
-      Error in `vectbl_as_row_location2()`:
+      Error in `[[<-.tbl_df`:
       ! Must assign to row with a single valid subscript.
       x Subscript `foo` has the wrong type `tbl_df<
         x: integer

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -605,7 +605,7 @@
       df <- tibble(x = 1:3, y = x, z = y)
       df[1:2] <- list(0, 0, 0)
     Condition
-      Error in `vectbl_as_new_col_index()`:
+      Error in `[<-`:
       ! Can't recycle `list(0, 0, 0)` (size 3) to size 2.
     Code
       df[] <- list(0, 0)

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -848,7 +848,7 @@
       foo <- tibble(a = 1:3, b = letters[1:3])
       foo[!is.na(foo)] <- "bogus"
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Assigned data `"bogus"` must be compatible with existing data.
       i Error occurred for column `a`.
       Caused by error in `vec_assign()`:

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -615,7 +615,7 @@
     Code
       df[1, ] <- 1:3
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `[<-`:
       ! Assigned data `1:3` must be compatible with row subscript `1`.
       x 1 row must be assigned.
       x Assigned data has 3 rows.
@@ -625,7 +625,7 @@
     Code
       df[1:2, ] <- 1:3
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `[<-`:
       ! Assigned data `1:3` must be compatible with row subscript `1:2`.
       x 2 rows must be assigned.
       x Assigned data has 3 rows.
@@ -635,7 +635,7 @@
     Code
       df[, ] <- 1:2
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `[<-`:
       ! Assigned data `1:2` must be compatible with existing data.
       x Existing data has 3 rows.
       x Assigned data has 2 rows.
@@ -665,7 +665,7 @@
     Code
       df[1, 1:2] <- list(a = 1:3, b = 1)
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `[<-`:
       ! Assigned data `list(a = 1:3, b = 1)` must be compatible with row subscript `1`.
       x 1 row must be assigned.
       x Element 1 of assigned data has 3 rows.
@@ -675,7 +675,7 @@
     Code
       df[1, 1:2] <- list(a = 1, b = 1:3)
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `[<-`:
       ! Assigned data `list(a = 1, b = 1:3)` must be compatible with row subscript `1`.
       x 1 row must be assigned.
       x Element 2 of assigned data has 3 rows.
@@ -685,7 +685,7 @@
     Code
       df[1:2, 1:2] <- list(a = 1:3, b = 1)
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `[<-`:
       ! Assigned data `list(a = 1:3, b = 1)` must be compatible with row subscript `1:2`.
       x 2 rows must be assigned.
       x Element 1 of assigned data has 3 rows.
@@ -695,7 +695,7 @@
     Code
       df[1:2, 1:2] <- list(a = 1, b = 1:3)
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `[<-`:
       ! Assigned data `list(a = 1, b = 1:3)` must be compatible with row subscript `1:2`.
       x 2 rows must be assigned.
       x Element 2 of assigned data has 3 rows.
@@ -705,7 +705,7 @@
     Code
       df[1, ] <- list(a = 1:3, b = 1, c = 1:3)
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `[<-`:
       ! Assigned data `list(a = 1:3, b = 1, c = 1:3)` must be compatible with row subscript `1`.
       x 1 row must be assigned.
       x Element 1 of assigned data has 3 rows.
@@ -715,7 +715,7 @@
     Code
       df[1, ] <- list(a = 1, b = 1:3, c = 1:3)
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `[<-`:
       ! Assigned data `list(a = 1, b = 1:3, c = 1:3)` must be compatible with row subscript `1`.
       x 1 row must be assigned.
       x Element 2 of assigned data has 3 rows.
@@ -725,7 +725,7 @@
     Code
       df[1:2, ] <- list(a = 1:3, b = 1, c = 1:3)
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `[<-`:
       ! Assigned data `list(a = 1:3, b = 1, c = 1:3)` must be compatible with row subscript `1:2`.
       x 2 rows must be assigned.
       x Element 1 of assigned data has 3 rows.
@@ -735,7 +735,7 @@
     Code
       df[1:2, ] <- list(a = 1, b = 1:3, c = 1:3)
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `[<-`:
       ! Assigned data `list(a = 1, b = 1:3, c = 1:3)` must be compatible with row subscript `1:2`.
       x 2 rows must be assigned.
       x Element 2 of assigned data has 3 rows.
@@ -989,7 +989,7 @@
       df <- tibble(x = 1:3)
       df[["x"]] <- 8:9
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `[[<-`:
       ! Assigned data `8:9` must be compatible with existing data.
       x Existing data has 3 rows.
       x Assigned data has 2 rows.
@@ -999,7 +999,7 @@
     Code
       df[["w"]] <- 8:9
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `[[<-`:
       ! Assigned data `8:9` must be compatible with existing data.
       x Existing data has 3 rows.
       x Assigned data has 2 rows.
@@ -1009,7 +1009,7 @@
     Code
       df[["a"]] <- character()
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `[[<-`:
       ! Assigned data `character()` must be compatible with existing data.
       x Existing data has 3 rows.
       x Assigned data has 0 rows.
@@ -1033,7 +1033,7 @@
       df <- tibble(x = 1:3)
       df$x <- 8:9
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `$<-`:
       ! Assigned data `8:9` must be compatible with existing data.
       x Existing data has 3 rows.
       x Assigned data has 2 rows.
@@ -1043,7 +1043,7 @@
     Code
       df$w <- 8:9
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `$<-`:
       ! Assigned data `8:9` must be compatible with existing data.
       x Existing data has 3 rows.
       x Assigned data has 2 rows.
@@ -1053,7 +1053,7 @@
     Code
       df$a <- character()
     Condition
-      Error in `abort_assign_incompatible_size()`:
+      Error in `$<-`:
       ! Assigned data `character()` must be compatible with existing data.
       x Existing data has 3 rows.
       x Assigned data has 0 rows.

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -443,27 +443,27 @@
       foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
       foo[list(1:3)] <- 1
     Condition
-      Error in `vectbl_as_new_col_index()`:
+      Error in `[<-`:
       ! Must assign to columns with a valid subscript vector.
       x Subscript `list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
     Code
       foo[as.list(1:3)] <- 1
     Condition
-      Error in `vectbl_as_new_col_index()`:
+      Error in `[<-`:
       ! Must assign to columns with a valid subscript vector.
       x Subscript `as.list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
     Code
       foo[factor(1:3)] <- 1
     Condition
-      Error in `vectbl_as_new_col_index()`:
+      Error in `[<-`:
       ! Can't assign to columns that don't exist.
       x Columns `1`, `2`, and `3` don't exist.
     Code
       foo[Sys.Date()] <- 1
     Condition
-      Error in `vectbl_as_new_col_index()`:
+      Error in `[<-`:
       ! Must assign to columns with a valid subscript vector.
       x Subscript `Sys.Date()` has the wrong type `date`.
       i It must be logical, numeric, or character.

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -5,13 +5,13 @@
       foo <- tibble(x = 1:10, y = 1:10)
       foo[c("x", "y", "z")]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[c("x", "y", "z")]`:
       ! Can't subset columns that don't exist.
       x Column `z` doesn't exist.
     Code
       foo[c("w", "x", "y", "z")]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[c("w", "x", "y", "z")]`:
       ! Can't subset columns that don't exist.
       x Columns `w` and `z` don't exist.
     Code
@@ -22,7 +22,7 @@
     Code
       foo[array("x", dim = c(1, 1, 1))]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[array("x", dim = c(1, 1, 1))]`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `array("x", dim = c(1, 1, 1))` must be a simple vector, not an array.
     Code
@@ -30,41 +30,41 @@
       foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
       foo[0.5]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[0.5]`:
       ! Must subset columns with a valid subscript vector.
       x Can't convert from `j` <double> to <integer> due to loss of precision.
     Code
       foo[1:5]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[1:5]`:
       ! Can't subset columns past the end.
       i Locations 4 and 5 don't exist.
       i There are only 3 columns.
     Code
       foo[-1:1]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[-1:1]`:
       ! Must subset columns with a valid subscript vector.
       x Negative and positive locations can't be mixed.
       i Subscript `-1:1` has a positive value at location 3.
     Code
       foo[c(-1, 1)]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[c(-1, 1)]`:
       ! Must subset columns with a valid subscript vector.
       x Negative and positive locations can't be mixed.
       i Subscript `c(-1, 1)` has a positive value at location 2.
     Code
       foo[c(-1, NA)]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[c(-1, NA)]`:
       ! Must subset columns with a valid subscript vector.
       x Negative locations can't have missing values.
       i Subscript `c(-1, NA)` has a missing value at location 2.
     Code
       foo[-4]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[-4]`:
       ! Can't negate columns past the end.
       i Location 4 doesn't exist.
       i There are only 3 columns.
@@ -81,20 +81,20 @@
     Code
       foo[array(1, dim = c(1, 1, 1))]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[array(1, dim = c(1, 1, 1))]`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `array(1, dim = c(1, 1, 1))` must be a simple vector, not an array.
     Code
       foo[mean]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[mean]`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `mean` has the wrong type `function`.
       i It must be logical, numeric, or character.
     Code
       foo[foo]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[foo]`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `foo` has the wrong type `tbl_df<
         x: integer
@@ -172,14 +172,14 @@
       foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
       foo[c(TRUE, TRUE)]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[c(TRUE, TRUE)]`:
       ! Must subset columns with a valid subscript vector.
       i Logical subscripts must match the size of the indexed input.
       x Input has size 3 but subscript `c(TRUE, TRUE)` has size 2.
     Code
       foo[c(TRUE, TRUE, FALSE, FALSE)]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[c(TRUE, TRUE, FALSE, FALSE)]`:
       ! Must subset columns with a valid subscript vector.
       i Logical subscripts must match the size of the indexed input.
       x Input has size 3 but subscript `c(TRUE, TRUE, FALSE, FALSE)` has size 4.
@@ -196,7 +196,7 @@
     Code
       foo[array(TRUE, dim = c(1, 1, 1))]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[array(TRUE, dim = c(1, 1, 1))]`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `array(TRUE, dim = c(1, 1, 1))` must be a simple vector, not an array.
     Code
@@ -226,27 +226,27 @@
       foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
       foo[list(1:3)]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[list(1:3)]`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
     Code
       foo[as.list(1:3)]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[as.list(1:3)]`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `as.list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
     Code
       foo[factor(1:3)]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[factor(1:3)]`:
       ! Can't subset columns that don't exist.
       x Columns `1`, `2`, and `3` don't exist.
     Code
       foo[Sys.Date()]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[Sys.Date()]`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `Sys.Date()` has the wrong type `date`.
       i It must be logical, numeric, or character.
@@ -297,7 +297,7 @@
     Code
       foo[array("x", dim = c(1, 1, 1))]
     Condition
-      Error in `[.tbl_df`:
+      Error in `foo[array("x", dim = c(1, 1, 1))]`:
       ! Must subset columns with a valid subscript vector.
       x Subscript `array("x", dim = c(1, 1, 1))` must be a simple vector, not an array.
     Code
@@ -443,27 +443,27 @@
       foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
       foo[list(1:3)] <- 1
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Must assign to columns with a valid subscript vector.
       x Subscript `list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
     Code
       foo[as.list(1:3)] <- 1
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Must assign to columns with a valid subscript vector.
       x Subscript `as.list(1:3)` has the wrong type `list`.
       i It must be logical, numeric, or character.
     Code
       foo[factor(1:3)] <- 1
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Can't assign to columns that don't exist.
       x Columns `1`, `2`, and `3` don't exist.
     Code
       foo[Sys.Date()] <- 1
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Must assign to columns with a valid subscript vector.
       x Subscript `Sys.Date()` has the wrong type `date`.
       i It must be logical, numeric, or character.

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -747,7 +747,7 @@
       df <- tibble(x = 1:3, y = letters[1:3], z = as.list(1:3))
       df[1:3, 1:2] <- df[2:3]
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Assigned data `df[2:3]` must be compatible with existing data.
       i Error occurred for column `x`.
       Caused by error in `vec_assign()`:
@@ -755,7 +755,7 @@
     Code
       df[1:3, 1:2] <- df[1]
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Assigned data `df[1]` must be compatible with existing data.
       i Error occurred for column `y`.
       Caused by error in `vec_assign()`:
@@ -763,7 +763,7 @@
     Code
       df[1:3, 1:2] <- df[[1]]
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Assigned data `df[[1]]` must be compatible with existing data.
       i Error occurred for column `y`.
       Caused by error in `vec_assign()`:
@@ -771,7 +771,7 @@
     Code
       df[1:3, 1:3] <- df[3:1]
     Condition
-      Error in `[<-.tbl_df`:
+      Error in `[<-`:
       ! Assigned data `df[3:1]` must be compatible with existing data.
       i Error occurred for column `x`.
       Caused by error in `vec_assign()`:

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -575,7 +575,7 @@
       df <- tibble(x = 1:2, y = x)
       df[4:5] <- 3
     Condition
-      Error in `numtbl_as_col_location_assign()`:
+      Error in `[<-`:
       ! Can't assign to columns beyond the end with non-consecutive locations.
       i Input has size 2.
       x Subscript `4:5` contains non-consecutive location 4.
@@ -968,7 +968,7 @@
       df <- tibble(x = 1:2, y = x)
       df[[4]] <- 3
     Condition
-      Error in `numtbl_as_col_location_assign()`:
+      Error in `[[<-`:
       ! Can't assign to columns beyond the end with non-consecutive locations.
       i Input has size 2.
       x Subscript `4` contains non-consecutive location 4.

--- a/tests/testthat/_snaps/subsetting.md
+++ b/tests/testthat/_snaps/subsetting.md
@@ -615,27 +615,33 @@
     Code
       df[1, ] <- 1:3
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `1:3` must be compatible with row subscript `1`.
       x 1 row must be assigned.
       x Assigned data has 3 rows.
       i Row updates require a list value. Do you need `list()` or `as.list()`?
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 3 to size 1.
     Code
       df[1:2, ] <- 1:3
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `1:3` must be compatible with row subscript `1:2`.
       x 2 rows must be assigned.
       x Assigned data has 3 rows.
       i Only vectors of size 1 are recycled.
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 3 to size 2.
     Code
       df[, ] <- 1:2
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `1:2` must be compatible with existing data.
       x Existing data has 3 rows.
       x Assigned data has 2 rows.
       i Only vectors of size 1 are recycled.
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 2 to size 3.
     Code
       df[1, ] <- list(a = 1:3, b = 1)
     Condition
@@ -659,67 +665,83 @@
     Code
       df[1, 1:2] <- list(a = 1:3, b = 1)
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `list(a = 1:3, b = 1)` must be compatible with row subscript `1`.
       x 1 row must be assigned.
       x Element 1 of assigned data has 3 rows.
       i Row updates require a list value. Do you need `list()` or `as.list()`?
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 3 to size 1.
     Code
       df[1, 1:2] <- list(a = 1, b = 1:3)
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `list(a = 1, b = 1:3)` must be compatible with row subscript `1`.
       x 1 row must be assigned.
       x Element 2 of assigned data has 3 rows.
       i Row updates require a list value. Do you need `list()` or `as.list()`?
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 3 to size 1.
     Code
       df[1:2, 1:2] <- list(a = 1:3, b = 1)
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `list(a = 1:3, b = 1)` must be compatible with row subscript `1:2`.
       x 2 rows must be assigned.
       x Element 1 of assigned data has 3 rows.
       i Only vectors of size 1 are recycled.
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 3 to size 2.
     Code
       df[1:2, 1:2] <- list(a = 1, b = 1:3)
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `list(a = 1, b = 1:3)` must be compatible with row subscript `1:2`.
       x 2 rows must be assigned.
       x Element 2 of assigned data has 3 rows.
       i Only vectors of size 1 are recycled.
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 3 to size 2.
     Code
       df[1, ] <- list(a = 1:3, b = 1, c = 1:3)
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `list(a = 1:3, b = 1, c = 1:3)` must be compatible with row subscript `1`.
       x 1 row must be assigned.
       x Element 1 of assigned data has 3 rows.
       i Row updates require a list value. Do you need `list()` or `as.list()`?
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 3 to size 1.
     Code
       df[1, ] <- list(a = 1, b = 1:3, c = 1:3)
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `list(a = 1, b = 1:3, c = 1:3)` must be compatible with row subscript `1`.
       x 1 row must be assigned.
       x Element 2 of assigned data has 3 rows.
       i Row updates require a list value. Do you need `list()` or `as.list()`?
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 3 to size 1.
     Code
       df[1:2, ] <- list(a = 1:3, b = 1, c = 1:3)
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `list(a = 1:3, b = 1, c = 1:3)` must be compatible with row subscript `1:2`.
       x 2 rows must be assigned.
       x Element 1 of assigned data has 3 rows.
       i Only vectors of size 1 are recycled.
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 3 to size 2.
     Code
       df[1:2, ] <- list(a = 1, b = 1:3, c = 1:3)
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `list(a = 1, b = 1:3, c = 1:3)` must be compatible with row subscript `1:2`.
       x 2 rows must be assigned.
       x Element 2 of assigned data has 3 rows.
       i Only vectors of size 1 are recycled.
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 3 to size 2.
     Code
       # # [<-.tbl_df and coercion
       df <- tibble(x = 1:3, y = letters[1:3], z = as.list(1:3))
@@ -967,27 +989,33 @@
       df <- tibble(x = 1:3)
       df[["x"]] <- 8:9
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `8:9` must be compatible with existing data.
       x Existing data has 3 rows.
       x Assigned data has 2 rows.
       i Only vectors of size 1 are recycled.
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 2 to size 3.
     Code
       df[["w"]] <- 8:9
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `8:9` must be compatible with existing data.
       x Existing data has 3 rows.
       x Assigned data has 2 rows.
       i Only vectors of size 1 are recycled.
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 2 to size 3.
     Code
       df[["a"]] <- character()
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `character()` must be compatible with existing data.
       x Existing data has 3 rows.
       x Assigned data has 0 rows.
       i Only vectors of size 1 are recycled.
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 0 to size 3.
     Code
       # # [<-.tbl_df throws an error with invalid values
       df <- tibble(x = 1:2, y = x)
@@ -1005,25 +1033,31 @@
       df <- tibble(x = 1:3)
       df$x <- 8:9
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `8:9` must be compatible with existing data.
       x Existing data has 3 rows.
       x Assigned data has 2 rows.
       i Only vectors of size 1 are recycled.
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 2 to size 3.
     Code
       df$w <- 8:9
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `8:9` must be compatible with existing data.
       x Existing data has 3 rows.
       x Assigned data has 2 rows.
       i Only vectors of size 1 are recycled.
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 2 to size 3.
     Code
       df$a <- character()
     Condition
-      Error:
+      Error in `abort_assign_incompatible_size()`:
       ! Assigned data `character()` must be compatible with existing data.
       x Existing data has 3 rows.
       x Assigned data has 0 rows.
       i Only vectors of size 1 are recycled.
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 0 to size 3.
 

--- a/tests/testthat/_snaps/tibble.md
+++ b/tests/testthat/_snaps/tibble.md
@@ -3,8 +3,12 @@
     Code
       tibble(a = 1, a = 1)
     Condition
-      Error in `error_column_names_must_be_unique()`:
-      ! could not find function "error_column_names_must_be_unique"
+      Error:
+      ! Column name `a` must not be duplicated.Use `.name_repair` to specify repair.
+      Caused by error in `repaired_names()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 2.
     Code
       tibble(a = new_environment())
     Condition

--- a/tests/testthat/_snaps/tibble.md
+++ b/tests/testthat/_snaps/tibble.md
@@ -3,23 +3,18 @@
     Code
       tibble(a = 1, a = 1)
     Condition
-      Error:
-      ! Column name `a` must not be duplicated.
-      Use `.name_repair` to specify repair.
-      Caused by error in `repaired_names()`:
-      ! Names must be unique.
-      x These names are duplicated:
-        * "a" at locations 1 and 2.
+      Error in `error_column_names_must_be_unique()`:
+      ! could not find function "error_column_names_must_be_unique"
     Code
       tibble(a = new_environment())
     Condition
-      Error:
+      Error in `tibble()`:
       ! All columns in a tibble must be vectors.
       x Column `a` is an environment.
     Code
       tibble(a = 1, b = 2:3, c = 4:6, d = 7:10)
     Condition
-      Error:
+      Error in `tibble()`:
       ! Tibble columns must have compatible sizes.
       * Size 2: Existing data.
       * Size 3: Column `c`.

--- a/tests/testthat/_snaps/tibble.md
+++ b/tests/testthat/_snaps/tibble.md
@@ -3,8 +3,9 @@
     Code
       tibble(a = 1, a = 1)
     Condition
-      Error:
-      ! Column name `a` must not be duplicated.Use `.name_repair` to specify repair.
+      Error in `tibble()`:
+      ! Column name `a` must not be duplicated.
+      Use `.name_repair` to specify repair.
       Caused by error in `repaired_names()`:
       ! Names must be unique.
       x These names are duplicated:

--- a/tests/testthat/_snaps/tribble.md
+++ b/tests/testthat/_snaps/tribble.md
@@ -3,12 +3,12 @@
     Code
       tribble(1)
     Condition
-      Error:
+      Error in `tribble()`:
       ! Must specify at least one column using the `~name` syntax.
     Code
       tribble(~a, ~b, 1)
     Condition
-      Error:
+      Error in `tribble()`:
       ! Data must be rectangular.
       * Found 2 columns.
       * Found 1 cells.
@@ -16,29 +16,29 @@
     Code
       tribble(a ~ b, 1)
     Condition
-      Error:
+      Error in `tribble()`:
       ! All column specifications must use the `~name` syntax.
       x Found `a` on the left-hand side of `~`.
     Code
       tribble(a ~ b + c, 1)
     Condition
-      Error:
+      Error in `tribble()`:
       ! All column specifications must use the `~name` syntax.
       x Found `a` on the left-hand side of `~`.
     Code
       tribble(~b, 1, "a")
     Condition
-      Error:
-      ! Can't create column `b`: Can't combine `..1` <double> and `..2` <character>.
+      Error in `tibble_abort_class()`:
+      ! could not find function "tibble_abort_class"
     Code
       frame_matrix(1)
     Condition
-      Error:
+      Error in `frame_matrix()`:
       ! Must specify at least one column using the `~name` syntax.
     Code
       frame_matrix(~a, list(1))
     Condition
-      Error:
+      Error in `frame_matrix()`:
       ! All values must be atomic.
       x Found list-valued element at position 1.
 

--- a/tests/testthat/_snaps/tribble.md
+++ b/tests/testthat/_snaps/tribble.md
@@ -28,8 +28,10 @@
     Code
       tribble(~b, 1, "a")
     Condition
-      Error in `tibble_abort_class()`:
-      ! could not find function "tibble_abort_class"
+      Error in `tribble()`:
+      ! Can't create column `b`
+      Caused by error:
+      ! Can't combine `..1` <double> and `..2` <character>.
     Code
       frame_matrix(1)
     Condition

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -992,7 +992,7 @@ df[mean, ]
 
 ```r
 tbl[mean, ]
-#> Error in `vectbl_as_row_location()`:
+#> Error in `[.tbl_df`:
 #> ! Must subset rows with a valid subscript vector.
 #> x Subscript `mean` has the wrong type `function`.
 #> i It must be logical, numeric, or character.
@@ -1009,7 +1009,7 @@ df[list(1), ]
 
 ```r
 tbl[list(1), ]
-#> Error in `vectbl_as_row_location()`:
+#> Error in `[.tbl_df`:
 #> ! Must subset rows with a valid subscript vector.
 #> x Subscript `list(1)` has the wrong type `list`.
 #> i It must be logical, numeric, or character.
@@ -1096,7 +1096,7 @@ df[c(TRUE, FALSE), ]
 
 ```r
 tbl[c(TRUE, FALSE), ]
-#> Error in `vectbl_as_row_location()`:
+#> Error in `[.tbl_df`:
 #> ! Must subset rows with a valid subscript vector.
 #> i Logical subscripts must match the size of the indexed input.
 #> x Input has size 4 but subscript `c(TRUE, FALSE)` has size 2.
@@ -3160,7 +3160,7 @@ with_df(df[0:2, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[0:2, ] <- tbl[1, ])
-#> Error in `numtbl_as_row_location_assign()`:
+#> Error in `[<-.tbl_df`:
 #> ! Must assign to rows with a valid subscript vector.
 #> x Subscript `0:2` can't contain `0` values.
 #> i It has a `0` value at location 1.
@@ -3181,7 +3181,7 @@ with_df(df[0, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[0, ] <- tbl[1, ])
-#> Error in `numtbl_as_row_location_assign()`:
+#> Error in `[<-.tbl_df`:
 #> ! Must assign to rows with a valid subscript vector.
 #> x Subscript `0` can't contain `0` values.
 #> i It has a `0` value at location 1.
@@ -3222,7 +3222,7 @@ with_df(df[-1:2, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[-1:2, ] <- tbl[1, ])
-#> Error in `numtbl_as_row_location_assign()`:
+#> Error in `[<-.tbl_df`:
 #> ! Must assign to rows with a valid subscript vector.
 #> x Subscript `-1:2` can't contain `0` values.
 #> i It has a `0` value at location 2.
@@ -3239,7 +3239,7 @@ with_df(df[NA_integer_, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[NA_integer_, ] <- tbl[1, ])
-#> Error in `numtbl_as_row_location_assign()`:
+#> Error in `[<-.tbl_df`:
 #> ! Must assign to rows with a valid subscript vector.
 #> x Subscript `NA_integer_` can't contain missing values.
 #> x It has a missing value at location 1.
@@ -3256,7 +3256,7 @@ with_df2(df2[NA_integer_, ] <- df2[1, ])
 
 ```r
 with_tbl2(tbl2[NA_integer_, ] <- tbl2[1, ])
-#> Error in `numtbl_as_row_location_assign()`:
+#> Error in `[<-.tbl_df`:
 #> ! Must assign to rows with a valid subscript vector.
 #> x Subscript `NA_integer_` can't contain missing values.
 #> x It has a missing value at location 1.
@@ -3519,7 +3519,7 @@ with_df(df[6, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[6, ] <- tbl[1, ])
-#> Error in `numtbl_as_row_location_assign()`:
+#> Error in `[<-.tbl_df`:
 #> ! Can't assign to rows beyond the end with non-consecutive locations.
 #> i Input has size 4.
 #> x Subscript `6` contains non-consecutive location 6.
@@ -3540,7 +3540,7 @@ with_df(df[-5, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[-5, ] <- tbl[1, ])
-#> Error in `numtbl_as_row_location_assign()`:
+#> Error in `[<-.tbl_df`:
 #> ! Can't negate rows past the end.
 #> i Location 5 doesn't exist.
 #> i There are only 4 rows.
@@ -3561,7 +3561,7 @@ with_df(df[-(5:7), ] <- df[1, ])
 
 ```r
 with_tbl(tbl[-(5:7), ] <- tbl[1, ])
-#> Error in `numtbl_as_row_location_assign()`:
+#> Error in `[<-.tbl_df`:
 #> ! Can't negate rows past the end.
 #> i Locations 5, 6, and 7 don't exist.
 #> i There are only 4 rows.
@@ -3582,7 +3582,7 @@ with_df(df[-6, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[-6, ] <- tbl[1, ])
-#> Error in `numtbl_as_row_location_assign()`:
+#> Error in `[<-.tbl_df`:
 #> ! Can't negate rows past the end.
 #> i Location 6 doesn't exist.
 #> i There are only 4 rows.
@@ -4250,7 +4250,7 @@ df[[1:2, 1]]
 
 ```r
 tbl[[1:2, 1]]
-#> Error in `vectbl_as_row_location2()`:
+#> Error in `[[.tbl_df`:
 #> ! Must extract row with a single valid subscript.
 #> x Subscript `1:2` has size 2 but must be size 1.
 ```
@@ -4266,7 +4266,7 @@ with_df(df[[1:2, 1]] <- 0)
 
 ```r
 with_tbl(tbl[[1:2, 1]] <- 0)
-#> Error in `vectbl_as_row_location2()`:
+#> Error in `[[<-.tbl_df`:
 #> ! Must assign to row with a single valid subscript.
 #> x Subscript `1:2` has size 2 but must be size 1.
 ```

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -337,7 +337,7 @@ df[[c("n", "c")]]
 
 ```r
 tbl[[c("n", "c")]]
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `tbl[[c("n", "c")]]`:
 #> ! Must extract column with a single valid subscript.
 #> x Subscript `c("n", "c")` has size 2 but must be size 1.
 ```
@@ -353,7 +353,7 @@ df[[TRUE]]
 
 ```r
 tbl[[TRUE]]
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `tbl[[TRUE]]`:
 #> ! Must extract column with a single valid subscript.
 #> x Subscript `TRUE` has the wrong type `logical`.
 #> i It must be numeric or character.
@@ -370,7 +370,7 @@ df[[mean]]
 
 ```r
 tbl[[mean]]
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `tbl[[mean]]`:
 #> ! Must extract column with a single valid subscript.
 #> x Subscript `mean` has the wrong type `function`.
 #> i It must be numeric or character.
@@ -391,7 +391,7 @@ df[[NA]]
 
 ```r
 tbl[[NA]]
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `tbl[[NA]]`:
 #> ! Must extract column with a single valid subscript.
 #> x Subscript `NA` can't be `NA`.
 ```
@@ -407,7 +407,7 @@ df[[NA_character_]]
 
 ```r
 tbl[[NA_character_]]
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `tbl[[NA_character_]]`:
 #> ! Must extract column with a single valid subscript.
 #> x Subscript `NA_character_` can't be `NA`.
 ```
@@ -423,7 +423,7 @@ df[[NA_integer_]]
 
 ```r
 tbl[[NA_integer_]]
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `tbl[[NA_integer_]]`:
 #> ! Must extract column with a single valid subscript.
 #> x Subscript `NA_integer_` can't be `NA`.
 ```
@@ -439,7 +439,7 @@ df[[-1]]
 
 ```r
 tbl[[-1]]
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `tbl[[-1]]`:
 #> ! Must extract column with a single valid subscript.
 #> x Subscript `-1` has value -1 but must be a positive location.
 ```
@@ -472,7 +472,7 @@ df[[1.5]]
 
 ```r
 tbl[[1.5]]
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `tbl[[1.5]]`:
 #> ! Must extract column with a single valid subscript.
 #> x Subscript `1.5` has the wrong type `double`.
 #> i It must be numeric or character.
@@ -489,7 +489,7 @@ df[[Inf]]
 
 ```r
 tbl[[Inf]]
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `tbl[[Inf]]`:
 #> ! Must extract column with a single valid subscript.
 #> x Subscript `Inf` has the wrong type `double`.
 #> i It must be numeric or character.
@@ -1468,7 +1468,7 @@ with_df(df[[TRUE]] <- 0)
 
 ```r
 with_tbl(tbl[[TRUE]] <- 0)
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `[[<-`:
 #> ! Must assign to column with a single valid subscript.
 #> x Subscript `TRUE` has the wrong type `logical`.
 #> i It must be numeric or character.
@@ -1485,7 +1485,7 @@ with_df(df[[1:3]] <- 0)
 
 ```r
 with_tbl(tbl[[1:3]] <- 0)
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `[[<-`:
 #> ! Must assign to column with a single valid subscript.
 #> x Subscript `1:3` has size 3 but must be size 1.
 ```
@@ -1501,7 +1501,7 @@ with_df(df[[c("n", "c")]] <- 0)
 
 ```r
 with_tbl(tbl[[c("n", "c")]] <- 0)
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `[[<-`:
 #> ! Must assign to column with a single valid subscript.
 #> x Subscript `c("n", "c")` has size 2 but must be size 1.
 ```
@@ -1517,7 +1517,7 @@ with_df(df[[FALSE]] <- 0)
 
 ```r
 with_tbl(tbl[[FALSE]] <- 0)
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `[[<-`:
 #> ! Must assign to column with a single valid subscript.
 #> x Subscript `FALSE` has the wrong type `logical`.
 #> i It must be numeric or character.
@@ -1534,7 +1534,7 @@ with_df(df[[1:2]] <- 0)
 
 ```r
 with_tbl(tbl[[1:2]] <- 0)
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `[[<-`:
 #> ! Must assign to column with a single valid subscript.
 #> x Subscript `1:2` has size 2 but must be size 1.
 ```
@@ -1550,7 +1550,7 @@ with_df(df[[NA_integer_]] <- 0)
 
 ```r
 with_tbl(tbl[[NA_integer_]] <- 0)
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `[[<-`:
 #> ! Must assign to column with a single valid subscript.
 #> x Subscript `NA_integer_` can't be `NA`.
 ```
@@ -1566,7 +1566,7 @@ with_df(df[[NA]] <- 0)
 
 ```r
 with_tbl(tbl[[NA]] <- 0)
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `[[<-`:
 #> ! Must assign to column with a single valid subscript.
 #> x Subscript `NA` can't be `NA`.
 ```
@@ -1582,7 +1582,7 @@ with_df(df[[NA_character_]] <- 0)
 
 ```r
 with_tbl(tbl[[NA_character_]] <- 0)
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `[[<-`:
 #> ! Must assign to column with a single valid subscript.
 #> x Subscript `NA_character_` can't be `NA`.
 ```

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -2325,7 +2325,7 @@ with_df(df[c(1, 1)] <- list(1, 2))
 
 ```r
 with_tbl(tbl[c(1, 1)] <- list(1, 2))
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Column index 1 is used more than once for assignment.
 ```
 
@@ -2372,7 +2372,7 @@ with_df(df[NA] <- list("x"))
 
 ```r
 with_tbl(tbl[NA] <- list("x"))
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Can't use NA as column index with `[` at positions 1, 2, and 3.
 ```
 
@@ -2387,7 +2387,7 @@ with_df(df[NA_integer_] <- list("x"))
 
 ```r
 with_tbl(tbl[NA_integer_] <- list("x"))
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Can't use NA as column index in a tibble for assignment.
 ```
 
@@ -2402,7 +2402,7 @@ with_df(df[NA_character_] <- list("x"))
 
 ```r
 with_tbl(tbl[NA_character_] <- list("x"))
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Can't use NA as column index in a tibble for assignment.
 ```
 
@@ -2674,7 +2674,7 @@ with_df(df[is.na(df)] <- 1:2)
 
 ```r
 with_tbl(tbl[is.na(tbl)] <- 1:2)
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Subscript `is.na(tbl)` is a matrix, the data `1:2` must have size 1.
 ```
 
@@ -2817,7 +2817,7 @@ with_df(df[1:2] <- array(8:1, dim = c(2, 1, 4)))
 
 ```r
 with_tbl(tbl[1:2] <- array(8:1, dim = c(2, 1, 4)))
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! `array(8:1, dim = c(2, 1, 4))` must be a vector, a bare list, a data frame, a matrix, or NULL.
 ```
 
@@ -2836,7 +2836,7 @@ with_df(df[1:2] <- array(8:1, dim = c(4, 1, 2)))
 
 ```r
 with_tbl(tbl[1:2] <- array(8:1, dim = c(4, 1, 2)))
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! `array(8:1, dim = c(4, 1, 2))` must be a vector, a bare list, a data frame, a matrix, or NULL.
 ```
 
@@ -3019,7 +3019,7 @@ with_df(df[1, 2:3] <- NULL)
 
 ```r
 with_tbl(tbl[1, 2:3] <- NULL)
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! `NULL` must be a vector, a bare list, a data frame or a matrix.
 ```
 
@@ -3042,7 +3042,7 @@ with_df(df[1] <- mean)
 
 ```r
 with_tbl(tbl[1] <- mean)
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! `mean` must be a vector, a bare list, a data frame, a matrix, or NULL.
 ```
 
@@ -3081,7 +3081,7 @@ with_df(df[1] <- lm(mpg ~ wt, data = mtcars))
 
 ```r
 with_tbl(tbl[1] <- lm(mpg ~ wt, data = mtcars))
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! `lm(mpg ~ wt, data = mtcars)` must be a vector, a bare list, a data frame, a matrix, or NULL.
 ```
 
@@ -3321,7 +3321,7 @@ with_df(df[NA, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[NA, ] <- tbl[1, ])
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Can't use NA as row index in a tibble for assignment.
 ```
 
@@ -3638,7 +3638,7 @@ with_df(df[as.character(-(1:3)), ] <- df[1, ])
 with_tbl(tbl[as.character(-(1:3)), ] <- tbl[1, ])
 #> Warning: The `i` argument of `[.tbl_df` must use valid row names as of tibble 3.0.0.
 #> Use `NA_integer_` as row index to obtain a row full of `NA` values.
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Can't use NA as row index in a tibble for assignment.
 ```
 
@@ -3660,7 +3660,7 @@ with_df(df[as.character(3:5), ] <- df[1, ])
 with_tbl(tbl[as.character(3:5), ] <- tbl[1, ])
 #> Warning: The `i` argument of `[.tbl_df` must use valid row names as of tibble 3.0.0.
 #> Use `NA_integer_` as row index to obtain a row full of `NA` values.
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Can't use NA as row index in a tibble for assignment.
 ```
 
@@ -3684,7 +3684,7 @@ with_df(df[as.character(-(3:5)), ] <- df[1, ])
 with_tbl(tbl[as.character(-(3:5)), ] <- tbl[1, ])
 #> Warning: The `i` argument of `[.tbl_df` must use valid row names as of tibble 3.0.0.
 #> Use `NA_integer_` as row index to obtain a row full of `NA` values.
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Can't use NA as row index in a tibble for assignment.
 ```
 
@@ -3699,7 +3699,7 @@ with_df(df[NA_character_, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[NA_character_, ] <- tbl[1, ])
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Can't use NA as row index in a tibble for assignment.
 ```
 
@@ -3991,7 +3991,7 @@ with_df(df[2:3, "n"] <- NULL)
 
 ```r
 with_tbl(tbl[2:3, "n"] <- NULL)
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! `NULL` must be a vector, a bare list, a data frame or a matrix.
 ```
 

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -1722,11 +1722,7 @@ with_df(df[[1]] <- 3:1)
 
 ```r
 with_tbl(tbl[[1]] <- 3:1)
-#> Error:
-#> ! Assigned data `3:1` must be compatible with existing data.
-#> x Existing data has 4 rows.
-#> x Assigned data has 3 rows.
-#> i Only vectors of size 1 are recycled.
+#> Error in error_assign_incompatible_size(nrow, value, j, i_arg, value_arg): could not find function "error_assign_incompatible_size"
 ```
 
 </td></tr><tr style="vertical-align:top"><td>
@@ -1744,11 +1740,7 @@ with_df(df[[1]] <- 2:1)
 
 ```r
 with_tbl(tbl[[1]] <- 2:1)
-#> Error:
-#> ! Assigned data `2:1` must be compatible with existing data.
-#> x Existing data has 4 rows.
-#> x Assigned data has 2 rows.
-#> i Only vectors of size 1 are recycled.
+#> Error in error_assign_incompatible_size(nrow, value, j, i_arg, value_arg): could not find function "error_assign_incompatible_size"
 ```
 
 </td></tr></tbody></table>
@@ -2321,7 +2313,7 @@ with_df(df[c(1, 1)] <- list(1, 2))
 
 ```r
 with_tbl(tbl[c(1, 1)] <- list(1, 2))
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! Column index 1 is used more than once for assignment.
 ```
 
@@ -2368,7 +2360,7 @@ with_df(df[NA] <- list("x"))
 
 ```r
 with_tbl(tbl[NA] <- list("x"))
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! Can't use NA as column index with `[` at positions 1, 2, and 3.
 ```
 
@@ -2383,7 +2375,7 @@ with_df(df[NA_integer_] <- list("x"))
 
 ```r
 with_tbl(tbl[NA_integer_] <- list("x"))
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! Can't use NA as column index in a tibble for assignment.
 ```
 
@@ -2398,7 +2390,7 @@ with_df(df[NA_character_] <- list("x"))
 
 ```r
 with_tbl(tbl[NA_character_] <- list("x"))
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! Can't use NA as column index in a tibble for assignment.
 ```
 
@@ -2670,7 +2662,7 @@ with_df(df[is.na(df)] <- 1:2)
 
 ```r
 with_tbl(tbl[is.na(tbl)] <- 1:2)
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! Subscript `is.na(tbl)` is a matrix, the data `1:2` must have size 1.
 ```
 
@@ -2689,10 +2681,7 @@ with_df(df[matrix(c(rep(TRUE, 5), rep(FALSE, 7)), ncol = 3)] <- 4)
 
 ```r
 with_tbl(tbl[matrix(c(rep(TRUE, 5), rep(FALSE, 7)), ncol = 3)] <- 4)
-#> Error:
-#> ! Assigned data `4` must be compatible with existing data.
-#> i Error occurred for column `c`.
-#> x Can't convert <double> to <character>.
+#> Error in error_assign_incompatible_type(x, rep(list(value), j), j, value_arg, : could not find function "error_assign_incompatible_type"
 ```
 
 </td></tr></tbody></table>
@@ -2742,7 +2731,7 @@ with_df(df[1:3, 1:2] <- matrix(6:1, ncol = 2))
 
 ```r
 with_tbl(tbl[1:3, 1:2] <- matrix(6:1, ncol = 2))
-#> Error:
+#> Error in `abort_assign_incompatible_type()`:
 #> ! Assigned data `matrix(6:1, ncol = 2)` must be compatible with existing data.
 #> i Error occurred for column `c`.
 #> x Can't convert <integer> to <character>.
@@ -2811,7 +2800,7 @@ with_df(df[1:2] <- array(8:1, dim = c(2, 1, 4)))
 
 ```r
 with_tbl(tbl[1:2] <- array(8:1, dim = c(2, 1, 4)))
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! `array(8:1, dim = c(2, 1, 4))` must be a vector, a bare list, a data frame, a matrix, or NULL.
 ```
 
@@ -2830,7 +2819,7 @@ with_df(df[1:2] <- array(8:1, dim = c(4, 1, 2)))
 
 ```r
 with_tbl(tbl[1:2] <- array(8:1, dim = c(4, 1, 2)))
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! `array(8:1, dim = c(4, 1, 2))` must be a vector, a bare list, a data frame, a matrix, or NULL.
 ```
 
@@ -3013,7 +3002,7 @@ with_df(df[1, 2:3] <- NULL)
 
 ```r
 with_tbl(tbl[1, 2:3] <- NULL)
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! `NULL` must be a vector, a bare list, a data frame or a matrix.
 ```
 
@@ -3036,7 +3025,7 @@ with_df(df[1] <- mean)
 
 ```r
 with_tbl(tbl[1] <- mean)
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! `mean` must be a vector, a bare list, a data frame, a matrix, or NULL.
 ```
 
@@ -3075,7 +3064,7 @@ with_df(df[1] <- lm(mpg ~ wt, data = mtcars))
 
 ```r
 with_tbl(tbl[1] <- lm(mpg ~ wt, data = mtcars))
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! `lm(mpg ~ wt, data = mtcars)` must be a vector, a bare list, a data frame, a matrix, or NULL.
 ```
 
@@ -3315,7 +3304,7 @@ with_df(df[NA, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[NA, ] <- tbl[1, ])
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! Can't use NA as row index in a tibble for assignment.
 ```
 
@@ -3382,11 +3371,7 @@ with_df(df[2:4, ] <- df[1:2, ])
 
 ```r
 with_tbl(tbl[2:4, ] <- tbl[1:2, ])
-#> Error:
-#> ! Assigned data `tbl[1:2, ]` must be compatible with row subscript `2:4`.
-#> x 3 rows must be assigned.
-#> x Element 1 of assigned data has 2 rows.
-#> i Only vectors of size 1 are recycled.
+#> Error in error_assign_incompatible_size(nrow, value, j, i_arg, value_arg): could not find function "error_assign_incompatible_size"
 ```
 
 </td></tr></tbody></table>
@@ -3424,11 +3409,7 @@ with_df2(df2[2:4, ] <- df2[2:3, ])
 
 ```r
 with_tbl2(tbl2[2:4, ] <- tbl2[2:3, ])
-#> Error:
-#> ! Assigned data `tbl2[2:3, ]` must be compatible with row subscript `2:4`.
-#> x 3 rows must be assigned.
-#> x Element 1 of assigned data has 2 rows.
-#> i Only vectors of size 1 are recycled.
+#> Error in error_assign_incompatible_size(nrow, value, j, i_arg, value_arg): could not find function "error_assign_incompatible_size"
 ```
 
 </td></tr></tbody></table>
@@ -3628,7 +3609,7 @@ with_df(df[as.character(-(1:3)), ] <- df[1, ])
 with_tbl(tbl[as.character(-(1:3)), ] <- tbl[1, ])
 #> Warning: The `i` argument of `[.tbl_df` must use valid row names as of tibble 3.0.0.
 #> Use `NA_integer_` as row index to obtain a row full of `NA` values.
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! Can't use NA as row index in a tibble for assignment.
 ```
 
@@ -3650,7 +3631,7 @@ with_df(df[as.character(3:5), ] <- df[1, ])
 with_tbl(tbl[as.character(3:5), ] <- tbl[1, ])
 #> Warning: The `i` argument of `[.tbl_df` must use valid row names as of tibble 3.0.0.
 #> Use `NA_integer_` as row index to obtain a row full of `NA` values.
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! Can't use NA as row index in a tibble for assignment.
 ```
 
@@ -3674,7 +3655,7 @@ with_df(df[as.character(-(3:5)), ] <- df[1, ])
 with_tbl(tbl[as.character(-(3:5)), ] <- tbl[1, ])
 #> Warning: The `i` argument of `[.tbl_df` must use valid row names as of tibble 3.0.0.
 #> Use `NA_integer_` as row index to obtain a row full of `NA` values.
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! Can't use NA as row index in a tibble for assignment.
 ```
 
@@ -3689,7 +3670,7 @@ with_df(df[NA_character_, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[NA_character_, ] <- tbl[1, ])
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! Can't use NA as row index in a tibble for assignment.
 ```
 
@@ -3722,7 +3703,7 @@ with_df(df[2:3, 1] <- df[1:2, 2])
 
 ```r
 with_tbl(tbl[2:3, 1] <- tbl[1:2, 2])
-#> Error:
+#> Error in `abort_assign_incompatible_type()`:
 #> ! Assigned data `tbl[1:2, 2]` must be compatible with existing data.
 #> i Error occurred for column `n`.
 #> x Can't convert <character> to <integer>.
@@ -3747,7 +3728,7 @@ with_df(df[2:3, 2] <- df[1:2, 3])
 
 ```r
 with_tbl(tbl[2:3, 2] <- tbl[1:2, 3])
-#> Error:
+#> Error in `abort_assign_incompatible_type()`:
 #> ! Assigned data `tbl[1:2, 3]` must be compatible with existing data.
 #> i Error occurred for column `c`.
 #> x Can't convert <list> to <character>.
@@ -3797,7 +3778,7 @@ with_df2(df2[2:3, 1] <- df2[1:2, 2])
 
 ```r
 with_tbl2(tbl2[2:3, 1] <- tbl2[1:2, 2])
-#> Error:
+#> Error in `abort_assign_incompatible_type()`:
 #> ! Assigned data `tbl2[1:2, 2]` must be compatible with existing data.
 #> i Error occurred for column `tb`.
 #> x Can't convert <double[,4]> to <tbl_df>.
@@ -3978,7 +3959,7 @@ with_df(df[2:3, "n"] <- NULL)
 
 ```r
 with_tbl(tbl[2:3, "n"] <- NULL)
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! `NULL` must be a vector, a bare list, a data frame or a matrix.
 ```
 

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -1828,7 +1828,7 @@ with_df(df[[5]] <- 0)
 
 ```r
 with_tbl(tbl[[5]] <- 0)
-#> Error in `numtbl_as_col_location_assign()`:
+#> Error in `[[<-`:
 #> ! Can't assign to columns beyond the end with non-consecutive locations.
 #> i Input has size 3.
 #> x Subscript `5` contains non-consecutive location 5.
@@ -2625,7 +2625,7 @@ with_df(df[5] <- list(4:1))
 
 ```r
 with_tbl(tbl[5] <- list(4:1))
-#> Error in `numtbl_as_col_location_assign()`:
+#> Error in `[<-`:
 #> ! Can't assign to columns beyond the end with non-consecutive locations.
 #> i Input has size 3.
 #> x Subscript `5` contains non-consecutive location 5.

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -2693,7 +2693,7 @@ with_df(df[matrix(c(rep(TRUE, 5), rep(FALSE, 7)), ncol = 3)] <- 4)
 
 ```r
 with_tbl(tbl[matrix(c(rep(TRUE, 5), rep(FALSE, 7)), ncol = 3)] <- 4)
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Assigned data `4` must be compatible with existing data.
 #> i Error occurred for column `c`.
 #> Caused by error in `vec_assign()`:

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -1722,7 +1722,7 @@ with_df(df[[1]] <- 3:1)
 
 ```r
 with_tbl(tbl[[1]] <- 3:1)
-#> Error in `abort_assign_incompatible_size()`:
+#> Error in `[[<-`:
 #> ! Assigned data `3:1` must be compatible with existing data.
 #> x Existing data has 4 rows.
 #> x Assigned data has 3 rows.
@@ -1746,7 +1746,7 @@ with_df(df[[1]] <- 2:1)
 
 ```r
 with_tbl(tbl[[1]] <- 2:1)
-#> Error in `abort_assign_incompatible_size()`:
+#> Error in `[[<-`:
 #> ! Assigned data `2:1` must be compatible with existing data.
 #> x Existing data has 4 rows.
 #> x Assigned data has 2 rows.
@@ -3388,7 +3388,7 @@ with_df(df[2:4, ] <- df[1:2, ])
 
 ```r
 with_tbl(tbl[2:4, ] <- tbl[1:2, ])
-#> Error in `abort_assign_incompatible_size()`:
+#> Error in `[<-`:
 #> ! Assigned data `tbl[1:2, ]` must be compatible with row subscript `2:4`.
 #> x 3 rows must be assigned.
 #> x Element 1 of assigned data has 2 rows.
@@ -3432,7 +3432,7 @@ with_df2(df2[2:4, ] <- df2[2:3, ])
 
 ```r
 with_tbl2(tbl2[2:4, ] <- tbl2[2:3, ])
-#> Error in `abort_assign_incompatible_size()`:
+#> Error in `[<-`:
 #> ! Assigned data `tbl2[2:3, ]` must be compatible with row subscript `2:4`.
 #> x 3 rows must be assigned.
 #> x Element 1 of assigned data has 2 rows.

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -455,7 +455,7 @@ df[[4]]
 
 ```r
 tbl[[4]]
-#> Error in `vectbl_as_col_location2()`:
+#> Error in `tbl[[4]]`:
 #> ! Can't subset columns past the end.
 #> i Location 4 doesn't exist.
 #> i There are only 3 columns.
@@ -3784,10 +3784,11 @@ with_df(df[2:3, 3] <- df2[1:2, 1])
 
 ```r
 with_tbl(tbl[2:3, 3] <- tbl2[1:2, 1])
-#> Error:
+#> Error in `[<-`:
 #> ! Assigned data `tbl2[1:2, 1]` must be compatible with existing data.
 #> i Error occurred for column `li`.
-#> x Can't convert <tbl_df> to <list>.
+#> Caused by error in `vec_assign()`:
+#> ! Can't convert <tbl_df> to <list>.
 ```
 
 </td></tr><tr style="vertical-align:top"><td>

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -2747,7 +2747,7 @@ with_df(df[1:3, 1:2] <- matrix(6:1, ncol = 2))
 
 ```r
 with_tbl(tbl[1:3, 1:2] <- matrix(6:1, ncol = 2))
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Assigned data `matrix(6:1, ncol = 2)` must be compatible with existing data.
 #> i Error occurred for column `c`.
 #> Caused by error in `vec_assign()`:
@@ -3732,7 +3732,7 @@ with_df(df[2:3, 1] <- df[1:2, 2])
 
 ```r
 with_tbl(tbl[2:3, 1] <- tbl[1:2, 2])
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Assigned data `tbl[1:2, 2]` must be compatible with existing data.
 #> i Error occurred for column `n`.
 #> Caused by error in `vec_assign()`:
@@ -3758,7 +3758,7 @@ with_df(df[2:3, 2] <- df[1:2, 3])
 
 ```r
 with_tbl(tbl[2:3, 2] <- tbl[1:2, 3])
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Assigned data `tbl[1:2, 3]` must be compatible with existing data.
 #> i Error occurred for column `c`.
 #> Caused by error in `vec_assign()`:
@@ -3809,7 +3809,7 @@ with_df2(df2[2:3, 1] <- df2[1:2, 2])
 
 ```r
 with_tbl2(tbl2[2:3, 1] <- tbl2[1:2, 2])
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Assigned data `tbl2[1:2, 2]` must be compatible with existing data.
 #> i Error occurred for column `tb`.
 #> Caused by error in `vec_assign()`:

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -4250,7 +4250,7 @@ df[[1:2, 1]]
 
 ```r
 tbl[[1:2, 1]]
-#> Error in `[[.tbl_df`:
+#> Error in `tbl[[1:2, 1]]`:
 #> ! Must extract row with a single valid subscript.
 #> x Subscript `1:2` has size 2 but must be size 1.
 ```
@@ -4266,7 +4266,7 @@ with_df(df[[1:2, 1]] <- 0)
 
 ```r
 with_tbl(tbl[[1:2, 1]] <- 0)
-#> Error in `[[<-.tbl_df`:
+#> Error in `[[<-`:
 #> ! Must assign to row with a single valid subscript.
 #> x Subscript `1:2` has size 2 but must be size 1.
 ```

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -3160,7 +3160,7 @@ with_df(df[0:2, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[0:2, ] <- tbl[1, ])
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Must assign to rows with a valid subscript vector.
 #> x Subscript `0:2` can't contain `0` values.
 #> i It has a `0` value at location 1.
@@ -3181,7 +3181,7 @@ with_df(df[0, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[0, ] <- tbl[1, ])
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Must assign to rows with a valid subscript vector.
 #> x Subscript `0` can't contain `0` values.
 #> i It has a `0` value at location 1.
@@ -3222,7 +3222,7 @@ with_df(df[-1:2, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[-1:2, ] <- tbl[1, ])
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Must assign to rows with a valid subscript vector.
 #> x Subscript `-1:2` can't contain `0` values.
 #> i It has a `0` value at location 2.
@@ -3239,7 +3239,7 @@ with_df(df[NA_integer_, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[NA_integer_, ] <- tbl[1, ])
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Must assign to rows with a valid subscript vector.
 #> x Subscript `NA_integer_` can't contain missing values.
 #> x It has a missing value at location 1.
@@ -3256,7 +3256,7 @@ with_df2(df2[NA_integer_, ] <- df2[1, ])
 
 ```r
 with_tbl2(tbl2[NA_integer_, ] <- tbl2[1, ])
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Must assign to rows with a valid subscript vector.
 #> x Subscript `NA_integer_` can't contain missing values.
 #> x It has a missing value at location 1.
@@ -3519,7 +3519,7 @@ with_df(df[6, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[6, ] <- tbl[1, ])
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Can't assign to rows beyond the end with non-consecutive locations.
 #> i Input has size 4.
 #> x Subscript `6` contains non-consecutive location 6.
@@ -3540,7 +3540,7 @@ with_df(df[-5, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[-5, ] <- tbl[1, ])
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Can't negate rows past the end.
 #> i Location 5 doesn't exist.
 #> i There are only 4 rows.
@@ -3561,7 +3561,7 @@ with_df(df[-(5:7), ] <- df[1, ])
 
 ```r
 with_tbl(tbl[-(5:7), ] <- tbl[1, ])
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Can't negate rows past the end.
 #> i Locations 5, 6, and 7 don't exist.
 #> i There are only 4 rows.
@@ -3582,7 +3582,7 @@ with_df(df[-6, ] <- df[1, ])
 
 ```r
 with_tbl(tbl[-6, ] <- tbl[1, ])
-#> Error in `[<-.tbl_df`:
+#> Error in `[<-`:
 #> ! Can't negate rows past the end.
 #> i Location 6 doesn't exist.
 #> i There are only 4 rows.

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -1722,7 +1722,11 @@ with_df(df[[1]] <- 3:1)
 
 ```r
 with_tbl(tbl[[1]] <- 3:1)
-#> Error in error_assign_incompatible_size(nrow, value, j, i_arg, value_arg): could not find function "error_assign_incompatible_size"
+#> Error:
+#> ! Assigned data `3:1` must be compatible with existing data.
+#> x Existing data has 4 rows.
+#> x Assigned data has 3 rows.
+#> i Only vectors of size 1 are recycled.
 ```
 
 </td></tr><tr style="vertical-align:top"><td>
@@ -1740,7 +1744,11 @@ with_df(df[[1]] <- 2:1)
 
 ```r
 with_tbl(tbl[[1]] <- 2:1)
-#> Error in error_assign_incompatible_size(nrow, value, j, i_arg, value_arg): could not find function "error_assign_incompatible_size"
+#> Error:
+#> ! Assigned data `2:1` must be compatible with existing data.
+#> x Existing data has 4 rows.
+#> x Assigned data has 2 rows.
+#> i Only vectors of size 1 are recycled.
 ```
 
 </td></tr></tbody></table>
@@ -2681,7 +2689,10 @@ with_df(df[matrix(c(rep(TRUE, 5), rep(FALSE, 7)), ncol = 3)] <- 4)
 
 ```r
 with_tbl(tbl[matrix(c(rep(TRUE, 5), rep(FALSE, 7)), ncol = 3)] <- 4)
-#> Error in error_assign_incompatible_type(x, rep(list(value), j), j, value_arg, : could not find function "error_assign_incompatible_type"
+#> Error:
+#> ! Assigned data `4` must be compatible with existing data.
+#> i Error occurred for column `c`.
+#> x Can't convert <double> to <character>.
 ```
 
 </td></tr></tbody></table>
@@ -3371,7 +3382,11 @@ with_df(df[2:4, ] <- df[1:2, ])
 
 ```r
 with_tbl(tbl[2:4, ] <- tbl[1:2, ])
-#> Error in error_assign_incompatible_size(nrow, value, j, i_arg, value_arg): could not find function "error_assign_incompatible_size"
+#> Error:
+#> ! Assigned data `tbl[1:2, ]` must be compatible with row subscript `2:4`.
+#> x 3 rows must be assigned.
+#> x Element 1 of assigned data has 2 rows.
+#> i Only vectors of size 1 are recycled.
 ```
 
 </td></tr></tbody></table>
@@ -3409,7 +3424,11 @@ with_df2(df2[2:4, ] <- df2[2:3, ])
 
 ```r
 with_tbl2(tbl2[2:4, ] <- tbl2[2:3, ])
-#> Error in error_assign_incompatible_size(nrow, value, j, i_arg, value_arg): could not find function "error_assign_incompatible_size"
+#> Error:
+#> ! Assigned data `tbl2[2:3, ]` must be compatible with row subscript `2:4`.
+#> x 3 rows must be assigned.
+#> x Element 1 of assigned data has 2 rows.
+#> i Only vectors of size 1 are recycled.
 ```
 
 </td></tr></tbody></table>

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -992,7 +992,7 @@ df[mean, ]
 
 ```r
 tbl[mean, ]
-#> Error in `[.tbl_df`:
+#> Error in `tbl[mean, ]`:
 #> ! Must subset rows with a valid subscript vector.
 #> x Subscript `mean` has the wrong type `function`.
 #> i It must be logical, numeric, or character.
@@ -1009,7 +1009,7 @@ df[list(1), ]
 
 ```r
 tbl[list(1), ]
-#> Error in `[.tbl_df`:
+#> Error in `tbl[list(1), ]`:
 #> ! Must subset rows with a valid subscript vector.
 #> x Subscript `list(1)` has the wrong type `list`.
 #> i It must be logical, numeric, or character.
@@ -1096,7 +1096,7 @@ df[c(TRUE, FALSE), ]
 
 ```r
 tbl[c(TRUE, FALSE), ]
-#> Error in `[.tbl_df`:
+#> Error in `tbl[c(TRUE, FALSE), ]`:
 #> ! Must subset rows with a valid subscript vector.
 #> i Logical subscripts must match the size of the indexed input.
 #> x Input has size 4 but subscript `c(TRUE, FALSE)` has size 2.

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -2689,10 +2689,11 @@ with_df(df[matrix(c(rep(TRUE, 5), rep(FALSE, 7)), ncol = 3)] <- 4)
 
 ```r
 with_tbl(tbl[matrix(c(rep(TRUE, 5), rep(FALSE, 7)), ncol = 3)] <- 4)
-#> Error:
+#> Error in `[<-.tbl_df`:
 #> ! Assigned data `4` must be compatible with existing data.
 #> i Error occurred for column `c`.
-#> x Can't convert <double> to <character>.
+#> Caused by error in `vec_assign()`:
+#> ! Can't convert <double> to <character>.
 ```
 
 </td></tr></tbody></table>
@@ -2742,10 +2743,11 @@ with_df(df[1:3, 1:2] <- matrix(6:1, ncol = 2))
 
 ```r
 with_tbl(tbl[1:3, 1:2] <- matrix(6:1, ncol = 2))
-#> Error in `abort_assign_incompatible_type()`:
+#> Error in `[<-.tbl_df`:
 #> ! Assigned data `matrix(6:1, ncol = 2)` must be compatible with existing data.
 #> i Error occurred for column `c`.
-#> x Can't convert <integer> to <character>.
+#> Caused by error in `vec_assign()`:
+#> ! Can't convert <integer> to <character>.
 ```
 
 </td></tr><tr style="vertical-align:top"><td>
@@ -3722,10 +3724,11 @@ with_df(df[2:3, 1] <- df[1:2, 2])
 
 ```r
 with_tbl(tbl[2:3, 1] <- tbl[1:2, 2])
-#> Error in `abort_assign_incompatible_type()`:
+#> Error in `[<-.tbl_df`:
 #> ! Assigned data `tbl[1:2, 2]` must be compatible with existing data.
 #> i Error occurred for column `n`.
-#> x Can't convert <character> to <integer>.
+#> Caused by error in `vec_assign()`:
+#> ! Can't convert <character> to <integer>.
 ```
 
 </td></tr><tr style="vertical-align:top"><td>
@@ -3747,10 +3750,11 @@ with_df(df[2:3, 2] <- df[1:2, 3])
 
 ```r
 with_tbl(tbl[2:3, 2] <- tbl[1:2, 3])
-#> Error in `abort_assign_incompatible_type()`:
+#> Error in `[<-.tbl_df`:
 #> ! Assigned data `tbl[1:2, 3]` must be compatible with existing data.
 #> i Error occurred for column `c`.
-#> x Can't convert <list> to <character>.
+#> Caused by error in `vec_assign()`:
+#> ! Can't convert <list> to <character>.
 ```
 
 </td></tr><tr style="vertical-align:top"><td>
@@ -3797,10 +3801,11 @@ with_df2(df2[2:3, 1] <- df2[1:2, 2])
 
 ```r
 with_tbl2(tbl2[2:3, 1] <- tbl2[1:2, 2])
-#> Error in `abort_assign_incompatible_type()`:
+#> Error in `[<-.tbl_df`:
 #> ! Assigned data `tbl2[1:2, 2]` must be compatible with existing data.
 #> i Error occurred for column `tb`.
-#> x Can't convert <double[,4]> to <tbl_df>.
+#> Caused by error in `vec_assign()`:
+#> ! Can't convert <double[,4]> to <tbl_df>.
 ```
 
 </td></tr><tr style="vertical-align:top"><td>

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -1722,11 +1722,13 @@ with_df(df[[1]] <- 3:1)
 
 ```r
 with_tbl(tbl[[1]] <- 3:1)
-#> Error:
+#> Error in `abort_assign_incompatible_size()`:
 #> ! Assigned data `3:1` must be compatible with existing data.
 #> x Existing data has 4 rows.
 #> x Assigned data has 3 rows.
 #> i Only vectors of size 1 are recycled.
+#> Caused by error in `vectbl_recycle_rhs_rows()`:
+#> ! Can't recycle input of size 3 to size 4.
 ```
 
 </td></tr><tr style="vertical-align:top"><td>
@@ -1744,11 +1746,13 @@ with_df(df[[1]] <- 2:1)
 
 ```r
 with_tbl(tbl[[1]] <- 2:1)
-#> Error:
+#> Error in `abort_assign_incompatible_size()`:
 #> ! Assigned data `2:1` must be compatible with existing data.
 #> x Existing data has 4 rows.
 #> x Assigned data has 2 rows.
 #> i Only vectors of size 1 are recycled.
+#> Caused by error in `vectbl_recycle_rhs_rows()`:
+#> ! Can't recycle input of size 2 to size 4.
 ```
 
 </td></tr></tbody></table>
@@ -3384,11 +3388,13 @@ with_df(df[2:4, ] <- df[1:2, ])
 
 ```r
 with_tbl(tbl[2:4, ] <- tbl[1:2, ])
-#> Error:
+#> Error in `abort_assign_incompatible_size()`:
 #> ! Assigned data `tbl[1:2, ]` must be compatible with row subscript `2:4`.
 #> x 3 rows must be assigned.
 #> x Element 1 of assigned data has 2 rows.
 #> i Only vectors of size 1 are recycled.
+#> Caused by error in `vectbl_recycle_rhs_rows()`:
+#> ! Can't recycle input of size 2 to size 3.
 ```
 
 </td></tr></tbody></table>
@@ -3426,11 +3432,13 @@ with_df2(df2[2:4, ] <- df2[2:3, ])
 
 ```r
 with_tbl2(tbl2[2:4, ] <- tbl2[2:3, ])
-#> Error:
+#> Error in `abort_assign_incompatible_size()`:
 #> ! Assigned data `tbl2[2:3, ]` must be compatible with row subscript `2:4`.
 #> x 3 rows must be assigned.
 #> x Element 1 of assigned data has 2 rows.
 #> i Only vectors of size 1 are recycled.
+#> Caused by error in `vectbl_recycle_rhs_rows()`:
+#> ! Can't recycle input of size 2 to size 3.
 ```
 
 </td></tr></tbody></table>

--- a/tests/testthat/_snaps/vignette-invariants/invariants.md
+++ b/tests/testthat/_snaps/vignette-invariants/invariants.md
@@ -2287,7 +2287,7 @@ with_df(df[1:2] <- list(0, 0, 0))
 
 ```r
 with_tbl(tbl[1:2] <- list(0, 0, 0))
-#> Error in `vectbl_as_new_col_index()`:
+#> Error in `[<-`:
 #> ! Can't recycle `list(0, 0, 0)` (size 3) to size 2.
 ```
 
@@ -2306,7 +2306,7 @@ with_df(df[1:3] <- list(0, 0))
 
 ```r
 with_tbl(tbl[1:3] <- list(0, 0))
-#> Error in `vectbl_as_new_col_index()`:
+#> Error in `[<-`:
 #> ! Can't recycle `list(0, 0)` (size 2) to size 3.
 ```
 

--- a/tests/testthat/_snaps/vignette-tibble/tibble.md
+++ b/tests/testthat/_snaps/vignette-tibble/tibble.md
@@ -267,7 +267,7 @@ tibble(a = 1:3, b = 1)
 #> 2     2     1
 #> 3     3     1
 tibble(a = 1:3, c = 1:2)
-#> Error:
+#> Error in `tibble()`:
 #> ! Tibble columns must have compatible sizes.
 #> * Size 3: Existing data.
 #> * Size 2: Column `c`.

--- a/tests/testthat/test-add.R
+++ b/tests/testthat/test-add.R
@@ -41,14 +41,14 @@ test_that("adds empty row if no arguments", {
 })
 
 test_that("error if adding row with unknown variables", {
-  expect_tibble_error(
+  expect_tibble_abort(
     add_row(tibble(a = 3), xxyzy = "err"),
-    error_incompatible_new_rows("xxyzy")
+    abort_incompatible_new_rows("xxyzy")
   )
 
-  expect_tibble_error(
+  expect_tibble_abort(
     add_row(tibble(a = 3), b = "err", c = "oops"),
-    error_incompatible_new_rows(c("b", "c"))
+    abort_incompatible_new_rows(c("b", "c"))
   )
 })
 
@@ -104,9 +104,9 @@ test_that("can safely add to factor columns everywhere (#296)", {
 
 test_that("error if both .before and .after are given", {
   df <- tibble(a = 1:3)
-  expect_tibble_error(
+  expect_tibble_abort(
     add_row(df, a = 4:5, .after = 2, .before = 3),
-    error_both_before_after()
+    abort_both_before_after()
   )
 })
 
@@ -131,9 +131,9 @@ test_that("add_row() keeps the class of empty columns", {
 
 test_that("add_row() fails nicely for grouped data frames (#179)", {
   skip_if_not_installed("dplyr")
-  expect_tibble_error(
+  expect_tibble_abort(
     add_row(dplyr::group_by(trees, Volume), Height = 3),
-    error_add_rows_to_grouped_df()
+    abort_add_rows_to_grouped_df()
   )
 })
 
@@ -206,16 +206,16 @@ test_that("add_column() can add to empty tibble or data frame", {
 })
 
 test_that("error if adding existing columns", {
-  expect_tibble_error(
+  expect_tibble_abort(
     add_column(tibble(a = 3), a = 5),
-    error_column_names_must_be_unique("a", repair_hint = TRUE)
+    abort_column_names_must_be_unique("a", repair_hint = TRUE)
   )
 })
 
 test_that("error if adding wrong number of rows with add_column()", {
-  expect_tibble_error(
+  expect_tibble_abort(
     add_column(tibble(a = 3), b = 4:5),
-    error_incompatible_new_cols(1, data.frame(b = 4:5))
+    abort_incompatible_new_cols(1, data.frame(b = 4:5))
   )
 })
 
@@ -275,21 +275,21 @@ test_that("can add column relative to named column", {
 
 test_that("error if both .before and .after are given", {
   df <- tibble(a = 1:3)
-  expect_tibble_error(
+  expect_tibble_abort(
     add_column(df, b = 4:6, .after = 2, .before = 3),
-    error_both_before_after()
+    abort_both_before_after()
   )
 })
 
 test_that("error if column named by .before or .after not found", {
   df <- tibble(a = 1:3)
-  expect_tibble_error(
+  expect_tibble_abort(
     add_column(df, b = 4:6, .after = "x"),
-    error_unknown_column_names("x")
+    abort_unknown_column_names("x")
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     add_column(df, b = 4:6, .before = "x"),
-    error_unknown_column_names("x")
+    abort_unknown_column_names("x")
   )
 })
 

--- a/tests/testthat/test-as_tibble.R
+++ b/tests/testthat/test-as_tibble.R
@@ -16,40 +16,40 @@ test_that("columns are recycled to common length", {
 })
 
 test_that("columns must be same length", {
-  expect_tibble_error(
+  expect_tibble_abort(
     as_tibble(list(x = 1:2, y = 1:3)),
-    error_incompatible_size(NULL, c("x", "y"), 2:3, NA)
+    abort_incompatible_size(NULL, c("x", "y"), 2:3, NA)
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     as_tibble(list(x = 1:2, y = 1:3, z = 1:4)),
-    error_incompatible_size(
+    abort_incompatible_size(
       NULL,
       c("x", "y", "z"),
       2:4,
       NA
     )
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     as_tibble(list(x = 1:4, y = 1:2, z = 1:2)),
-    error_incompatible_size(
+    abort_incompatible_size(
       NULL,
       c("x", "y", "z"),
       c(4, 2, 2),
       NA
     )
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     as_tibble(list(x = 1, y = 1:4, z = 1:2)),
-    error_incompatible_size(
+    abort_incompatible_size(
       NULL,
       c("y", "z"),
       c(4, 2),
       NA
     )
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     as_tibble(list(x = 1:2, y = 1:4, z = 1)),
-    error_incompatible_size(
+    abort_incompatible_size(
       NULL,
       c("x", "y"),
       c(2, 4),
@@ -120,35 +120,35 @@ test_that("Superseded: Can convert unnamed atomic vectors to tibble by default",
 
 test_that("as_tibble() checks for `unique` names by default (#278)", {
   l1 <- list(1:10)
-  expect_tibble_error(
+  expect_tibble_abort(
     as_tibble(l1),
-    error_column_names_cannot_be_empty(1, repair_hint = TRUE)
+    abort_column_names_cannot_be_empty(1, repair_hint = TRUE)
   )
 
   l2 <- list(x = 1, 2)
-  expect_tibble_error(
+  expect_tibble_abort(
     as_tibble(l2),
-    error_column_names_cannot_be_empty(2, repair_hint = TRUE)
+    abort_column_names_cannot_be_empty(2, repair_hint = TRUE)
   )
 
   l3 <- list(x = 1, ... = 2)
-  expect_tibble_error(
+  expect_tibble_abort(
     as_tibble(l3),
-    error_column_names_cannot_be_dot_dot(2, repair_hint = TRUE)
+    abort_column_names_cannot_be_dot_dot(2, repair_hint = TRUE)
   )
 
   l4 <- list(x = 1, ..1 = 2)
-  expect_tibble_error(
+  expect_tibble_abort(
     as_tibble(l4),
-    error_column_names_cannot_be_dot_dot(2, repair_hint = TRUE)
+    abort_column_names_cannot_be_dot_dot(2, repair_hint = TRUE)
   )
 
   df <- list(a = 1, b = 2)
   names(df) <- c("", NA)
   df <- new_tibble(df, nrow = 1)
-  expect_tibble_error(
+  expect_tibble_abort(
     as_tibble(df),
-    error_column_names_cannot_be_empty(1:2, repair_hint = TRUE)
+    abort_column_names_cannot_be_empty(1:2, repair_hint = TRUE)
   )
 })
 
@@ -418,20 +418,20 @@ test_that("as_tibble_row() can convert named bare vectors to data frame", {
     tibble(a = 1, b = list(2:3))
   )
 
-  expect_tibble_error(
+  expect_tibble_abort(
     as_tibble_row(list(a = 1, b = 2:3)),
-    error_as_tibble_row_size_one(2, "b", 2)
+    abort_as_tibble_row_size_one(2, "b", 2)
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     as_tibble_row(setNames(nm = c(TRUE, FALSE, NA))),
-    error_column_names_cannot_be_empty(3, repair_hint = TRUE)
+    abort_column_names_cannot_be_empty(3, repair_hint = TRUE)
   )
 })
 
 test_that("as_tibble_row() works with non-bare vectors (#797)", {
-  expect_tibble_error(
+  expect_tibble_abort(
     as_tibble_row(new_environment()),
-    error_as_tibble_row_vector(new_environment())
+    abort_as_tibble_row_vector(new_environment())
   )
 
   time <- vec_slice(Sys.time(), 1)
@@ -473,9 +473,9 @@ test_that("as_tibble_col() can convert atomic vectors to data frame", {
   expect_identical(as_tibble_col(1:3), tibble(value = 1:3))
   expect_identical(as_tibble_col(list(4, 5:6), column_name = "data"), tibble(data = list(4, 5:6)))
 
-  expect_tibble_error(
+  expect_tibble_abort(
     as_tibble_col(lm(y ~ x, data.frame(x = 1:3, y = 2:4))),
-    error_column_scalar_type("value", 1, "a `lm` object")
+    abort_column_scalar_type("value", 1, "a `lm` object")
   )
 })
 
@@ -484,13 +484,13 @@ test_that("as_tibble_col() can convert atomic vectors to data frame", {
 test_that("`validate` triggers deprecation message, but then works", {
   scoped_lifecycle_warnings()
 
-  expect_tibble_error(
+  expect_tibble_abort(
     expect_warning(
       as_tibble(list(a = 1, "hi"), validate = TRUE),
       "deprecated",
       fixed = TRUE
     ),
-    error_column_names_cannot_be_empty(2, repair_hint = TRUE)
+    abort_column_names_cannot_be_empty(2, repair_hint = TRUE)
   )
 
   expect_warning(
@@ -511,21 +511,21 @@ test_that("`validate` triggers deprecation message, but then works", {
 
   df <- data.frame(a = 1, "hi")
   names(df) <- c("a", "")
-  expect_tibble_error(
+  expect_tibble_abort(
     expect_warning(
       as_tibble(df, validate = TRUE),
       "deprecated",
       fixed = TRUE
     ),
-    error_column_names_cannot_be_empty(2, repair_hint = TRUE)
+    abort_column_names_cannot_be_empty(2, repair_hint = TRUE)
   )
 })
 
 test_that("`validate` always raises lifecycle warning.", {
   expect_deprecated(
-    expect_tibble_error(
+    expect_tibble_abort(
       as_tibble(list(a = 1, "hi"), validate = TRUE, .name_repair = "check_unique"),
-      error_column_names_cannot_be_empty(2, repair_hint = TRUE)
+      abort_column_names_cannot_be_empty(2, repair_hint = TRUE)
     )
   )
 
@@ -543,20 +543,20 @@ test_that("`validate` always raises lifecycle warning.", {
 
   df <- data.frame(a = 1, "hi")
   names(df) <- c("a", "")
-  expect_tibble_error(
+  expect_tibble_abort(
     expect_warning(
       as_tibble(df, validate = TRUE, .name_repair = "check_unique"),
       NA
     ),
-    error_column_names_cannot_be_empty(2, repair_hint = TRUE)
+    abort_column_names_cannot_be_empty(2, repair_hint = TRUE)
   )
 })
 
 test_that("Inconsistent `validate` and `.name_repair` used together raise a warning.", {
   expect_deprecated(
-    expect_tibble_error(
+    expect_tibble_abort(
       as_tibble(list(a = 1, "hi"), validate = FALSE, .name_repair = "check_unique"),
-      error_column_names_cannot_be_empty(2, repair_hint = TRUE)
+      abort_column_names_cannot_be_empty(2, repair_hint = TRUE)
     )
   )
 
@@ -575,9 +575,9 @@ test_that("Inconsistent `validate` and `.name_repair` used together raise a warn
   df <- data.frame(a = 1, "hi")
   names(df) <- c("a", "")
   expect_deprecated(
-    expect_tibble_error(
+    expect_tibble_abort(
       as_tibble(df, validate = FALSE, .name_repair = "check_unique"),
-      error_column_names_cannot_be_empty(2, repair_hint = TRUE)
+      abort_column_names_cannot_be_empty(2, repair_hint = TRUE)
     )
   )
 })

--- a/tests/testthat/test-enframe.R
+++ b/tests/testthat/test-enframe.R
@@ -54,16 +54,16 @@ test_that("can enframe without names", {
 })
 
 test_that("can't use value = NULL", {
-  expect_tibble_error(
+  expect_tibble_abort(
     enframe(letters, value = NULL),
-    error_enframe_value_null()
+    abort_enframe_value_null()
   )
 })
 
 test_that("can't pass non-vector", {
-  expect_tibble_error(
+  expect_tibble_abort(
     enframe(lm(speed ~ ., cars)),
-    error_enframe_must_be_vector(lm(speed ~ ., cars))
+    abort_enframe_must_be_vector(lm(speed ~ ., cars))
   )
 })
 

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -1,10 +1,10 @@
-test_that("tibble_error()", {
-  # Must be called from a function whose name starts with `error_`
-  error_foo <- function() {
-    tibble_error("message", foo = 42, bar = 7)
+test_that("tibble_abort()", {
+  # Must be called from a function whose name starts with `abort_`
+  abort_foo <- function() {
+    tibble_abort("message", foo = 42, bar = 7)
   }
-  expect_identical(
-    error_foo(),
+  expect_cnd_equivalent(
+    tryCatch(abort_foo(), error = identity),
     error_cnd(
       class = c("tibble_error_foo", "tibble_error"),
       message = "message",

--- a/tests/testthat/test-msg.R
+++ b/tests/testthat/test-msg.R
@@ -3,7 +3,7 @@ test_that("error class", {
 })
 
 test_that("aborting with class", {
-  expect_error(cnd_signal(error_enframe_value_null()), class = tibble_error_class("enframe_value_null")[[1]])
+  expect_error(abort_enframe_value_null(), class = tibble_error_class("enframe_value_null")[[1]])
 })
 
 test_that("output test", {
@@ -11,139 +11,139 @@ test_that("output test", {
 
   expect_snapshot(variant = rlang_variant(), {
     "# add"
-    error_add_rows_to_grouped_df()
+    print_error(abort_add_rows_to_grouped_df())
 
-    error_incompatible_new_rows("a")
-    error_incompatible_new_rows(letters[2:3])
-    error_incompatible_new_rows(LETTERS)
+    print_error(abort_incompatible_new_rows("a"))
+    print_error(abort_incompatible_new_rows(letters[2:3]))
+    print_error(abort_incompatible_new_rows(LETTERS))
 
-    error_both_before_after()
+    print_error(abort_both_before_after())
 
-    error_unknown_column_names("a")
-    error_unknown_column_names(c("b", "c"))
-    error_unknown_column_names(LETTERS)
+    print_error(abort_unknown_column_names("a"))
+    print_error(abort_unknown_column_names(c("b", "c")))
+    print_error(abort_unknown_column_names(LETTERS))
 
-    error_incompatible_new_cols(10, data.frame(a = 1:2))
-    error_incompatible_new_cols(1, data.frame(a = 1:3, b = 2:4))
+    print_error(abort_incompatible_new_cols(10, data.frame(a = 1:2)))
+    print_error(abort_incompatible_new_cols(1, data.frame(a = 1:3, b = 2:4)))
 
     "# as_tibble"
-    error_column_scalar_type("a", 3, "environment")
-    error_column_scalar_type("", 3, "environment")
-    error_column_scalar_type(letters[2:3], 3:4, c("name", "NULL"))
-    error_column_scalar_type(c("", "", LETTERS), 1:28, c("QQ", "VV", letters))
+    print_error(abort_column_scalar_type("a", 3, "environment"))
+    print_error(abort_column_scalar_type("", 3, "environment"))
+    print_error(abort_column_scalar_type(letters[2:3], 3:4, c("name", "NULL")))
+    print_error(abort_column_scalar_type(c("", "", LETTERS), 1:28, c("QQ", "VV", letters)))
 
-    error_as_tibble_row_vector(new_environment())
-    error_as_tibble_row_size_one(3, "foo", 7)
+    print_error(abort_as_tibble_row_vector(new_environment()))
+    print_error(abort_as_tibble_row_size_one(3, "foo", 7))
 
     "# class-tbl_df"
-    error_names_must_be_non_null()
+    print_error(abort_names_must_be_non_null())
 
-    error_names_must_have_length(length = 5, n = 3)
+    print_error(abort_names_must_have_length(length = 5, n = 3))
 
     "#enframe"
-    error_enframe_value_null()
-    error_enframe_must_be_vector(lm(speed ~ ., cars))
+    print_error(abort_enframe_value_null())
+    print_error(abort_enframe_must_be_vector(lm(speed ~ ., cars)))
 
     "# names"
-    error_column_names_cannot_be_empty(1, repair_hint = TRUE)
-    error_column_names_cannot_be_empty(2:3, repair_hint = TRUE)
-    error_column_names_cannot_be_empty(seq_along(letters), repair_hint = TRUE)
-    error_column_names_cannot_be_empty(4:6, repair_hint = FALSE)
+    print_error(abort_column_names_cannot_be_empty(1, repair_hint = TRUE))
+    print_error(abort_column_names_cannot_be_empty(2:3, repair_hint = TRUE))
+    print_error(abort_column_names_cannot_be_empty(seq_along(letters), repair_hint = TRUE))
+    print_error(abort_column_names_cannot_be_empty(4:6, repair_hint = FALSE))
 
-    error_column_names_cannot_be_dot_dot(1, repair_hint = FALSE)
-    error_column_names_cannot_be_dot_dot(2:3, repair_hint = TRUE)
-    error_column_names_cannot_be_dot_dot(1:26, repair_hint = TRUE)
+    print_error(abort_column_names_cannot_be_dot_dot(1, repair_hint = FALSE))
+    print_error(abort_column_names_cannot_be_dot_dot(2:3, repair_hint = TRUE))
+    print_error(abort_column_names_cannot_be_dot_dot(1:26, repair_hint = TRUE))
 
-    error_column_names_must_be_unique("a", repair_hint = FALSE)
-    error_column_names_must_be_unique(letters[2:3], repair_hint = TRUE)
-    error_column_names_must_be_unique(LETTERS, repair_hint = TRUE)
+    print_error(abort_column_names_must_be_unique("a", repair_hint = FALSE))
+    print_error(abort_column_names_must_be_unique(letters[2:3], repair_hint = TRUE))
+    print_error(abort_column_names_must_be_unique(LETTERS, repair_hint = TRUE))
 
     "# new"
-    error_new_tibble_must_be_list()
-    error_new_tibble_nrow_must_be_nonnegative()
+    print_error(abort_new_tibble_must_be_list())
+    print_error(abort_new_tibble_nrow_must_be_nonnegative())
 
     "# rownames"
-    error_already_has_rownames()
+    print_error(abort_already_has_rownames())
 
     "# subsetting"
-    error_need_rhs_vector(quote(RHS))
-    error_need_rhs_vector_or_null(quote(RHS))
+    print_error(abort_need_rhs_vector(quote(RHS)))
+    print_error(abort_need_rhs_vector_or_null(quote(RHS)))
 
-    error_na_column_index(1:3)
-    error_dim_column_index(as.matrix("x"))
+    print_error(abort_na_column_index(1:3))
+    print_error(abort_dim_column_index(as.matrix("x")))
 
-    error_assign_columns_non_na_only()
-    error_subset_columns_non_missing_only()
-    error_assign_columns_non_missing_only()
+    print_error(abort_assign_columns_non_na_only())
+    print_error(abort_subset_columns_non_missing_only())
+    print_error(abort_assign_columns_non_missing_only())
 
-    error_duplicate_column_subscript_for_assignment(c(1, 1))
-    error_duplicate_column_subscript_for_assignment(c(1, 1, 2, 2))
+    print_error(abort_duplicate_column_subscript_for_assignment(c(1, 1)))
+    print_error(abort_duplicate_column_subscript_for_assignment(c(1, 1, 2, 2)))
 
-    error_assign_rows_non_na_only()
+    print_error(abort_assign_rows_non_na_only())
 
-    error_duplicate_row_subscript_for_assignment(c(1, 1))
-    error_duplicate_row_subscript_for_assignment(c(1, 1, 2, 2))
+    print_error(abort_duplicate_row_subscript_for_assignment(c(1, 1)))
+    print_error(abort_duplicate_row_subscript_for_assignment(c(1, 1, 2, 2)))
 
-    error_assign_incompatible_size(3, list(1:2), 1, NULL, quote(rhs))
-    error_assign_incompatible_size(4, list(1:4, 3:4), 2, quote(4:1), quote(rhs))
+    print_error(abort_assign_incompatible_size(3, list(1:2), 1, NULL, quote(rhs)))
+    print_error(abort_assign_incompatible_size(4, list(1:4, 3:4), 2, quote(4:1), quote(rhs)))
 
-    error_assign_incompatible_type(tibble(a = 1), list("c"), 1, quote(rhs), "Can't frobnicate.")
+    print_error(abort_assign_incompatible_type(tibble(a = 1), list("c"), 1, quote(rhs), "Can't frobnicate."))
 
     "# subsetting-matrix"
-    error_subset_matrix_must_be_logical(quote(is.na(x) + 1))
-    error_subset_matrix_must_have_same_dimensions(quote(t(is.na(x))))
-    error_subset_matrix_scalar_type(quote(is.na(x)), quote(new_environment()))
-    error_subset_matrix_must_be_scalar(quote(is.na(x)), quote(1:3))
+    print_error(abort_subset_matrix_must_be_logical(quote(is.na(x) + 1)))
+    print_error(abort_subset_matrix_must_have_same_dimensions(quote(t(is.na(x)))))
+    print_error(abort_subset_matrix_scalar_type(quote(is.na(x)), quote(new_environment())))
+    print_error(abort_subset_matrix_must_be_scalar(quote(is.na(x)), quote(1:3)))
 
     "# tibble"
-    error_tibble_row_size_one(3, "foo", 7)
+    print_error(abort_tibble_row_size_one(3, "foo", 7))
 
-    error_incompatible_size(
+    print_error(abort_incompatible_size(
       10,
       letters[1:3],
       c(4, 4, 3),
       "Requested with `uvw` argument"
-    )
-    error_incompatible_size(
+    ))
+    print_error(abort_incompatible_size(
       10,
       letters[1:3],
       c(2, 2, 3),
       "Requested with `xyz` argument"
-    )
-    error_incompatible_size(
+    ))
+    print_error(abort_incompatible_size(
       NULL,
       letters[1:3],
       c(2, 2, 3),
       "Requested with `xyz` argument"
-    )
-    error_incompatible_size(
+    ))
+    print_error(abort_incompatible_size(
       10,
       1:3,
       c(4, 4, 3),
       "Requested with `uvw` argument"
-    )
-    error_incompatible_size(
+    ))
+    print_error(abort_incompatible_size(
       10,
       1:3,
       c(2, 2, 3),
       "Requested with `xyz` argument"
-    )
-    error_incompatible_size(
+    ))
+    print_error(abort_incompatible_size(
       NULL,
       1:3,
       c(2, 2, 3),
       "Requested with `xyz` argument"
-    )
+    ))
 
     "# tribble"
-    error_tribble_needs_columns()
+    print_error(abort_tribble_needs_columns())
 
-    error_tribble_lhs_column_syntax(quote(lhs))
+    print_error(abort_tribble_lhs_column_syntax(quote(lhs)))
 
-    error_tribble_rhs_column_syntax(quote(a + b))
+    print_error(abort_tribble_rhs_column_syntax(quote(a + b)))
 
-    error_tribble_non_rectangular(5, 17)
+    print_error(abort_tribble_non_rectangular(5, 17))
 
-    error_frame_matrix_list(2:4)
+    print_error(abort_frame_matrix_list(2:4))
   })
 })

--- a/tests/testthat/test-msg.R
+++ b/tests/testthat/test-msg.R
@@ -88,6 +88,7 @@ test_that("output test", {
     print_error(abort_assign_incompatible_size(4, list(1:4, 3:4), 2, quote(4:1), quote(rhs)))
 
     print_error(abort_assign_incompatible_type(tibble(a = 1), list("c"), 1, quote(rhs)))
+    print_error(abort_assign_vector(list("c"), 1, quote(rhs)))
 
     "# subsetting-matrix"
     print_error(abort_subset_matrix_must_be_logical(quote(is.na(x) + 1)))

--- a/tests/testthat/test-msg.R
+++ b/tests/testthat/test-msg.R
@@ -87,7 +87,7 @@ test_that("output test", {
     print_error(abort_assign_incompatible_size(3, list(1:2), 1, NULL, quote(rhs)))
     print_error(abort_assign_incompatible_size(4, list(1:4, 3:4), 2, quote(4:1), quote(rhs)))
 
-    print_error(abort_assign_incompatible_type(tibble(a = 1), list("c"), 1, quote(rhs), "Can't frobnicate."))
+    print_error(abort_assign_incompatible_type(tibble(a = 1), list("c"), 1, quote(rhs)))
 
     "# subsetting-matrix"
     print_error(abort_subset_matrix_must_be_logical(quote(is.na(x) + 1)))

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -1,14 +1,14 @@
 test_that("set_repaired_names()", {
   x <- set_names(1:3, letters[1:3])
   expect_equal(set_repaired_names(x), x)
-  expect_tibble_error(set_repaired_names(1, repair_hint = FALSE), error_column_names_cannot_be_empty(1, repair_hint = FALSE))
+  expect_tibble_abort(set_repaired_names(1, repair_hint = FALSE), abort_column_names_cannot_be_empty(1, repair_hint = FALSE))
 })
 
 test_that("repaired_names()", {
   expect_equal(repaired_names(letters[1:3], repair_hint = FALSE), letters[1:3])
-  expect_tibble_error(repaired_names(c(""), repair_hint = FALSE), error_column_names_cannot_be_empty(1, repair_hint = FALSE))
-  expect_tibble_error(repaired_names(c("..1"), repair_hint = FALSE), error_column_names_cannot_be_dot_dot(1, repair_hint = FALSE))
-  expect_tibble_error(repaired_names(c("a", "a"), repair_hint = FALSE), error_column_names_must_be_unique("a", repair_hint = FALSE))
+  expect_tibble_abort(repaired_names(c(""), repair_hint = FALSE), abort_column_names_cannot_be_empty(1, repair_hint = FALSE))
+  expect_tibble_abort(repaired_names(c("..1"), repair_hint = FALSE), abort_column_names_cannot_be_dot_dot(1, repair_hint = FALSE))
+  expect_tibble_abort(repaired_names(c("a", "a"), repair_hint = FALSE), abort_column_names_must_be_unique("a", repair_hint = FALSE))
   expect_equal(repaired_names(c("a", "a"), .name_repair = "minimal"), c("a", "a"))
 })
 

--- a/tests/testthat/test-new.R
+++ b/tests/testthat/test-new.R
@@ -102,29 +102,29 @@ test_that("new_tibble checks", {
   expect_identical(new_tibble(list(), nrow = 0), tibble())
   expect_identical(new_tibble(list(), nrow = 5), tibble(.rows = 5))
   expect_identical(new_tibble(list(a = 1:3, b = 4:6), nrow = 3), tibble(a = 1:3, b = 4:6))
-  expect_tibble_error(
+  expect_tibble_abort(
     new_tibble(1:3, nrow = 1),
-    error_new_tibble_must_be_list()
+    abort_new_tibble_must_be_list()
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     new_tibble(list(a = 1), nrow = -1),
-    error_new_tibble_nrow_must_be_nonnegative()
+    abort_new_tibble_nrow_must_be_nonnegative()
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     new_tibble(list(a = 1), nrow = "a"),
-    error_new_tibble_nrow_must_be_nonnegative()
+    abort_new_tibble_nrow_must_be_nonnegative()
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     new_tibble(list(a = 1), nrow = 1:2),
-    error_new_tibble_nrow_must_be_nonnegative()
+    abort_new_tibble_nrow_must_be_nonnegative()
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     new_tibble(list(a = 1), nrow = 2147483648),
-    error_new_tibble_nrow_must_be_nonnegative()
+    abort_new_tibble_nrow_must_be_nonnegative()
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     new_tibble(list(1), nrow = 1),
-    error_names_must_be_non_null()
+    abort_names_must_be_non_null()
   )
   expect_error(
     new_tibble(set_names(list(1), NA_character_), nrow = 1),
@@ -148,9 +148,9 @@ test_that("new_tibble checks", {
 })
 
 test_that("validate_tibble() checks", {
-  expect_tibble_error(
+  expect_tibble_abort(
     validate_tibble(new_tibble(list(a = 1, b = 2:3), nrow = 1)),
-    error_incompatible_size(1, c("a", "b"), 1:2, "Requested with `nrow` argument")
+    abort_incompatible_size(1, c("a", "b"), 1:2, "Requested with `nrow` argument")
   )
 })
 

--- a/tests/testthat/test-rownames.R
+++ b/tests/testthat/test-rownames.R
@@ -22,9 +22,9 @@ test_that("rownames_to_column keeps the tbl classes (#882)", {
   expect_false(has_rownames(res))
   expect_equal(class(res), class(mtcars))
   expect_equal(res$rowname, rownames(mtcars))
-  expect_tibble_error(
+  expect_tibble_abort(
     rownames_to_column(mtcars, "wt"),
-    error_column_names_must_be_unique("wt", repair = FALSE)
+    abort_column_names_must_be_unique("wt", repair = FALSE)
   )
 
   mtcars2 <- as_tibble(mtcars, rownames = NA)
@@ -33,9 +33,9 @@ test_that("rownames_to_column keeps the tbl classes (#882)", {
   expect_false(has_rownames(res1))
   expect_equal(class(res1), class(mtcars2))
   expect_equal(res1$`Make&Model`, rownames(mtcars))
-  expect_tibble_error(
+  expect_tibble_abort(
     rownames_to_column(mtcars2, "wt"),
-    error_column_names_must_be_unique("wt", repair = FALSE)
+    abort_column_names_must_be_unique("wt", repair = FALSE)
   )
 })
 
@@ -44,9 +44,9 @@ test_that("rowid_to_column keeps the tbl classes", {
   expect_false(has_rownames(res))
   expect_equal(class(res), class(mtcars))
   expect_equal(res$rowid, seq_len(nrow(mtcars)))
-  expect_tibble_error(
+  expect_tibble_abort(
     rowid_to_column(mtcars, "wt"),
-    error_column_names_must_be_unique("wt", repair = FALSE)
+    abort_column_names_must_be_unique("wt", repair = FALSE)
   )
 
   mtcars2 <- as_tibble(mtcars, rownames = NA)
@@ -55,9 +55,9 @@ test_that("rowid_to_column keeps the tbl classes", {
   expect_false(has_rownames(res1))
   expect_equal(class(res1), class(mtcars2))
   expect_equal(res1$row_id, seq_len(nrow(mtcars)))
-  expect_tibble_error(
+  expect_tibble_abort(
     rowid_to_column(mtcars2, "wt"),
-    error_column_names_must_be_unique("wt", repair = FALSE)
+    abort_column_names_must_be_unique("wt", repair = FALSE)
   )
 })
 
@@ -79,13 +79,13 @@ test_that("column_to_rownames returns tbl", {
   expect_warning(res <- column_to_rownames(res0, var = "num"), NA)
   expect_true(has_rownames(res))
   expect_equal(rownames(res), as.character(mtcars1$num))
-  expect_tibble_error(
+  expect_tibble_abort(
     column_to_rownames(res),
-    error_already_has_rownames()
+    abort_already_has_rownames()
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     column_to_rownames(rownames_to_column(mtcars1, var), "num2"),
-    error_unknown_column_names("num2")
+    abort_unknown_column_names("num2")
   )
 })
 

--- a/tests/testthat/test-subsetting.R
+++ b/tests/testthat/test-subsetting.R
@@ -599,7 +599,7 @@ test_that("[<-.tbl_df supports matrix on the RHS (#762)", {
     df[1:3, 1:2] <- matrix(6:1, ncol = 2),
     abort_assign_incompatible_type(
       df, as.data.frame(matrix(6:1, ncol = 2)), 2, quote(matrix(6:1, ncol = 2)),
-      cnd_message(tryCatch(vctrs::vec_assign(letters, 1:3, 3:1), error = identity))
+      tryCatch(vctrs::vec_assign(letters, 1:3, 3:1), error = identity)
     )
   )
   expect_tibble_abort(

--- a/tests/testthat/test-subsetting.R
+++ b/tests/testthat/test-subsetting.R
@@ -129,9 +129,9 @@ test_that("[.tbl_df is careful about column indexes (#83)", {
       foo[-4],
       class = "vctrs_error_subscript_oob"
     )
-    expect_tibble_error(
+    expect_tibble_abort(
       foo[c(1:3, NA)],
-      error_na_column_index(4)
+      abort_na_column_index(4)
     )
 
     expect_error(foo[as.matrix(1)])
@@ -156,14 +156,14 @@ test_that("[.tbl_df is careful about column flags (#83)", {
       foo[c(TRUE, TRUE, FALSE, FALSE)],
       class = "vctrs_error_subscript_size"
     )
-    expect_tibble_error(
+    expect_tibble_abort(
       foo[c(TRUE, TRUE, NA)],
-      error_na_column_index(3)
+      abort_na_column_index(3)
     )
 
-    expect_tibble_error(
+    expect_tibble_abort(
       foo[as.matrix(TRUE)],
-      error_subset_matrix_must_have_same_dimensions(quote(as.matrix(TRUE)))
+      abort_subset_matrix_must_have_same_dimensions(quote(as.matrix(TRUE)))
     )
     expect_error(
       foo[array(TRUE, dim = c(1, 1, 1))],
@@ -512,17 +512,17 @@ test_that("[<-.tbl_df can remove columns", {
 test_that("[<-.tbl_df throws an error with duplicate indexes (#658)", {
   verify_errors({
     df <- tibble(x = 1:2, y = x)
-    expect_tibble_error(
+    expect_tibble_abort(
       df[c(1, 1)] <- 3,
-      error_duplicate_column_subscript_for_assignment(c(1, 1))
+      abort_duplicate_column_subscript_for_assignment(c(1, 1))
     )
-    expect_tibble_error(
+    expect_tibble_abort(
       df[, c(1, 1)] <- 3,
-      error_duplicate_column_subscript_for_assignment(c(1, 1))
+      abort_duplicate_column_subscript_for_assignment(c(1, 1))
     )
-    expect_tibble_error(
+    expect_tibble_abort(
       df[c(1, 1), ] <- 3,
-      error_duplicate_row_subscript_for_assignment(c(1, 1))
+      abort_duplicate_row_subscript_for_assignment(c(1, 1))
     )
   })
 })
@@ -595,20 +595,20 @@ test_that("[<-.tbl_df supports matrix on the RHS (#762)", {
   expect_identical(df, tibble(x = 8:5, y = 4:1))
 
   df <- tibble(x = 1:4, y = letters[1:4])
-  expect_tibble_error(
+  expect_tibble_abort(
     df[1:3, 1:2] <- matrix(6:1, ncol = 2),
-    error_assign_incompatible_type(
+    abort_assign_incompatible_type(
       df, as.data.frame(matrix(6:1, ncol = 2)), 2, quote(matrix(6:1, ncol = 2)),
       cnd_message(tryCatch(vctrs::vec_assign(letters, 1:3, 3:1), error = identity))
     )
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     df[1:2] <- array(8:1, dim = c(2, 1, 4)),
-    error_need_rhs_vector_or_null(quote(array(8:1, dim = c(2, 1, 4))))
+    abort_need_rhs_vector_or_null(quote(array(8:1, dim = c(2, 1, 4))))
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     df[1:2] <- array(8:1, dim = c(4, 1, 2)),
-    error_need_rhs_vector_or_null(quote(array(8:1, dim = c(4, 1, 2))))
+    abort_need_rhs_vector_or_null(quote(array(8:1, dim = c(4, 1, 2))))
   )
 })
 
@@ -725,13 +725,13 @@ test_that("$<- throws different warning if attempting a partial initialization (
     fixed = TRUE
   )
 
-  expect_tibble_error(
+  expect_tibble_abort(
     expect_warning(
       df$z[1:2] <- 2,
       "Unknown or uninitialised column: `z`",
       fixed = TRUE
     ),
-    error_assign_incompatible_size(3, list(1:2), 1, NULL, quote(`<dbl>`))
+    abort_assign_incompatible_size(3, list(1:2), 1, NULL, quote(`<dbl>`))
   )
 })
 
@@ -749,14 +749,14 @@ test_that("$<- recycles only values of length one", {
   verify_errors({
     df <- tibble(x = 1:3)
 
-    expect_tibble_error(
+    expect_tibble_abort(
       df$w <- 8:9,
-      error_assign_incompatible_size(3, list(8:9), 1, NULL, quote(8:9))
+      abort_assign_incompatible_size(3, list(8:9), 1, NULL, quote(8:9))
     )
 
-    expect_tibble_error(
+    expect_tibble_abort(
       df$a <- character(),
-      error_assign_incompatible_size(3, list(character()), 1, NULL, quote(character()))
+      abort_assign_incompatible_size(3, list(character()), 1, NULL, quote(character()))
     )
   })
 })

--- a/tests/testthat/test-tibble.R
+++ b/tests/testthat/test-tibble.R
@@ -19,22 +19,22 @@ test_that("NULL is ignored when passed by value (#895, #900)", {
 })
 
 test_that("bogus columns raise an error", {
-  expect_tibble_error(
+  expect_tibble_abort(
     tibble(a = new.env()),
-    error_column_scalar_type("a", 1, "an environment")
+    abort_column_scalar_type("a", 1, "an environment")
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     tibble(a = quote(a)),
-    error_column_scalar_type("a", 1, "a symbol")
+    abort_column_scalar_type("a", 1, "a symbol")
   )
 })
 
 test_that("length 1 vectors are recycled", {
   expect_equal(nrow(tibble(x = 1:10)), 10)
   expect_equal(nrow(tibble(x = 1:10, y = 1)), 10)
-  expect_tibble_error(
+  expect_tibble_abort(
     tibble(x = 1:10, y = 1:2),
-    error_incompatible_size(10, "y", 2, "Existing data")
+    abort_incompatible_size(10, "y", 2, "Existing data")
   )
 })
 
@@ -115,9 +115,9 @@ test_that("tibble aliases", {
 # Validation --------------------------------------------------------------
 
 test_that("NULL isn't a valid column", {
-  expect_tibble_error(
+  expect_tibble_abort(
     check_valid_cols(list(a = NULL)),
-    error_column_scalar_type("a", 1, "NULL")
+    abort_column_scalar_type("a", 1, "NULL")
   )
 })
 
@@ -223,13 +223,13 @@ test_that("returns a single row (#416)", {
     tibble_row(trees[1, ]),
     tibble(trees[1, ])
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     tibble_row(a = 1, b = 2:3),
-    error_tibble_row_size_one(2, "b", 2)
+    abort_tibble_row_size_one(2, "b", 2)
   )
-  expect_tibble_error(
+  expect_tibble_abort(
     tibble_row(trees[2:3, ]),
-    error_tibble_row_size_one(1, "", 2)
+    abort_tibble_row_size_one(1, "", 2)
   )
 })
 

--- a/tests/testthat/test-tribble.R
+++ b/tests/testthat/test-tribble.R
@@ -84,49 +84,49 @@ test_that("tribble() creates lists for non-atomic inputs (#7)", {
 
 test_that("tribble() errs appropriately on bad calls", {
   # no colname
-  expect_tibble_error(
+  expect_tibble_abort(
     tribble(1, 2, 3),
-    error_tribble_needs_columns()
+    abort_tribble_needs_columns()
   )
 
   # invalid colname syntax
-  expect_tibble_error(
+  expect_tibble_abort(
     tribble(a ~ b),
-    error_tribble_lhs_column_syntax(quote(a))
+    abort_tribble_lhs_column_syntax(quote(a))
   )
 
   # invalid colname syntax
-  expect_tibble_error(
+  expect_tibble_abort(
     tribble(~ a + b),
-    error_tribble_rhs_column_syntax(quote(a + b))
+    abort_tribble_rhs_column_syntax(quote(a + b))
   )
 
   # tribble() must be passed colnames
-  expect_tibble_error(
+  expect_tibble_abort(
     tribble(
       "a", "b",
       1, 2
     ),
-    error_tribble_needs_columns()
+    abort_tribble_needs_columns()
   )
 
   # tribble() must produce rectangular structure (no filling)
-  expect_tibble_error(
+  expect_tibble_abort(
     tribble(
       ~a, ~b, ~c,
       1, 2,
       3, 4, 5
     ),
-    error_tribble_non_rectangular(3, 5)
+    abort_tribble_non_rectangular(3, 5)
   )
 
-  expect_tibble_error(
+  expect_tibble_abort(
     tribble(
       ~a, ~b, ~c, ~d,
       1, 2, 3, 4, 5,
       6, 7, 8, 9,
     ),
-    error_tribble_non_rectangular(4, 9)
+    abort_tribble_non_rectangular(4, 9)
   )
 })
 
@@ -205,24 +205,24 @@ test_that("frame_matrix constructs empty matrix as expected", {
 })
 
 test_that("frame_matrix cannot have list columns", {
-  expect_tibble_error(
+  expect_tibble_abort(
     frame_matrix(
       ~x,   ~y,
       "a", 1:3,
       "b", 4:6
     ),
-    error_frame_matrix_list(c(2, 4))
+    abort_frame_matrix_list(c(2, 4))
   )
 })
 
 test_that("tribble and frame_matrix cannot have named arguments", {
-  expect_tibble_error(
+  expect_tibble_abort(
     extract_frame_data_from_dots(
       ~x, ~y,
       "a" = 1:3,
       "b" = 4:6
     ),
-    error_tribble_named_after_tilde()
+    abort_tribble_named_after_tilde()
   )
 })
 

--- a/tests/testthat/test-zzz-add.R
+++ b/tests/testthat/test-zzz-add.R
@@ -41,13 +41,13 @@ test_that("adds empty row if no arguments", {
 test_that("error if adding row with unknown variables", {
   expect_legacy_error(
     add_row(tibble(a = 3), xxyzy = "err"),
-    error_inconsistent_new_rows("xxyzy"),
+    abort_inconsistent_new_rows("xxyzy"),
     fixed = TRUE
   )
 
   expect_legacy_error(
     add_row(tibble(a = 3), b = "err", c = "oops"),
-    error_inconsistent_new_rows(c("b", "c")),
+    abort_inconsistent_new_rows(c("b", "c")),
     fixed = TRUE
   )
 })
@@ -107,7 +107,7 @@ test_that("error if both .before and .after are given", {
   df <- tibble(a = 1:3)
   expect_legacy_error(
     add_row(df, a = 4:5, .after = 2, .before = 3),
-    error_both_before_after(),
+    abort_both_before_after(),
     fixed = TRUE
   )
 })
@@ -135,7 +135,7 @@ test_that("add_row() fails nicely for grouped data frames (#179)", {
   skip_if_not_installed("dplyr")
   expect_legacy_error(
     add_row(dplyr::group_by(iris, Species), Petal.Width = 3),
-    error_add_rows_to_grouped_df(),
+    abort_add_rows_to_grouped_df(),
     fixed = TRUE
   )
 })
@@ -186,7 +186,7 @@ test_that("add_column() can add to empty tibble or data frame", {
 test_that("error if adding existing columns", {
   expect_legacy_error(
     add_column(tibble(a = 3), a = 5),
-    error_duplicate_new_cols("a"),
+    abort_duplicate_new_cols("a"),
     fixed = TRUE
   )
 })
@@ -194,7 +194,7 @@ test_that("error if adding existing columns", {
 test_that("error if adding wrong number of rows with add_column()", {
   expect_legacy_error(
     add_column(tibble(a = 3), b = 4:5),
-    error_inconsistent_new_cols(1, data.frame(b = 4:5)),
+    abort_inconsistent_new_cols(1, data.frame(b = 4:5)),
     fixed = TRUE
   )
 })
@@ -257,7 +257,7 @@ test_that("error if both .before and .after are given", {
   df <- tibble(a = 1:3)
   expect_legacy_error(
     add_column(df, b = 4:6, .after = 2, .before = 3),
-    error_both_before_after(),
+    abort_both_before_after(),
     fixed = TRUE
   )
 })
@@ -268,12 +268,12 @@ test_that("error if column named by .before or .after not found", {
   df <- tibble(a = 1:3)
   expect_error(
     add_column(df, b = 4:6, .after = "x"),
-    error_unknown_names("x"),
+    abort_unknown_names("x"),
     fixed = TRUE
   )
   expect_error(
     add_column(df, b = 4:6, .before = "x"),
-    error_unknown_names("x"),
+    abort_unknown_names("x"),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-zzz-data-frame.R
+++ b/tests/testthat/test-zzz-data-frame.R
@@ -15,7 +15,7 @@ test_that("bogus columns raise an error", {
   skip_enh_tibble_null()
   expect_error(
     tibble(a = NULL),
-    error_column_scalar_type("a", "NULL"),
+    abort_column_scalar_type("a", "NULL"),
     fixed = TRUE
   )
 })
@@ -23,12 +23,12 @@ test_that("bogus columns raise an error", {
 test_that("bogus columns raise an error", {
   expect_legacy_error(
     tibble(a = new.env()),
-    error_column_scalar_type("a", "environment"),
+    abort_column_scalar_type("a", "environment"),
     fixed = TRUE
   )
   expect_legacy_error(
     tibble(a = quote(a)),
-    error_column_scalar_type("a", "name"),
+    abort_column_scalar_type("a", "name"),
     fixed = TRUE
   )
 })
@@ -38,7 +38,7 @@ test_that("length 1 vectors are recycled", {
   expect_equal(nrow(tibble(x = 1:10, y = 1)), 10)
   expect_legacy_error(
     tibble(x = 1:10, y = 1:2),
-    error_inconsistent_cols(NULL, c("x", "y"), c(10, 2), NA),
+    abort_inconsistent_cols(NULL, c("x", "y"), c(10, 2), NA),
     fixed = TRUE
   )
 })
@@ -132,12 +132,12 @@ test_that("columns are recycled to common length", {
 test_that("columns must be same length", {
   expect_legacy_error(
     as_tibble(list(x = 1:2, y = 1:3)),
-    error_inconsistent_cols(NULL, c("x", "y"), 2:3, NA),
+    abort_inconsistent_cols(NULL, c("x", "y"), 2:3, NA),
     fixed = TRUE
   )
   expect_legacy_error(
     as_tibble(list(x = 1:2, y = 1:3, z = 1:4)),
-    error_inconsistent_cols(
+    abort_inconsistent_cols(
       NULL,
       c("x", "y", "z"),
       2:4,
@@ -147,7 +147,7 @@ test_that("columns must be same length", {
   )
   expect_legacy_error(
     as_tibble(list(x = 1:4, y = 1:2, z = 1:2)),
-    error_inconsistent_cols(
+    abort_inconsistent_cols(
       NULL,
       c("x", "y", "z"),
       c(4, 2, 2),
@@ -157,7 +157,7 @@ test_that("columns must be same length", {
   )
   expect_legacy_error(
     as_tibble(list(x = 1, y = 1:4, z = 1:2)),
-    error_inconsistent_cols(
+    abort_inconsistent_cols(
       NULL,
       c("y", "z"),
       c(4, 2),
@@ -167,7 +167,7 @@ test_that("columns must be same length", {
   )
   expect_legacy_error(
     as_tibble(list(x = 1:2, y = 1:4, z = 1)),
-    error_inconsistent_cols(
+    abort_inconsistent_cols(
       NULL,
       c("x", "y"),
       c(2, 4),
@@ -270,28 +270,28 @@ test_that("as_tibble() checks for `unique` names by default (#278)", {
   l1 <- list(1:10)
   expect_legacy_error(
     as_tibble(l1),
-    error_column_must_be_named(1, repair_hint = TRUE),
+    abort_column_must_be_named(1, repair_hint = TRUE),
     fixed = TRUE
   )
 
   l2 <- list(x = 1, 2)
   expect_legacy_error(
     as_tibble(l2),
-    error_column_must_be_named(2, repair_hint = TRUE),
+    abort_column_must_be_named(2, repair_hint = TRUE),
     fixed = TRUE
   )
 
   l3 <- list(x = 1, ... = 2)
   expect_legacy_error(
     as_tibble(l3),
-    error_column_must_not_be_dot_dot(2, repair_hint = TRUE),
+    abort_column_must_not_be_dot_dot(2, repair_hint = TRUE),
     fixed = TRUE
   )
 
   l4 <- list(x = 1, ..1 = 2)
   expect_legacy_error(
     as_tibble(l4),
-    error_column_must_not_be_dot_dot(2, repair_hint = TRUE),
+    abort_column_must_not_be_dot_dot(2, repair_hint = TRUE),
     fixed = TRUE
   )
 
@@ -300,7 +300,7 @@ test_that("as_tibble() checks for `unique` names by default (#278)", {
   df <- new_tibble(df, nrow = 1)
   expect_legacy_error(
     as_tibble(df),
-    error_column_must_be_named(1:2, repair_hint = TRUE),
+    abort_column_must_be_named(1:2, repair_hint = TRUE),
     fixed = TRUE
   )
 })
@@ -427,7 +427,7 @@ test_that("as_tibble.table() supports .name_repair", {
 
   expect_legacy_error(
     as_tibble(x),
-    error_column_names_must_be_unique("a")
+    abort_column_names_must_be_unique("a")
   )
   expect_identical(
     names(as_tibble(x, .name_repair = "minimal")),
@@ -535,12 +535,12 @@ test_that("as_tibble() throws an error when user turns missing row names into co
   df <- data.frame(a = 1:3, b = 2:4)
   expect_legacy_error(
     as_tibble(df, rownames = "id"),
-    error_as_tibble_needs_rownames(),
+    abort_as_tibble_needs_rownames(),
     fixed = TRUE
   )
   expect_legacy_error(
     as_tibble(df[0, ], rownames = "id"),
-    error_as_tibble_needs_rownames(),
+    abort_as_tibble_needs_rownames(),
     fixed = TRUE
   )
 })
@@ -561,7 +561,7 @@ test_that("POSIXlt isn't a valid column", {
   skip_enh_posixlt_supported()
   expect_legacy_error(
     check_valid_cols(list(x = as.POSIXlt(Sys.time()))),
-    error_time_column_must_be_posixct("x"),
+    abort_time_column_must_be_posixct("x"),
     fixed = TRUE
   )
 })
@@ -569,7 +569,7 @@ test_that("POSIXlt isn't a valid column", {
 test_that("NULL isn't a valid column", {
   expect_legacy_error(
     check_valid_cols(list(a = NULL)),
-    error_column_scalar_type("a", "NULL"),
+    abort_column_scalar_type("a", "NULL"),
     fixed = TRUE
   )
 })
@@ -612,7 +612,7 @@ test_that("`validate` triggers deprecation message, but then works", {
       "deprecated",
       fixed = TRUE
     ),
-    error_column_must_be_named(2, repair_hint = TRUE)
+    abort_column_must_be_named(2, repair_hint = TRUE)
   )
 
   expect_warning(
@@ -639,7 +639,7 @@ test_that("`validate` triggers deprecation message, but then works", {
       "deprecated",
       fixed = TRUE
     ),
-    error_column_must_be_named(2, repair_hint = TRUE)
+    abort_column_must_be_named(2, repair_hint = TRUE)
   )
 })
 
@@ -653,7 +653,7 @@ test_that("Consistent `validate` and `.name_repair` used together keep silent.",
       as_tibble(list(a = 1, "hi"), validate = TRUE, .name_repair = "check_unique"),
       NA
     ),
-    error_column_must_be_named(2, repair_hint = TRUE)
+    abort_column_must_be_named(2, repair_hint = TRUE)
   )
 
   expect_warning(
@@ -677,7 +677,7 @@ test_that("Consistent `validate` and `.name_repair` used together keep silent.",
       as_tibble(df, validate = TRUE, .name_repair = "check_unique"),
       NA
     ),
-    error_column_must_be_named(2, repair_hint = TRUE)
+    abort_column_must_be_named(2, repair_hint = TRUE)
   )
 })
 
@@ -689,7 +689,7 @@ test_that("Inconsistent `validate` and `.name_repair` used together raise a warn
       as_tibble(list(a = 1, "hi"), validate = FALSE, .name_repair = "check_unique"),
       "precedence"
     ),
-    error_column_must_be_named(2, repair_hint = TRUE)
+    abort_column_must_be_named(2, repair_hint = TRUE)
   )
 
   expect_warning(
@@ -713,7 +713,7 @@ test_that("Inconsistent `validate` and `.name_repair` used together raise a warn
       as_tibble(df, validate = FALSE, .name_repair = "check_unique"),
       "precedence"
     ),
-    error_column_must_be_named(2, repair_hint = TRUE)
+    abort_column_must_be_named(2, repair_hint = TRUE)
   )
 })
 

--- a/tests/testthat/test-zzz-enframe.R
+++ b/tests/testthat/test-zzz-enframe.R
@@ -56,7 +56,7 @@ test_that("can enframe without names", {
 test_that("can't use value = NULL", {
   expect_legacy_error(
     enframe(letters, value = NULL),
-    error_enframe_value_null(),
+    abort_enframe_value_null(),
     fixed = TRUE
   )
 })
@@ -66,7 +66,7 @@ test_that("can't pass objects with dimensions", {
 
   expect_legacy_error(
     enframe(iris),
-    error_enframe_has_dim(iris),
+    abort_enframe_has_dim(iris),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-zzz-glimpse.R
+++ b/tests/testthat/test-zzz-glimpse.R
@@ -102,7 +102,7 @@ test_that("glimpse output matches known output", {
 test_that("glimpse(width = Inf) raises legible error", {
   expect_legacy_error(
     glimpse(mtcars, width = Inf),
-    error_glimpse_infinite_width(),
+    abort_glimpse_infinite_width(),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-zzz-matrix.R
+++ b/tests/testthat/test-zzz-matrix.R
@@ -139,7 +139,7 @@ test_that("converting from matrix throws an error if user turns missing row name
   x <- matrix(1:30, 6, 5)
   expect_error(
     as_tibble(x, rownames = "id", .name_repair = "minimal"),
-    error_as_tibble_needs_rownames(),
+    abort_as_tibble_needs_rownames(),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-zzz-msg.R
+++ b/tests/testthat/test-zzz-msg.R
@@ -1,43 +1,43 @@
 skip("All of them")
 
-test_that("error_enframe_value_null()", {
+test_that("abort_enframe_value_null()", {
   expect_equal(
-    error_enframe_value_null(),
+    abort_enframe_value_null(),
     "The `value` argument to `enframe()` cannot be NULL."
   )
 })
 
-test_that("error_enframe_has_dim()", {
+test_that("abort_enframe_has_dim()", {
   expect_equal(
-    error_enframe_has_dim(Titanic),
+    abort_enframe_has_dim(Titanic),
     "`x` must not have more than one dimension. `length(dim(x))` must be zero or one, not 4."
   )
 })
 
-test_that("error_1d_array_column()", {
+test_that("abort_1d_array_column()", {
   expect_equal(
-    error_1d_array_column(),
+    abort_1d_array_column(),
     "1d arrays are not supported in a tibble column."
   )
 })
 
-test_that("error_unsupported_index()", {
+test_that("abort_unsupported_index()", {
   expect_equal(
-    error_unsupported_index(raw()),
+    abort_unsupported_index(raw()),
     "Can't subset with `[` using an object of class raw."
   )
 })
 
-test_that("error_na_column_index()", {
+test_that("abort_na_column_index()", {
   expect_equal(
-    error_na_column_index(),
+    abort_na_column_index(),
     "Can't use numeric NA as column index with `[`."
   )
 })
 
-test_that("error_nonint_column_index()", {
+test_that("abort_nonint_column_index()", {
   expect_equal(
-    error_nonint_column_index(2:3, 3:4 + 0.5),
+    abort_nonint_column_index(2:3, 3:4 + 0.5),
     bullets(
       "Must use integers to index columns with `[`:",
       paste0("Position ", 2:3, " equals ", 3:4 + 0.5)
@@ -45,9 +45,9 @@ test_that("error_nonint_column_index()", {
   )
 })
 
-test_that("error_small_column_index()", {
+test_that("abort_small_column_index()", {
   expect_equal(
-    error_small_column_index(3, 2, -4),
+    abort_small_column_index(3, 2, -4),
     bullets(
       "Negative column indexes in `[` must match number of columns:",
       "`.data` has 3 columns",
@@ -56,9 +56,9 @@ test_that("error_small_column_index()", {
   )
 })
 
-test_that("error_large_column_index()", {
+test_that("abort_large_column_index()", {
   expect_equal(
-    error_large_column_index(3, 2, 5),
+    abort_large_column_index(3, 2, 5),
     bullets(
       "Positive column indexes in `[` must match number of columns:",
       "`.data` has 3 columns",
@@ -67,9 +67,9 @@ test_that("error_large_column_index()", {
   )
 })
 
-test_that("error_mismatch_column_flag()", {
+test_that("abort_mismatch_column_flag()", {
   expect_equal(
-    error_mismatch_column_flag(5, 3),
+    abort_mismatch_column_flag(5, 3),
     bullets(
       "Length of logical index vector for `[` must equal number of columns (or 1):",
       "`.data` has 5 columns",
@@ -78,53 +78,53 @@ test_that("error_mismatch_column_flag()", {
   )
 })
 
-test_that("error_na_column_flag()", {
+test_that("abort_na_column_flag()", {
   expect_equal(
-    error_na_column_flag(),
+    abort_na_column_flag(),
     "Can't use logical NA when selecting columns with `[`."
   )
 })
 
-test_that("error_unknown_names()", {
+test_that("abort_unknown_names()", {
   expect_equal(
-    error_unknown_names("a"),
+    abort_unknown_names("a"),
     "Can't find column `a` in `.data`."
   )
   expect_equal(
-    error_unknown_names(c("b", "c")),
+    abort_unknown_names(c("b", "c")),
     "Can't find columns `b`, `c` in `.data`."
   )
   expect_equal(
-    unell(error_unknown_names(LETTERS)),
+    unell(abort_unknown_names(LETTERS)),
     "Can't find columns `A`, `B`, `C`, `D`, `E`, ... (and 21 more) in `.data`."
   )
 })
 
-test_that("error_existing_names()", {
+test_that("abort_existing_names()", {
   expect_equal(
-    error_existing_names("a"),
+    abort_existing_names("a"),
     "Column `a` already exists in `.data`."
   )
   expect_equal(
-    error_existing_names(c("b", "c")),
+    abort_existing_names(c("b", "c")),
     "Columns `b`, `c` already exist in `.data`."
   )
   expect_equal(
-    unell(error_existing_names(LETTERS)),
+    unell(abort_existing_names(LETTERS)),
     "Columns `A`, `B`, `C`, `D`, `E`, ... (and 21 more) already exist in `.data`."
   )
 })
 
-test_that("error_add_rows_to_grouped_df()", {
+test_that("abort_add_rows_to_grouped_df()", {
   expect_equal(
-    error_add_rows_to_grouped_df(),
+    abort_add_rows_to_grouped_df(),
     "Can't add rows to grouped data frames"
   )
 })
 
-test_that("error_inconsistent_new_rows()", {
+test_that("abort_inconsistent_new_rows()", {
   expect_equal(
-    error_inconsistent_new_rows("a"),
+    abort_inconsistent_new_rows("a"),
     bullets(
       "New rows in `add_row()` must use columns that already exist:",
       "Can't find column `a` in `.data`."
@@ -132,7 +132,7 @@ test_that("error_inconsistent_new_rows()", {
   )
 
   expect_equal(
-    error_inconsistent_new_rows(letters[2:3]),
+    abort_inconsistent_new_rows(letters[2:3]),
     bullets(
       "New rows in `add_row()` must use columns that already exist:",
       "Can't find columns `b`, `c` in `.data`."
@@ -140,7 +140,7 @@ test_that("error_inconsistent_new_rows()", {
   )
 
   expect_equal(
-    unell(error_inconsistent_new_rows(LETTERS)),
+    unell(abort_inconsistent_new_rows(LETTERS)),
     bullets(
       "New rows in `add_row()` must use columns that already exist:",
       "Can't find columns `A`, `B`, `C`, `D`, `E`, ... (and 21 more) in `.data`."
@@ -148,76 +148,76 @@ test_that("error_inconsistent_new_rows()", {
   )
 })
 
-test_that("error_names_must_not_be_null()", {
+test_that("abort_names_must_not_be_null()", {
   expect_equal(
-    error_names_must_be_non_null(repair_hint = TRUE),
+    abort_names_must_be_non_null(repair_hint = TRUE),
     "The `names` must not be `NULL`.\nUse .name_repair to specify repair."
   )
   expect_equal(
-    error_names_must_be_non_null(repair_hint = FALSE),
+    abort_names_must_be_non_null(repair_hint = FALSE),
     "The `names` must not be `NULL`."
   )
 })
 
-test_that("error_names_must_have_length()", {
+test_that("abort_names_must_have_length()", {
   expect_equal(
-    error_names_must_have_length(length = 5, n = 3),
+    abort_names_must_have_length(length = 5, n = 3),
     "The `names` must have length 3, not 5."
   )
 })
 
-test_that("error_column_must_be_named()", {
+test_that("abort_column_must_be_named()", {
   expect_equal(
-    error_column_must_be_named(1, repair_hint = TRUE),
+    abort_column_must_be_named(1, repair_hint = TRUE),
     "Column 1 must be named.\nUse .name_repair to specify repair."
   )
   expect_equal(
-    error_column_must_be_named(2:3, repair_hint = TRUE),
+    abort_column_must_be_named(2:3, repair_hint = TRUE),
     "Columns 2, 3 must be named.\nUse .name_repair to specify repair."
   )
   expect_equal(
-    unell(error_column_must_be_named(seq_along(letters), repair_hint = TRUE)),
+    unell(abort_column_must_be_named(seq_along(letters), repair_hint = TRUE)),
     "Columns 1, 2, 3, 4, 5, ... (and 21 more) must be named.\nUse .name_repair to specify repair."
   )
   expect_equal(
-    error_column_must_be_named(4:6, repair_hint = FALSE),
+    abort_column_must_be_named(4:6, repair_hint = FALSE),
     "Columns 4, 5, 6 must be named."
   )
 })
 
-test_that("error_column_names_must_be_unique()", {
+test_that("abort_column_names_must_be_unique()", {
   expect_equal(
-    error_column_names_must_be_unique("a", repair_hint = FALSE),
+    abort_column_names_must_be_unique("a", repair_hint = FALSE),
     "Column name `a` must not be duplicated."
   )
   expect_equal(
-    error_column_names_must_be_unique(letters[2:3], repair_hint = TRUE),
+    abort_column_names_must_be_unique(letters[2:3], repair_hint = TRUE),
     "Column names `b`, `c` must not be duplicated.\nUse .name_repair to specify repair."
   )
   expect_equal(
-    unell(error_column_names_must_be_unique(LETTERS, repair_hint = TRUE)),
+    unell(abort_column_names_must_be_unique(LETTERS, repair_hint = TRUE)),
     "Column names `A`, `B`, `C`, `D`, `E`, ... (and 21 more) must not be duplicated.\nUse .name_repair to specify repair."
   )
 })
 
-test_that("error_column_names_must_be_syntactic()", {
+test_that("abort_column_names_must_be_syntactic()", {
   expect_equal(
-    error_column_names_must_be_syntactic("a", repair_hint = FALSE),
+    abort_column_names_must_be_syntactic("a", repair_hint = FALSE),
     "Column name `a` must be syntactic."
   )
   expect_equal(
-    error_column_names_must_be_syntactic(letters[2:3], repair_hint = TRUE),
+    abort_column_names_must_be_syntactic(letters[2:3], repair_hint = TRUE),
     "Column names `b`, `c` must be syntactic.\nUse .name_repair to specify repair."
   )
   expect_equal(
-    unell(error_column_names_must_be_syntactic(LETTERS, repair_hint = TRUE)),
+    unell(abort_column_names_must_be_syntactic(LETTERS, repair_hint = TRUE)),
     "Column names `A`, `B`, `C`, `D`, `E`, ... (and 21 more) must be syntactic.\nUse .name_repair to specify repair."
   )
 })
 
-test_that("error_column_scalar_type()", {
+test_that("abort_column_scalar_type()", {
   expect_equal(
-    error_column_scalar_type("a", "environment"),
+    abort_column_scalar_type("a", "environment"),
     bullets(
       "All columns in a tibble must be 1d or 2d objects:",
       "Column `a` is environment"
@@ -225,7 +225,7 @@ test_that("error_column_scalar_type()", {
   )
 
   expect_equal(
-    error_column_scalar_type(letters[2:3], c("name", "NULL")),
+    abort_column_scalar_type(letters[2:3], c("name", "NULL")),
     bullets(
       "All columns in a tibble must be 1d or 2d objects:",
       "Column `b` is name",
@@ -234,7 +234,7 @@ test_that("error_column_scalar_type()", {
   )
 
   expect_equal(
-    error_column_scalar_type(LETTERS, letters),
+    abort_column_scalar_type(LETTERS, letters),
     bullets(
       "All columns in a tibble must be 1d or 2d objects:",
       paste0("Column `", LETTERS, "` is ", letters)
@@ -242,24 +242,24 @@ test_that("error_column_scalar_type()", {
   )
 })
 
-test_that("error_time_column_must_be_posixct()", {
+test_that("abort_time_column_must_be_posixct()", {
   expect_equal(
-    error_time_column_must_be_posixct("a"),
+    abort_time_column_must_be_posixct("a"),
     "Column `a` is a date/time and must be stored as POSIXct, not POSIXlt."
   )
   expect_equal(
-    error_time_column_must_be_posixct(letters[2:3]),
+    abort_time_column_must_be_posixct(letters[2:3]),
     "Columns `b`, `c` are dates/times and must be stored as POSIXct, not POSIXlt."
   )
   expect_equal(
-    unell(error_time_column_must_be_posixct(LETTERS)),
+    unell(abort_time_column_must_be_posixct(LETTERS)),
     "Columns `A`, `B`, `C`, `D`, `E`, ... (and 21 more) are dates/times and must be stored as POSIXct, not POSIXlt."
   )
 })
 
-test_that("error_inconsistent_cols()", {
+test_that("abort_inconsistent_cols()", {
   expect_equal(
-    error_inconsistent_cols(
+    abort_inconsistent_cols(
       10,
       letters[1:3],
       c(4, 4, 3),
@@ -274,7 +274,7 @@ test_that("error_inconsistent_cols()", {
   )
 
   expect_equal(
-    error_inconsistent_cols(
+    abort_inconsistent_cols(
       10,
       letters[1:3],
       c(2, 2, 3),
@@ -289,7 +289,7 @@ test_that("error_inconsistent_cols()", {
   )
 
   expect_equal(
-    error_inconsistent_cols(
+    abort_inconsistent_cols(
       NULL,
       letters[1:3],
       c(2, 2, 3),
@@ -303,9 +303,9 @@ test_that("error_inconsistent_cols()", {
   )
 })
 
-test_that("error_inconsistent_new_cols()", {
+test_that("abort_inconsistent_new_cols()", {
   expect_equal(
-    error_inconsistent_new_cols(10, data.frame(a = 1:2)),
+    abort_inconsistent_new_cols(10, data.frame(a = 1:2)),
     bullets(
       "New columns in `add_column()` must be consistent with `.data`:",
       "`.data` has 10 rows",
@@ -314,7 +314,7 @@ test_that("error_inconsistent_new_cols()", {
   )
 
   expect_equal(
-    error_inconsistent_new_cols(1, data.frame(a = 1:3, b = 2:4)),
+    abort_inconsistent_new_cols(1, data.frame(a = 1:3, b = 2:4)),
     bullets(
       "New columns in `add_column()` must be consistent with `.data`:",
       "`.data` has 1 row",
@@ -323,9 +323,9 @@ test_that("error_inconsistent_new_cols()", {
   )
 })
 
-test_that("error_duplicate_new_cols()", {
+test_that("abort_duplicate_new_cols()", {
   expect_equal(
-    error_duplicate_new_cols("a"),
+    abort_duplicate_new_cols("a"),
     bullets(
       "Can't add duplicate columns with `add_column()`:",
       "Column `a` already exists in `.data`."
@@ -333,7 +333,7 @@ test_that("error_duplicate_new_cols()", {
   )
 
   expect_equal(
-    error_duplicate_new_cols(letters[2:3]),
+    abort_duplicate_new_cols(letters[2:3]),
     bullets(
       "Can't add duplicate columns with `add_column()`:",
       "Columns `b`, `c` already exist in `.data`."
@@ -341,7 +341,7 @@ test_that("error_duplicate_new_cols()", {
   )
 
   expect_equal(
-    unell(error_duplicate_new_cols(LETTERS)),
+    unell(abort_duplicate_new_cols(LETTERS)),
     bullets(
       "Can't add duplicate columns with `add_column()`:",
       "Columns `A`, `B`, `C`, `D`, `E`, ... (and 21 more) already exist in `.data`."
@@ -349,44 +349,44 @@ test_that("error_duplicate_new_cols()", {
   )
 })
 
-test_that("error_both_before_after()", {
+test_that("abort_both_before_after()", {
   expect_equal(
-    error_both_before_after(),
+    abort_both_before_after(),
     "Can't specify both `.before` and `.after`."
   )
 })
 
-test_that("error_already_has_rownames()", {
+test_that("abort_already_has_rownames()", {
   expect_equal(
-    error_already_has_rownames(),
+    abort_already_has_rownames(),
     "`df` must be a data frame without row names in `column_to_rownames()`."
   )
 })
 
-test_that("error_already_has_rownames()", {
+test_that("abort_already_has_rownames()", {
   expect_equal(
-    error_as_tibble_needs_rownames(),
+    abort_as_tibble_needs_rownames(),
     "Object passed to `as_tibble()` must have row names if the `rownames` argument is set."
   )
 })
 
-test_that("error_glimpse_infinite_width()", {
+test_that("abort_glimpse_infinite_width()", {
   expect_equal(
-    error_glimpse_infinite_width(),
+    abort_glimpse_infinite_width(),
     "`glimpse()` requires a finite value for the `width` argument."
   )
 })
 
-test_that("error_tribble_needs_columns()", {
+test_that("abort_tribble_needs_columns()", {
   expect_equal(
-    error_tribble_needs_columns(),
+    abort_tribble_needs_columns(),
     "`tribble()` needs to specify at least one column using the `~name` syntax."
   )
 })
 
-test_that("error_tribble_lhs_column_syntax()", {
+test_that("abort_tribble_lhs_column_syntax()", {
   expect_equal(
-    error_tribble_lhs_column_syntax(quote(lhs)),
+    abort_tribble_lhs_column_syntax(quote(lhs)),
     bullets(
       "All column specifications in `tribble()` must use the `~name` syntax.",
       "Found `lhs` on the left-hand side of `~`."
@@ -394,9 +394,9 @@ test_that("error_tribble_lhs_column_syntax()", {
   )
 })
 
-test_that("error_tribble_rhs_column_syntax()", {
+test_that("abort_tribble_rhs_column_syntax()", {
   expect_equal(
-    error_tribble_rhs_column_syntax(quote(a + b)),
+    abort_tribble_rhs_column_syntax(quote(a + b)),
     bullets(
       'All column specifications in `tribble()` must use the `~name` or `~"name"` syntax.',
       "Found `a + b` on the right-hand side of `~`."
@@ -404,9 +404,9 @@ test_that("error_tribble_rhs_column_syntax()", {
   )
 })
 
-test_that("error_tribble_non_rectangular()", {
+test_that("abort_tribble_non_rectangular()", {
   expect_equal(
-    error_tribble_non_rectangular(5, 17),
+    abort_tribble_non_rectangular(5, 17),
     bullets(
       "`tribble()` must be used with rectangular data:",
       "Found 5 columns.",
@@ -416,9 +416,9 @@ test_that("error_tribble_non_rectangular()", {
   )
 })
 
-test_that("error_frame_matrix_list()", {
+test_that("abort_frame_matrix_list()", {
   expect_equal(
-    error_frame_matrix_list(2:4),
+    abort_frame_matrix_list(2:4),
     bullets(
       "All values in `frame_matrix()` must be atomic:",
       "Found list-valued elements at positions 2, 3, 4."
@@ -426,9 +426,9 @@ test_that("error_frame_matrix_list()", {
   )
 })
 
-test_that("error_name_repair_arg()", {
+test_that("abort_name_repair_arg()", {
   expect_equal(
-    error_name_repair_arg(),
+    abort_name_repair_arg(),
     "The `.name_repair` argument must be a string or a function that specifies the name repair strategy."
   )
 })
@@ -440,9 +440,9 @@ test_that("abort_new_tibble_must_be_list()", {
   )
 })
 
-test_that("error_new_tibble_needs_nrow()", {
+test_that("abort_new_tibble_needs_nrow()", {
   expect_equal(
-    error_new_tibble_needs_nrow(),
+    abort_new_tibble_needs_nrow(),
     "Must pass a scalar integer as `nrow` argument to `new_tibble()`."
   )
 })

--- a/tests/testthat/test-zzz-msg.R
+++ b/tests/testthat/test-zzz-msg.R
@@ -433,9 +433,9 @@ test_that("error_name_repair_arg()", {
   )
 })
 
-test_that("error_new_tibble_must_be_list()", {
+test_that("abort_new_tibble_must_be_list()", {
   expect_equal(
-    error_new_tibble_must_be_list(),
+    abort_new_tibble_must_be_list(),
     "Must pass a list as `x` argument to `new_tibble()`."
   )
 })

--- a/tests/testthat/test-zzz-name-repair.R
+++ b/tests/testthat/test-zzz-name-repair.R
@@ -3,7 +3,7 @@ test_that("minimal names are made from `n` when `name = NULL`", {
   expect_identical(minimal_names(NULL, 2), c("", ""))
   expect_error(
     minimal_names(NULL),
-    error_name_length_required(),
+    abort_name_length_required(),
     fixed = TRUE
   )
 })
@@ -21,12 +21,12 @@ test_that("set_minimal_names() copes with NULL input names", {
 test_that("check_minimal() errors when names aren't minimal", {
   expect_legacy_error(
     check_minimal(NULL),
-    error_names_must_be_non_null(repair_hint = FALSE),
+    abort_names_must_be_non_null(repair_hint = FALSE),
     fixed = TRUE
   )
   expect_legacy_error(
     check_minimal(c("a", NA)),
-    error_column_must_be_named(2, repair_hint = FALSE),
+    abort_column_must_be_named(2, repair_hint = FALSE),
     fixed = TRUE
   )
 })
@@ -76,13 +76,13 @@ test_that("unique_names() strips positional suffixes, re-applies as needed", {
 test_that("check_unique() imposes check_minimal()", {
   expect_legacy_error(
     check_unique(NULL),
-    error_names_must_be_non_null(repair_hint = FALSE),
+    abort_names_must_be_non_null(repair_hint = FALSE),
     fixed = TRUE
   )
 
   expect_legacy_error(
     check_unique(c("x", NA)),
-    error_column_must_be_named(2, repair_hint = FALSE),
+    abort_column_must_be_named(2, repair_hint = FALSE),
     fixed = TRUE
   )
 })
@@ -90,22 +90,22 @@ test_that("check_unique() imposes check_minimal()", {
 test_that("check_unique() errors for empty or duplicated names", {
   expect_legacy_error(
     check_unique(c("x", "")),
-    error_column_must_be_named(2, repair_hint = FALSE),
+    abort_column_must_be_named(2, repair_hint = FALSE),
     fixed = TRUE
   )
   expect_legacy_error(
     check_unique(c("", "x", "")),
-    error_column_must_be_named(c(1, 3), repair_hint = FALSE),
+    abort_column_must_be_named(c(1, 3), repair_hint = FALSE),
     fixed = TRUE
   )
   expect_legacy_error(
     check_unique(c("x", "x", "y")),
-    error_column_names_must_be_unique("x", repair_hint = FALSE),
+    abort_column_names_must_be_unique("x", repair_hint = FALSE),
     fixed = TRUE
   )
   expect_legacy_error(
     check_unique(c("x", "y", "x", "y")),
-    error_column_names_must_be_unique(c("x", "y"), repair_hint = FALSE),
+    abort_column_names_must_be_unique(c("x", "y"), repair_hint = FALSE),
     fixed = TRUE
   )
 })
@@ -170,7 +170,7 @@ test_that("names<-() and set_names() reject non-minimal names", {
   # https://github.com/tidyverse/tibble/issues/562
   expect_warning(
     set_names(df, NULL),
-    if (is_rstudio()) NA else error_names_must_be_non_null(),
+    if (is_rstudio()) NA else abort_names_must_be_non_null(),
     fixed = TRUE
   )
 })
@@ -182,25 +182,25 @@ test_that("names<-() and set_names() reject non-minimal names", {
 
   expect_legacy_warning(
     `names<-`(df, NA),
-    error_names_must_have_length(1, 3),
+    abort_names_must_have_length(1, 3),
     fixed = TRUE
   )
 
   expect_legacy_warning(
     `names<-`(df, ""),
-    error_names_must_have_length(1, 3),
+    abort_names_must_have_length(1, 3),
     fixed = TRUE
   )
 
   expect_legacy_warning(
     `names<-`(df, 1),
-    error_names_must_have_length(1, 3),
+    abort_names_must_have_length(1, 3),
     fixed = TRUE
   )
 
   expect_legacy_warning(
     `names<-`(df, 1:2),
-    error_names_must_have_length(2, 3),
+    abort_names_must_have_length(2, 3),
     fixed = TRUE
   )
 

--- a/tests/testthat/test-zzz-rownames.R
+++ b/tests/testthat/test-zzz-rownames.R
@@ -24,7 +24,7 @@ test_that("rownames_to_column keeps the tbl classes (#882)", {
   expect_equal(res$rowname, rownames(mtcars))
   expect_legacy_error(
     rownames_to_column(mtcars, "wt"),
-    error_existing_names("wt"),
+    abort_existing_names("wt"),
     fixed = TRUE
   )
 
@@ -36,7 +36,7 @@ test_that("rownames_to_column keeps the tbl classes (#882)", {
   expect_equal(res1$`Make&Model`, rownames(mtcars))
   expect_legacy_error(
     rownames_to_column(mtcars2, "wt"),
-    error_existing_names("wt"),
+    abort_existing_names("wt"),
     fixed = TRUE
   )
 })
@@ -48,7 +48,7 @@ test_that("rowid_to_column keeps the tbl classes", {
   expect_equal(res$rowid, seq_len(nrow(mtcars)))
   expect_legacy_error(
     rowid_to_column(mtcars, "wt"),
-    error_existing_names("wt"),
+    abort_existing_names("wt"),
     fixed = TRUE
   )
 
@@ -60,7 +60,7 @@ test_that("rowid_to_column keeps the tbl classes", {
   expect_equal(res1$row_id, seq_len(nrow(mtcars)))
   expect_legacy_error(
     rowid_to_column(mtcars2, "wt"),
-    error_existing_names("wt"),
+    abort_existing_names("wt"),
     fixed = TRUE
   )
 })
@@ -85,12 +85,12 @@ test_that("column_to_rownames returns tbl", {
   expect_equal(rownames(res), as.character(mtcars1$num))
   expect_legacy_error(
     column_to_rownames(res),
-    error_already_has_rownames(),
+    abort_already_has_rownames(),
     fixed = TRUE
   )
   expect_legacy_error(
     column_to_rownames(rownames_to_column(mtcars1, var), "num2"),
-    error_unknown_names("num2"),
+    abort_unknown_names("num2"),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-zzz-syntactic-names.R
+++ b/tests/testthat/test-zzz-syntactic-names.R
@@ -264,7 +264,7 @@ test_that("non-universal names", {
 test_that("check_syntactic() imposes check_minimal()", {
   expect_legacy_error(
     check_syntactic(NULL),
-    error_names_must_be_non_null(repair_hint = FALSE),
+    abort_names_must_be_non_null(repair_hint = FALSE),
     fixed = TRUE
   )
 })
@@ -272,7 +272,7 @@ test_that("check_syntactic() imposes check_minimal()", {
 test_that("check_syntactic() imposes check_unique()", {
   expect_legacy_error(
     check_syntactic(c("x", "x", "y")),
-    error_column_names_must_be_unique("x"),
+    abort_column_names_must_be_unique("x"),
     fixed = TRUE
   )
 })
@@ -280,7 +280,7 @@ test_that("check_syntactic() imposes check_unique()", {
 test_that("check_syntactic() errors for non-syntactic names", {
   expect_legacy_error(
     check_syntactic(c("x", "a:b", "break")),
-    error_column_names_must_be_syntactic(c("a:b", "break"), repair_hint = FALSE),
+    abort_column_names_must_be_syntactic(c("a:b", "break"), repair_hint = FALSE),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-zzz-tbl-df.R
+++ b/tests/testthat/test-zzz-tbl-df.R
@@ -61,34 +61,34 @@ test_that("[.tbl_df is careful about names (#1245)", {
   foo <- tibble(x = 1:10, y = 1:10)
   expect_legacy_error(
     foo["z"],
-    error_unknown_names("z"),
+    abort_unknown_names("z"),
     fixed = TRUE
   )
   expect_legacy_error(
     foo[c("x", "y", "z")],
-    error_unknown_names("z"),
+    abort_unknown_names("z"),
     fixed = TRUE
   )
 
   expect_legacy_error(
     foo[, "z"],
-    error_unknown_names("z"),
+    abort_unknown_names("z"),
     fixed = TRUE
   )
   expect_legacy_error(
     foo[, c("x", "y", "z")],
-    error_unknown_names("z"),
+    abort_unknown_names("z"),
     fixed = TRUE
   )
 
   expect_legacy_error(
     foo[as.matrix("x")],
-    error_dim_column_index(as.matrix("x")),
+    abort_dim_column_index(as.matrix("x")),
     fixed = TRUE
   )
   expect_legacy_error(
     foo[array("x", dim = c(1, 1, 1))],
-    error_dim_column_index(array("x", dim = c(1, 1, 1))),
+    abort_dim_column_index(array("x", dim = c(1, 1, 1))),
     fixed = TRUE
   )
 })
@@ -99,12 +99,12 @@ test_that("[.tbl_df is careful about column indexes (#83)", {
 
   expect_legacy_error(
     foo[0.5],
-    error_nonint_column_index(1, 0.5),
+    abort_nonint_column_index(1, 0.5),
     fixed = TRUE
   )
   expect_legacy_error(
     foo[1:5],
-    error_large_column_index(3, 4:5, 4:5),
+    abort_large_column_index(3, 4:5, 4:5),
     fixed = TRUE
   )
 
@@ -114,23 +114,23 @@ test_that("[.tbl_df is careful about column indexes (#83)", {
 
   expect_legacy_error(
     foo[-4],
-    error_small_column_index(3, 1, -4),
+    abort_small_column_index(3, 1, -4),
     fixed = TRUE
   )
   expect_legacy_error(
     foo[c(1:3, NA)],
-    error_na_column_index(),
+    abort_na_column_index(),
     fixed = TRUE
   )
 
   expect_legacy_error(
     foo[as.matrix(1)],
-    error_dim_column_index(as.matrix("x")),
+    abort_dim_column_index(as.matrix("x")),
     fixed = TRUE
   )
   expect_legacy_error(
     foo[array(1, dim = c(1, 1, 1))],
-    error_dim_column_index(array("x", dim = c(1, 1, 1))),
+    abort_dim_column_index(array("x", dim = c(1, 1, 1))),
     fixed = TRUE
   )
 })
@@ -144,28 +144,28 @@ test_that("[.tbl_df is careful about column flags (#83)", {
 
   expect_legacy_error(
     foo[c(TRUE, TRUE)],
-    error_mismatch_column_flag(3, 2),
+    abort_mismatch_column_flag(3, 2),
     fixed = TRUE
   )
   expect_legacy_error(
     foo[c(TRUE, TRUE, FALSE, FALSE)],
-    error_mismatch_column_flag(3, 4),
+    abort_mismatch_column_flag(3, 4),
     fixed = TRUE
   )
   expect_legacy_error(
     foo[c(TRUE, TRUE, NA)],
-    error_na_column_flag(),
+    abort_na_column_flag(),
     fixed = TRUE
   )
 
   expect_legacy_error(
     foo[as.matrix(TRUE)],
-    error_dim_column_index(as.matrix("x")),
+    abort_dim_column_index(as.matrix("x")),
     fixed = TRUE
   )
   expect_legacy_error(
     foo[array(TRUE, dim = c(1, 1, 1))],
-    error_dim_column_index(array("x", dim = c(1, 1, 1))),
+    abort_dim_column_index(array("x", dim = c(1, 1, 1))),
     fixed = TRUE
   )
 })
@@ -174,27 +174,27 @@ test_that("[.tbl_df rejects unknown column indexes (#83)", {
   foo <- tibble(x = 1:10, y = 1:10, z = 1:10)
   expect_legacy_error(
     foo[list(1:3)],
-    error_unsupported_index(list(1:3)),
+    abort_unsupported_index(list(1:3)),
     fixed = TRUE
   )
   expect_legacy_error(
     foo[as.list(1:3)],
-    error_unsupported_index(as.list(1:3)),
+    abort_unsupported_index(as.list(1:3)),
     fixed = TRUE
   )
   expect_legacy_error(
     foo[factor(1:3)],
-    error_unsupported_index(factor(1:3)),
+    abort_unsupported_index(factor(1:3)),
     fixed = TRUE
   )
   expect_legacy_error(
     foo[Sys.Date()],
-    error_unsupported_index(Sys.Date()),
+    abort_unsupported_index(Sys.Date()),
     fixed = TRUE
   )
   expect_legacy_error(
     foo[Sys.time()],
-    error_unsupported_index(Sys.time()),
+    abort_unsupported_index(Sys.time()),
     fixed = TRUE
   )
 })
@@ -432,12 +432,12 @@ test_that("new_tibble checks (2)", {
   expect_legacy_error(
     new_tibble(list(a = 1)),
     class = get_defunct_error_class(),
-    error_new_tibble_needs_nrow(),
+    abort_new_tibble_needs_nrow(),
     fixed = TRUE
   )
   expect_legacy_error(
     new_tibble(list(1), nrow = NULL),
-    error_new_tibble_needs_nrow(),
+    abort_new_tibble_needs_nrow(),
     fixed = TRUE
   )
 })
@@ -447,7 +447,7 @@ test_that("new_tibble checks (3)", {
 
   expect_legacy_error(
     new_tibble(list(1), nrow = 1),
-    error_names_must_be_non_null(repair_hint = FALSE),
+    abort_names_must_be_non_null(repair_hint = FALSE),
     fixed = TRUE
   )
   expect_error(
@@ -475,14 +475,14 @@ test_that("new_tibble checks (3)", {
 test_that("validate_tibble() checks", {
   expect_legacy_error(
     validate_tibble(new_tibble(list(a = 1, b = 2:3), nrow = 1)),
-    error_inconsistent_cols(1, c("a", "b"), 1:2, "`nrow` argument"),
+    abort_inconsistent_cols(1, c("a", "b"), 1:2, "`nrow` argument"),
     fixed = TRUE
   )
 
   skip_brk_inner_dim_not_stripped()
   expect_error(
     validate_tibble(new_tibble(list(a = array(1:3)), nrow = 3)),
-    error_1d_array_column(),
+    abort_1d_array_column(),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-zzz-tbl-df.R
+++ b/tests/testthat/test-zzz-tbl-df.R
@@ -419,7 +419,7 @@ test_that("new_tibble checks", {
   expect_identical(new_tibble(list(a = 1:3, b = 4:6), nrow = 3), tibble(a = 1:3, b = 4:6))
   expect_legacy_error(
     new_tibble(1:3, nrow = 1),
-    error_new_tibble_must_be_list(),
+    abort_new_tibble_must_be_list(),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-zzz-tribble.R
+++ b/tests/testthat/test-zzz-tribble.R
@@ -86,21 +86,21 @@ test_that("tribble() errs appropriately on bad calls", {
   # no colname
   expect_legacy_error(
     tribble(1, 2, 3),
-    error_tribble_needs_columns(),
+    abort_tribble_needs_columns(),
     fixed = TRUE
   )
 
   # invalid colname syntax
   expect_legacy_error(
     tribble(a ~ b),
-    error_tribble_lhs_column_syntax(quote(a)),
+    abort_tribble_lhs_column_syntax(quote(a)),
     fixed = TRUE
   )
 
   # invalid colname syntax
   expect_legacy_error(
     tribble(~ a + b),
-    error_tribble_rhs_column_syntax(quote(a + b)),
+    abort_tribble_rhs_column_syntax(quote(a + b)),
     fixed = TRUE
   )
 
@@ -119,7 +119,7 @@ test_that("tribble() errs appropriately on bad calls", {
       1, 2,
       3, 4, 5
     ),
-    error_tribble_non_rectangular(3, 5),
+    abort_tribble_non_rectangular(3, 5),
     fixed = TRUE
   )
 
@@ -129,7 +129,7 @@ test_that("tribble() errs appropriately on bad calls", {
       1, 2, 3, 4, 5,
       6, 7, 8, 9,
     ),
-    error_tribble_non_rectangular(4, 9),
+    abort_tribble_non_rectangular(4, 9),
     fixed = TRUE
   )
 })
@@ -193,7 +193,7 @@ test_that("frame_matrix cannot have list columns", {
       "a", 1:3,
       "b", 4:6
     ),
-    error_frame_matrix_list(c(2, 4)),
+    abort_frame_matrix_list(c(2, 4)),
     fixed = TRUE
   )
 })


### PR DESCRIPTION
Also call `abort()` directly, avoid handling condition objects.

This PR uses `my_caller_env()` from c147ebf704be92810bb074400b77a97a51b8e211 to automatically retrieve the calling environment for correct error locations. Is there any downside, compared to the recommended approach of passing `caller_env()` across the entire chain of calls?