### PR TITLE
chore: Drop fansi and import cli

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ BugReports: https://github.com/tidyverse/tibble/issues
 Depends: 
     R (>= 3.4.0)
 Imports: 
-    fansi (>= 0.4.0),
+    cli,
     lifecycle (>= 1.0.0),
     magrittr,
     methods,
@@ -45,7 +45,6 @@ Suggests:
     blob,
     brio,
     callr,
-    cli,
     DiagrammeR,
     dplyr,
     evaluate,

--- a/R/ansi.R
+++ b/R/ansi.R
@@ -1,5 +1,5 @@
 # nocov start - https://github.com/tidyverse/tibble/blob/main/R/ansi.R
-set_ansi_hooks <- function() {
+set_fansi_hooks <- function() {
   knitr::opts_chunk$set(collapse = TRUE)
 
   if (Sys.getenv("IN_GALLEY") != "") {

--- a/R/ansi.R
+++ b/R/ansi.R
@@ -1,5 +1,5 @@
-# nocov start - https://github.com/tidyverse/tibble/blob/main/R/fansi.R
-set_fansi_hooks <- function() {
+# nocov start - https://github.com/tidyverse/tibble/blob/main/R/ansi.R
+set_ansi_hooks <- function() {
   knitr::opts_chunk$set(collapse = TRUE)
 
   if (Sys.getenv("IN_GALLEY") != "") {
@@ -23,13 +23,6 @@ set_fansi_hooks <- function() {
 }
 
 colourise_chunk <- function(type) {
-  # Fallback if fansi is missing
-  if (is_installed("fansi")) {
-    sgr_to_html <- fansi::sgr_to_html
-  } else {
-    sgr_to_html <- identity
-  }
-
   function(x, options) {
     # lines <- strsplit(x, "\\n")[[1]]
     lines <- x
@@ -39,7 +32,7 @@ colourise_chunk <- function(type) {
     paste0(
       '<div class="sourceCode"><pre class="sourceCode"><code class="sourceCode">',
       paste0(
-        sgr_to_html(htmltools::htmlEscape(lines)),
+        cli::ansi_html(htmltools::htmlEscape(lines)),
         collapse = "\n"
       ),
       "</code></pre></div>"


### PR DESCRIPTION
to go with https://github.com/r-lib/pillar/pull/663

What is the implication for support inside knitr? 

I saw this https://rpubs.com/krlmlr/pillar-focus

Could `set_ansi_hooks()` be baked in somehow?

Currently, there is no highlighting of code, except for hugodown and pkgdown. 
https://tibble.tidyverse.org/articles/tibble.html  and https://www.tidyverse.org/blog/2023/08/teach-tidyverse-23/#conflict-resolution-in-the-tidyverse

Rmarkdown and Quarto show dull colors in output  https://github.com/quarto-dev/quarto-cli/issues/3730

For example https://r4ds.hadley.nz/logicals#comparisons 

Relates to https://github.com/tidyverse/tibble/issues/475

The PR doesn't break highlighting in pkgdown
![image](https://github.com/tidyverse/tibble/assets/52606734/f8e037b8-aa76-405f-a1b9-c1802a0a09ed)

https://github.com/hadley/r4ds/issues/1027