### PR TITLE
fix: `new_tibble()` and `as_tibble()` support attributes named `"n"` and `"x"`

### DIFF
--- a/R/as_tibble.R
+++ b/R/as_tibble.R
@@ -115,7 +115,8 @@ lst_to_tibble <- function(x, .rows, .name_repair, lengths = NULL, call = caller_
   x <- unclass(x)
   x <- set_repaired_names(x, repair_hint = TRUE, .name_repair, call = call)
   x <- check_valid_cols(x, call = call)
-  recycle_columns(x, .rows, lengths)
+  x <- recycle_columns(x, .rows, lengths)
+  x
 }
 
 check_valid_cols <- function(x, pos = NULL, call = caller_env()) {

--- a/R/new.R
+++ b/R/new.R
@@ -92,15 +92,28 @@ new_tibble <- function(x, ..., nrow = NULL, class = NULL, subclass = NULL) {
     class <- c(class[!class %in% tibble_class], tibble_class_no_data_frame)
   }
 
-  slots <- c("x", "n", "class")
-  args[slots] <- list(x, nrow, class)
-
   # `new_data_frame()` restores compact row names
   # Can't add to the assignment above, a literal NULL would be inserted otherwise
   args[["row.names"]] <- NULL
 
+  # Attributes n and x are special and must be assigned after construction
+  an <- args[["n"]]
+  ax <- args[["x"]]
+  args[["n"]] <- NULL
+  args[["x"]] <- NULL
+
   # need exec() to avoid evaluating language attributes (e.g. rsample)
-  exec(new_data_frame, !!!args)
+  out <- exec(new_data_frame, x = x, n = nrow, !!!args, class = class)
+
+  if (!is.null(an)) {
+    attr(out, "n") <- an
+  }
+
+  if (!is.null(ax)) {
+    attr(out, "x") <- ax
+  }
+
+  out
 }
 
 #' @description

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,24 +1,23 @@
 # Revdeps
 
-## Failed to check (11)
+## Failed to check (8)
 
 |package          |version |error |warning |note |
 |:----------------|:-------|:-----|:-------|:----|
-|bulkreadr        |?       |      |        |     |
-|dplyr            |?       |      |        |     |
-|historicalborrow |?       |      |        |     |
-|LexisNexisTools  |?       |      |        |     |
-|matrixset        |?       |      |        |     |
-|NMsim            |?       |      |        |     |
-|RevGadgets       |?       |      |        |     |
-|simaerep         |?       |      |        |     |
-|simTool          |?       |      |        |     |
-|tidyposterior    |?       |      |        |     |
-|workflowsets     |?       |      |        |     |
+|bigrquerystorage |1.1.0   |1     |        |     |
+|ctsem            |3.9.1   |1     |        |     |
+|EcoEnsemble      |1.0.5   |1     |        |     |
+|glmmfields       |0.1.8   |1     |        |     |
+|loon.tourr       |?       |      |        |     |
+|multinma         |0.6.1   |1     |        |     |
+|treestats        |1.0.5   |1     |        |     |
+|triptych         |0.1.2   |1     |        |     |
 
-## New problems (1)
+## New problems (3)
 
