### PR TITLE
feat: `as.data.frame.tbl_df()` supports a character vector in the `row.names` argument

### DIFF
--- a/R/rownames.R
+++ b/R/rownames.R
@@ -122,3 +122,13 @@ raw_rownames <- function(x) {
 abort_already_has_rownames <- function() {
   tibble_abort("`.data` must be a data frame without row names.")
 }
+
+abort_character_rownames <- function() {
+  tibble_abort("`row.names` must be a character vector.")
+}
+
+abort_inconsistent_rownames <- function(bad, nrow) {
+  tibble_abort(paste0(
+    "`row.names` must have length ", nrow, ", not ", bad, "."
+  ))
+}

--- a/R/tbl_df.R
+++ b/R/tbl_df.R
@@ -74,6 +74,15 @@ as.data.frame.tbl_df <- function(x, row.names = NULL, optional = FALSE, ...) {
   unname <- which(!map_lgl(x, is_bare_list))
   x[unname] <- map(.subset(x, unname), vectbl_set_names, NULL)
   class(x) <- "data.frame"
+  if (!is.null(row.names)) {
+    if (!is_bare_character(row.names)) {
+      abort_character_rownames()
+    }
+    if (length(row.names) != nrow(x)) {
+      abort_inconsistent_rownames(length(row.names), nrow(x))
+    }
+    attr(x, "row.names") <- row.names
+  }
   x
 }
 

--- a/tests/testthat/test-tbl_df.R
+++ b/tests/testthat/test-tbl_df.R
@@ -26,6 +26,22 @@ test_that("as.data.frame() keeps zero-column data frames and matrices (#970)", {
   expect_identical(as.data.frame(mat)$y, mat$y)
 })
 
+test_that("as.data.frame() allows row names", {
+  df <- tibble(a = 1:3)
+  expect_identical(
+    as.data.frame(df, row.names = letters[1:3]),
+    vctrs::new_data_frame(list(a = 1:3), row.names = letters[1:3])
+  )
+  expect_tibble_abort(
+    as.data.frame(df, row.names = 1:3),
+    abort_character_rownames()
+  )
+  expect_tibble_abort(
+    as.data.frame(df, row.names = letters[1:2]),
+    abort_inconsistent_rownames(2, 3)
+  )
+})
+
 test_that("names<-()", {
   new_tbl <- function(...) {
     data <- list(1, "b")


### PR DESCRIPTION
Closes #1202.