### PR TITLE
docs: Use pak for installing dev version in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -37,8 +37,8 @@ install.packages("tidyverse")
 install.packages("tibble")
 
 # Or the the development version from GitHub:
-# install.packages("devtools")
-devtools::install_github("tidyverse/tibble")
+# install.packages("pak")
+pak::pak("tidyverse/tibble")
 ```
 
 ## Usage


### PR DESCRIPTION
replaced devtools w/ pak.

did not render the readme because `downlit::readme_document` is not exported anywhere (see this [relevant issue](https://github.com/cynkra/fledge/pull/121) in `flegde`, which is also present in a few other tidyverse readmes such as [duckplyr](https://github.com/tidyverse/duckplyr/issues/254))
