### PR TITLE
docs: Use lambda in `across()` in vignette for compatibility with dplyr 1.1.0

### DIFF
--- a/tests/testthat/_snaps/vignette-numbers/numbers.md
+++ b/tests/testthat/_snaps/vignette-numbers/numbers.md
@@ -108,7 +108,7 @@ markets
 #> 10 1992. 1646. 1716. 1754. 2497.
 #> # ... with 1,850 more rows
 markets %>%
-  mutate(across(-time, num, digits = 3))
+  mutate(across(-time, ~ num(.x, digits = 3)))
 #> # A tibble: 1,860 x 5
 #>     time       DAX       SMI       CAC      FTSE
 #>    <dbl> <num:.3!> <num:.3!> <num:.3!> <num:.3!>

--- a/vignettes/numbers.Rmd
+++ b/vignettes/numbers.Rmd
@@ -79,7 +79,7 @@ markets <-
 
 markets
 markets %>%
-  mutate(across(-time, num, digits = 3))
+  mutate(across(-time, ~ num(.x, digits = 3)))
 ```
 
 ## Computing on `num`


### PR DESCRIPTION
to work around vignette message.