### PR TITLE
fix: subset tibble with `"0"` for row index

### DIFF
--- a/src/coerce.c
+++ b/src/coerce.c
@@ -10,7 +10,7 @@ static long long string_to_int64(const char* x) {
   long long xi = strtoll(x, &px, 10);
   if (*px) return LLONG_MIN;
   if (xi == LLONG_MAX) return LLONG_MIN;
-  if (xi < 0) return LLONG_MIN;
+  if (xi < 1) return LLONG_MIN;
   return xi;
 }
 

--- a/tests/testthat/test-string-to-indices.R
+++ b/tests/testthat/test-string-to-indices.R
@@ -1,5 +1,6 @@
 test_that("works as expected", {
   expect_identical(string_to_indices(as.character(1:3)), 1:3)
+  expect_identical(string_to_indices(as.character(0:2)), c(NA_integer_, 1L, 2L))
   expect_identical(string_to_indices(letters[1:3]), rep(NA_integer_, 3))
   expect_identical(string_to_indices(as.character(1:3 + 1e10)), 1:3 + 1e10)
   expect_identical(string_to_indices(c(as.character(1:3 + 1e10), "x")), c(1:3 + 1e10, NA))

--- a/tests/testthat/test-subsetting.R
+++ b/tests/testthat/test-subsetting.R
@@ -55,6 +55,24 @@ test_that("[ with 0 cols returns correct number of rows", {
   expect_equal(nrow(trees_tbl[-(1:10), 0]), nrow_trees - 10)
 })
 
+test_that("[ with '0' for rows works correctly (#1636)", {
+  simple_tbl <- tibble(a = 1:3)
+  simple_df <- data.frame(a = 1:3)
+
+  expect_identical(
+    simple_tbl["0", ],
+    as_tibble(simple_df["0", , drop = FALSE])
+  )
+  expect_identical(
+    simple_tbl[as.character(0:1), ],
+    as_tibble(simple_df[as.character(0:1), , drop = FALSE])
+  )
+  expect_identical(
+    simple_tbl[as.character(-1:0), ],
+    as_tibble(simple_df[as.character(-1:0), , drop = FALSE])
+  )
+})
+
 test_that("[ with explicit NULL works as expected (#696)", {
   trees_tbl <- as_tibble(trees)
 

--- a/tests/testthat/test-subsetting.R
+++ b/tests/testthat/test-subsetting.R
@@ -60,15 +60,15 @@ test_that("[ with '0' for rows works correctly (#1636)", {
   simple_df <- data.frame(a = 1:3)
 
   expect_identical(
-    simple_tbl["0", ],
+    suppressWarnings(simple_tbl["0", ]),
     as_tibble(simple_df["0", , drop = FALSE])
   )
   expect_identical(
-    simple_tbl[as.character(0:1), ],
+    suppressWarnings(simple_tbl[as.character(0:1), ]),
     as_tibble(simple_df[as.character(0:1), , drop = FALSE])
   )
   expect_identical(
-    simple_tbl[as.character(-1:0), ],
+    suppressWarnings(simple_tbl[as.character(-1:0), ]),
     as_tibble(simple_df[as.character(-1:0), , drop = FALSE])
   )
 })


### PR DESCRIPTION
Fix #1636