### PR TITLE
Namespace-qualify rlang::local_options() in tests

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -11,17 +11,12 @@ colon_colon <- `::`
   )
 }
 
+
+rlang::local_options(
+  warnPartialMatchAttr = TRUE,
+  warnPartialMatchDollar = TRUE,
+  .frame = testthat::teardown_env()
+)
 if (getRversion() >= "3.6") {
-  local_options(
-    warnPartialMatchArgs = TRUE,
-    warnPartialMatchAttr = TRUE,
-    warnPartialMatchDollar = TRUE,
-    .frame = testthat::teardown_env()
-  )
-} else {
-  local_options(
-    warnPartialMatchAttr = TRUE,
-    warnPartialMatchDollar = TRUE,
-    .frame = testthat::teardown_env()
-  )
+  rlang::local_options(warnPartialMatchArgs = TRUE)
 }

--- a/tests/testthat/test-add.R
+++ b/tests/testthat/test-add.R
@@ -176,7 +176,7 @@ test_that("can add new column", {
 })
 
 test_that("add_column() works with 0-col tibbles (#786)", {
-  local_options(lifecycle_verbosity = "error")
+  rlang::local_options(lifecycle_verbosity = "error")
 
   expect_identical(
     add_column(new_tibble(list(), nrow = 1), a = 1),


### PR DESCRIPTION
Currently, `library(tibble); testthat::test_file('third_party/R/packages/tibble/tibble/tests/testthat/test-as_tibble.R')` fails for me on not finding this function.

IINM, what's going on is in "normal" testthat suite runs, the package namespace will be attached, and hence `import(rlang)` will do its job. I'm not quite sure why that hasn't happened for me under `test_file()`, but it does seem helpful not to assume upstream packages are available, anyway.