-|package |version |error  |warning |note |
-|:-------|:-------|:------|:-------|:----|
-|[NMdata](problems.md#nmdata)|0.1.2   |__+1__ |        |     |
+|package         |version |error  |warning |note     |
+|:---------------|:-------|:------|:-------|:--------|
+|[covidcast](problems.md#covidcast)|0.5.2   |__+1__ |        |1 __+1__ |
+|[LexisNexisTools](problems.md#lexisnexistools)|0.3.7   |__+1__ |        |         |
+|[NMdata](problems.md#nmdata)|0.1.5   |__+1__ |        |         |
 

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,15 +1,32 @@
 ## revdepcheck results
 
-We checked 14 reverse dependencies (3 from CRAN + 11 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 2057 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
 
- * We saw 1 new problems
- * We failed to check 0 packages
+ * We saw 3 new problems
+ * We failed to check 8 packages
 
 Issues with CRAN packages are summarised below.
 
 ### New problems
 (This reports the first line of each new failure)
 
+* covidcast
+  checking running R code from vignettes ... ERROR
+  checking re-building of vignette outputs ... NOTE
+
+* LexisNexisTools
+  checking tests ... ERROR
+
 * NMdata
   checking tests ... ERROR
 
+### Failed to check
+
+* bigrquerystorage (NA)
+* ctsem            (NA)
+* EcoEnsemble      (NA)
+* glmmfields       (NA)
+* loon.tourr       (NA)
+* multinma         (NA)
+* treestats        (NA)
+* triptych         (NA)

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -1,12 +1,174 @@
+# covidcast
+
+<details>
+
+* Version: 0.5.2
+* GitHub: https://github.com/cmu-delphi/covidcast
+* Source code: https://github.com/cran/covidcast
+* Date/Publication: 2023-07-12 23:40:06 UTC
+* Number of recursive dependencies: 93
+
+Run `revdepcheck::cloud_details(, "covidcast")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking running R code from vignettes ... ERROR
+    ```
+    Errors in running code in vignettes:
+    when running code in ‘multi-signals.Rmd’
+      ...
+    
+    > signals <- covidcast_signals(data_source = "jhu-csse", 
+    +     signal = c("confirmed_7dav_incidence_prop", "deaths_7dav_incidence_prop"), 
+    +     star .... [TRUNCATED] 
+    
+      When sourcing ‘multi-signals.R’:
+    Error: Rate limit exceeded when fetching data from API anonymously. See the "API keys" section of the `covidcast_signal()` documentation for information on registering for an API key.
+    ℹ Message from server:
+    ℹ Rate limit exceeded for anonymous queries. To remove this limit, register a free API key at https://api.delphi.cmu.edu/epidata/admin/registration_form
+    Execution halted
+    when running code in ‘plotting-signals.Rmd’
+      ...
+    server maintenance, and new features.
+    
+    > dv <- covidcast_signal(data_source = "doctor-visits", 
+    +     signal = "smoothed_adj_cli", start_day = "2020-07-01", end_day = "2020-07-14")
+    
+      When sourcing ‘plotting-signals.R’:
+    Error: Rate limit exceeded when fetching data from API anonymously. See the "API keys" section of the `covidcast_signal()` documentation for information on registering for an API key.
+    ℹ Message from server:
+    ℹ Rate limit exceeded for anonymous queries. To remove this limit, register a free API key at https://api.delphi.cmu.edu/epidata/admin/registration_form
+    Execution halted
+    
+      ‘correlation-utils.Rmd’ using ‘UTF-8’... OK
+      ‘covidcast.Rmd’ using ‘UTF-8’... OK
+      ‘external-data.Rmd’ using ‘UTF-8’... OK
+      ‘multi-signals.Rmd’ using ‘UTF-8’... failed
+      ‘plotting-signals.Rmd’ using ‘UTF-8’... failed
+    ```
+
+*   checking re-building of vignette outputs ... NOTE
+    ```
+    Error(s) in re-building vignettes:
+    --- re-building ‘correlation-utils.Rmd’ using rmarkdown
+    --- finished re-building ‘correlation-utils.Rmd’
+    
+    --- re-building ‘covidcast.Rmd’ using rmarkdown
+    
+    Quitting from lines  at lines 38-45 [unnamed-chunk-1] (covidcast.Rmd)
+    Error: processing vignette 'covidcast.Rmd' failed with diagnostics:
+    Rate limit exceeded when fetching data from API anonymously. See the "API keys" section of the `covidcast_signal()` documentation for information on registering for an API key.
+    ℹ Message from server:
+    ℹ Rate limit exceeded for anonymous queries. To remove this limit, register a free API key at https://api.delphi.cmu.edu/epidata/admin/registration_form
+    --- failed re-building ‘covidcast.Rmd’
+    
+    --- re-building ‘external-data.Rmd’ using rmarkdown
+    ```
+
+## In both
+
+*   checking data for non-ASCII characters ... NOTE
+    ```
+      Note: found 20 marked UTF-8 strings
+    ```
+
+# LexisNexisTools
+
+<details>
+
+* Version: 0.3.7
+* GitHub: https://github.com/JBGruber/LexisNexisTools
+* Source code: https://github.com/cran/LexisNexisTools
+* Date/Publication: 2023-07-05 13:33:03 UTC
+* Number of recursive dependencies: 119
+
+Run `revdepcheck::cloud_details(, "LexisNexisTools")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking tests ... ERROR
+    ```
+      Running ‘spelling.R’
+      Running ‘testthat.R’
+    Running the tests in ‘tests/testthat.R’ failed.
+    Complete output:
+      > library("testthat")
+      > library("LexisNexisTools")
+      LexisNexisTools Version 0.3.7
+      Warning messages:
+      1: In .recacheSubclasses(def@className, def, env) :
+        undefined subclass "ndiMatrix" of class "replValueSp"; definition not updated
+      2: In .recacheSubclasses(def@className, def, env) :
+        undefined subclass "pcorMatrix" of class "replValueSp"; definition not updated
+      3: In .recacheSubclasses(def@className, def, env) :
+        undefined subclass "ndiMatrix" of class "replValueSp"; definition not updated
+      4: In .recacheSubclasses(def@className, def, env) :
+        undefined subclass "pcorMatrix" of class "replValueSp"; definition not updated
+      > 
+      > test_check("LexisNexisTools")
+      
+        |                                                  | 0 % ~calculating  
+        |+++++                                             | 10% ~00s          
+        |++++++++++                                        | 20% ~00s          
+        |+++++++++++++++                                   | 30% ~00s          
+        |++++++++++++++++++++                              | 40% ~00s          
+        |+++++++++++++++++++++++++                         | 50% ~00s          
+        |++++++++++++++++++++++++++++++                    | 60% ~00s          
+        |+++++++++++++++++++++++++++++++++++               | 70% ~00s          
+        |++++++++++++++++++++++++++++++++++++++++          | 80% ~00s          
+        |+++++++++++++++++++++++++++++++++++++++++++++     | 90% ~00s          
+        |++++++++++++++++++++++++++++++++++++++++++++++++++| 100% elapsed=00s  
+      [ FAIL 2 | WARN 0 | SKIP 3 | PASS 96 ]
+      
+      ══ Skipped tests (3) ═══════════════════════════════════════════════════════════
+      • !dir.exists("/home/johannes/Dropbox/LexisNexis_sample_files/") is TRUE (1):
+        'test-lnt_read_uni.R:23:3'
+      • On CRAN (2): 'test-lnt_convert.R:149:3', 'test-lnt_read_uni.R:33:3'
+      
+      ══ Failed tests ════════════════════════════════════════════════════════════════
+      ── Failure ('test-lnt_read.R:7:3'): Read in sample file ────────────────────────
+      {
+          ...
+      } not equal to readRDS("../files/LNToutput.RDS").
+      Attributes: < Component "paragraphs": Attributes: < Names: 2 string mismatches > >
+      Attributes: < Component "paragraphs": Attributes: < Length mismatch: comparison on first 2 components > >
+      Attributes: < Component "paragraphs": Attributes: < Component 1: Modes: character, externalptr > >
+      Attributes: < Component "paragraphs": Attributes: < Component 1: Lengths: 3, 1 > >
+      Attributes: < Component "paragraphs": Attributes: < Component 1: target is character, current is externalptr > >
+      Attributes: < Component "paragraphs": Attributes: < Component 2: Modes: numeric, character > >
+      Attributes: < Component "paragraphs": Attributes: < Component 2: Lengths: 122, 3 > >
+      Attributes: < Component "paragraphs": Attributes: < Component 2: target is numeric, current is character > >
+      ── Failure ('test-lnt_read.R:14:3'): Read in sample file ───────────────────────
+      {
+          ...
+      } not equal to readRDS("../files/LNToutput.RDS").
+      Attributes: < Component "paragraphs": Attributes: < Names: 2 string mismatches > >
+      Attributes: < Component "paragraphs": Attributes: < Length mismatch: comparison on first 2 components > >
+      Attributes: < Component "paragraphs": Attributes: < Component 1: Modes: character, externalptr > >
+      Attributes: < Component "paragraphs": Attributes: < Component 1: Lengths: 3, 1 > >
+      Attributes: < Component "paragraphs": Attributes: < Component 1: target is character, current is externalptr > >
+      Attributes: < Component "paragraphs": Attributes: < Component 2: Modes: numeric, character > >
+      Attributes: < Component "paragraphs": Attributes: < Component 2: Lengths: 122, 3 > >
+      Attributes: < Component "paragraphs": Attributes: < Component 2: target is numeric, current is character > >
+      
+      [ FAIL 2 | WARN 0 | SKIP 3 | PASS 96 ]
+      Error: Test failures
+      Execution halted
+    ```
+
 # NMdata
 
 <details>
 
-* Version: 0.1.2
+* Version: 0.1.5
 * GitHub: https://github.com/philipdelff/NMdata
 * Source code: https://github.com/cran/NMdata
-* Date/Publication: 2023-10-19 07:10:09 UTC
-* Number of recursive dependencies: 84
+* Date/Publication: 2024-02-21 08:10:02 UTC
+* Number of recursive dependencies: 80
 
 Run `revdepcheck::cloud_details(, "NMdata")` for more info
 
@@ -22,19 +184,53 @@ Run `revdepcheck::cloud_details(, "NMdata")` for more info
     Complete output:
       > library(testthat)
       > library(NMdata)
-      NMdata 0.1.2. Browse NMdata documentation at
+      NMdata 0.1.5. Browse NMdata documentation at
       https://philipdelff.github.io/NMdata/
       > 
       > test_check("NMdata")
-    ...
+      
+      Overview of model scanning results:
+                                  lst nrows ncols success warning
+                               <char> <int> <int>  <lgcl>  <lgcl>
+      1: testData/nonmem//xgxr001.lst   905    40    TRUE   FALSE
+      2: testData/nonmem//xgxr002.lst   905    34    TRUE   FALSE
+      3: testData/nonmem//xgxr003.lst   905    34    TRUE   FALSE
+      4: testData/nonmem//xgxr004.lst   731    35    TRUE   FALSE
+      5: testData/nonmem//xgxr005.lst   447    35    TRUE   FALSE
+      6: testData/nonmem//xgxr006.lst   893    35    TRUE   FALSE
+      7: testData/nonmem//xgxr007.lst   893    35    TRUE   FALSE
+      8: testData/nonmem//xgxr008.lst   893    35    TRUE   FALSE
+      9: testData/nonmem//xgxr009.lst   131    35    TRUE   FALSE
+      Error in (function (data, drop, col.flagn = "FLAG", rename, copy, file,  : 
+        drop cannot contain empty strings and NA's.
+      Table written to testOutput/flagsCount_5.csv
+         variable Nmissing
+           <fctr>    <int>
+      1:       DV      150
+      [ FAIL 1 | WARN 3 | SKIP 1 | PASS 271 ]
+      
+      ══ Skipped tests (1) ═══════════════════════════════════════════════════════════
+      • empty test (1): 'test_flagsCount.R:6:1'
+      
+      ══ Failed tests ════════════════════════════════════════════════════════════════
+      ── Failure ('test_NMscanData.R:449:5'): use as.fun to get a tibble ─────────────
+      `res1` has changed from known value recorded in 'testReference/NMscanData_18.rds'.
+      Attributes: < Names: 3 string mismatches >
+      Attributes: < Length mismatch: comparison on first 3 components >
+      Attributes: < Component 1: Modes: list, externalptr >
+      Attributes: < Component 1: Lengths: 6, 1 >
+      Attributes: < Component 1: names for target but not for current >
+      Attributes: < Component 1: current is not list-like >
+      Attributes: < Component 2: Modes: character, list >
+      Attributes: < Component 2: Lengths: 4, 6 >
       Attributes: < Component 2: names for current but not for target >
       ...
       Backtrace:
           ▆
-       1. └─testthat::expect_equal_to_reference(res1, fileRef, version = 2) at test_NMscanData.R:449:4
+       1. └─testthat::expect_equal_to_reference(res1, fileRef, version = 2) at test_NMscanData.R:449:5
        2.   └─testthat::expect_known_value(..., update = update)
       
-      [ FAIL 1 | WARN 0 | SKIP 1 | PASS 255 ]
+      [ FAIL 1 | WARN 3 | SKIP 1 | PASS 271 ]
       Error: Test failures
       Execution halted
     ```

--- a/tests/testthat/test-new.R
+++ b/tests/testthat/test-new.R
@@ -63,6 +63,23 @@ test_that("new_tibble() supports missing `nrow` (#781)", {
   expect_identical(new_tibble(list(a = 1:3)), tibble(a = 1:3))
 })
 
+test_that("new_tibble() keeps x and n attributes", {
+  expect_identical(
+    attr(new_tibble(list(x = 1), n = 2, nrow = 1), "n"),
+    2
+  )
+
+  expect_identical(
+    attr(new_tibble(structure(list(x = 1), n = 2), nrow = 1), "n"),
+    2
+  )
+
+  expect_identical(
+    attr(new_tibble(structure(list(x = 1), x = "value"), nrow = 1), "x"),
+    "value"
+  )
+})
+
 test_that("new_tibble() supports language objects", {
   expect_identical(
     new_tibble(list(), foo = quote(bar())),


### PR DESCRIPTION
Closes #1573.