### PR TITLE
docs: Update example for `nrow` argument to `new_tibble()`

### DIFF
--- a/R/new.R
+++ b/R/new.R
@@ -23,8 +23,8 @@
 #'
 #' @export
 #' @examples
-#' # The nrow argument is always required:
-#' new_tibble(list(a = 1:3, b = 4:6), nrow = 3)
+#' # The nrow argument can be omitted:
+#' new_tibble(list(a = 1:3, b = 4:6))
 #'
 #' # Existing row.names attributes are ignored:
 #' try(validate_tibble(new_tibble(trees, nrow = 3)))


### PR DESCRIPTION
`nrow` has been optional since eace1249dc8283e230273f8b46634c4ab43b863f.