### PR TITLE
fledge: CRAN release v3.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tibble
 Title: Simple Data Frames
-Version: 3.2.1.9900
+Version: 3.3.0
 Authors@R: 
     c(person(given = "Kirill",
              family = "M\u00fcller",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# tibble 3.2.1.9900
+# tibble 3.3.0
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,7 +34,7 @@
 
 - Skip tests if packages are missing.
 
-- Override :: to avoid failures in tests without suggested packages.
+- Override `::` to avoid failures in tests without suggested packages.
 
 
 # tibble 3.2.1

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-tibble 3.2.1.9900
+tibble 3.3.0
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-06-07, problems found: https://cran.r-project.org/web/checks/check_results_tibble.html
- [ ] NOTE: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-windows-x86_64, r-patched-linux-x86_64, r-release-linux-x86_64, r-release-windows-x86_64
     Found the following Rd file(s) with Rd \link{} targets missing package
     anchors:
     deprecated.Rd: quasiquotation
     formatting.Rd: tbl_format_setup
     frame_matrix.Rd: !!, !!!, quasiquotation
     lst.Rd: !!, !!!, .data, .env
     subsetting.Rd: vec_slice
     tibble.Rd: !!, !!!, .data, .env, quasiquotation
     tribble.Rd: !!, !!!, quasiquotation
     Please provide package anchors for all Rd \link{} targets not in the
     package itself and the base packages.
- [ ] NOTE: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-linux-x86_64-fedora-clang, r-devel-linux-x86_64-fedora-gcc, r-patched-linux-x86_64, r-release-linux-x86_64, r-release-macos-arm64, r-release-macos-x86_64
     File ‘tibble/libs/tibble.so’:
     Found non-API calls to R: ‘IS_S4_OBJECT’, ‘OBJECT’, ‘SET_S4_OBJECT’
     
     Compiled code should not call non-API entry points in R.
     
     See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual,
     and section ‘Moving into C API compliance’ for issues with the use of
     non-API entry points.
- [ ] NOTE: r-devel-windows-x86_64, r-release-windows-x86_64
     File 'tibble/libs/x64/tibble.dll':
     Found non-API calls to R: 'IS_S4_OBJECT', 'OBJECT', 'SET_S4_OBJECT'
     
     Compiled code should not call non-API entry points in R.
     
     See 'Writing portable packages' in the 'Writing R Extensions' manual,
     and section 'Moving into C API compliance' for issues with the use of
     non-API entry points.

Check results at: https://cran.r-project.org/web/checks/check_results_tibble.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`