### PR TITLE
feat: Hard deprecate `trunc_mat()`

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -102,7 +102,7 @@ format.tbl_df <- function(x, width = NULL, ..., n = NULL, max_extra_cols = NULL,
 #' @export
 #' @keywords internal
 trunc_mat <- function(x, n = NULL, width = NULL, n_extra = NULL) {
-  deprecate_soft("3.1.0", "tibble::trunc_mat()",
+  deprecate_stop("3.3.0", "tibble::trunc_mat()",
     details = "Printing has moved to the pillar package."
   )
 


### PR DESCRIPTION
Closes #960.

With @moodymudskipper.