### PR TITLE
feat: Rework `view()` to better work with RStudio and Positron

### DIFF
--- a/R/view.R
+++ b/R/view.R
@@ -65,7 +65,7 @@ view_with_coercion <- function(x, n, title, fn) {
 
   if (nrow(x) > n) {
     message("Showing the first ", n, " rows.")
-    x <- x[seq_len(n), , drop = FALSE]
+    x <- vec_slice(x, seq_len(n))
   }
 
   # Since we just created `x`, there won't be anything for

--- a/R/view.R
+++ b/R/view.R
@@ -24,7 +24,7 @@
 view <- function(x, title = NULL, ..., n = NULL) {
   check_dots_empty()
 
-  if (!rlang::is_interactive()) {
+  if (!is_interactive()) {
     return(invisible(x))
   }
 
@@ -65,7 +65,7 @@ view_with_coercion <- function(x, n, title, fn) {
 
   if (nrow(x) > n) {
     message("Showing the first ", n, " rows.")
-    x <- head(x, n)
+    x <- x[seq_len(n), , drop = FALSE]
   }
 
   # Since we just created `x`, there won't be anything for


### PR DESCRIPTION
Closes https://github.com/tidyverse/tibble/issues/1551 (while I was here, I may as well...)

In RStudio and Positron, when `View(foo)` is called, we check if `foo` exists as a symbol bound in the parent environment. If it does, we can "track" the lifetime of that object and auto update the data viewer when the user makes changes to it. This doesn't work with `view()`

https://github.com/user-attachments/assets/b2c7d809-2bc3-400e-8b14-5b93ed0b9aa7

This is because in `view()` we were actually _inlining_ the whole data frame object, rather than the expression the user typed in. So RStudio and Positron can't find anything to "track". This was also causing issues in Positron too actually (the inlined data frame could overwhelm us) https://github.com/posit-dev/positron/issues/4702.

@lionel- and I thought about this a bit and came up with an approach where we capture the user input to `view()` and use that to reconstruct an equivalent call to `View()` that we call in the parent environment. This mimics the idea of the user calling `View(foo)` directly in the global environment, so that RStudio/Positron can "track" `foo` correctly.

- In the case that `x` isn't a data frame, we don't do any of this. We "make" `x` into a data frame ourselves, so RStudio and Positron won't have anything to "track" in these cases so we don't do anything special
- In the case that `x` is a data frame but comes from something like `view(cbind(foo, foo))`, we do the fancy thing to recall this as `View()` in the parent frame, which works fine, but of course RStudio and Positron still won't have anything to track because this is an ephemeral object. This is expected.

It works like this now:

https://github.com/user-attachments/assets/a9415a07-717d-4600-b6b0-0457db5e8f72


https://github.com/user-attachments/assets/18890dcf-fa79-411c-95ec-0c717fc06283




---

Side note, how do you add news bullets in tibble?