### PR TITLE
docs: fix typos and grammar errors in roxygen documentation

### DIFF
--- a/R/add.R
+++ b/R/add.R
@@ -2,7 +2,7 @@
 #'
 #' @description
 #' This is a convenient way to add one or more rows of data to an existing data
-#' frame. See [tribble()] for an easy way to create an complete
+#' frame. See [tribble()] for an easy way to create a complete
 #' data frame row-by-row. Use [tibble_row()] to ensure that the new data
 #' has only one row.
 #'

--- a/R/new.R
+++ b/R/new.R
@@ -2,7 +2,7 @@
 #'
 #' @description
 #' Creates or validates a subclass of a tibble.
-#' These function is mostly useful for package authors that implement subclasses
+#' This function is mostly useful for package authors that implement subclasses
 #' of a tibble, like \pkg{sf} or \pkg{tsibble}.
 #'
 #' `new_tibble()` creates a new object as a subclass of `tbl_df`, `tbl` and `data.frame`.

--- a/R/rownames.R
+++ b/R/rownames.R
@@ -8,7 +8,7 @@
 #' Generally, it is best to avoid row names, because they are basically a
 #' character column with different semantics than every other column.
 #'
-#' These functions allow to you detect if a data frame has row names
+#' These functions allow you to detect if a data frame has row names
 #' (`has_rownames()`), remove them (`remove_rownames()`), or convert
 #' them back-and-forth between an explicit column (`rownames_to_column()`
 #' and `column_to_rownames()`).

--- a/R/tbl_df.R
+++ b/R/tbl_df.R
@@ -47,7 +47,7 @@ setOldClass(c("tbl_df", "tbl", "data.frame"))
 #'   Empty and duplicated column names are strongly discouraged, but the user
 #'   must indicate how to resolve. Read more in [vctrs::vec_as_names()].
 #' * Row names are not added and are strongly discouraged, in favor of storing
-#'   that info as a column. Read about in [rownames].
+#'   that info as a column. Read more in [rownames].
 #' * `df[, j]` returns a tibble; it does not automatically extract the column
 #'   inside. `df[, j, drop = FALSE]` is the default. Read more in [subsetting].
 #' * There is no partial matching when `$` is used to index by name. `df$name`

--- a/R/tibble.R
+++ b/R/tibble.R
@@ -21,7 +21,7 @@
 #'     refer to columns created earlier in the call. Only columns of length one
 #'     are recycled.
 #'   * If a column evaluates to a data frame or tibble, it is nested or spliced.
-#'     If it evaluates to a matrix or a array, it remains a matrix or array,
+#'     If it evaluates to a matrix or an array, it remains a matrix or array,
 #'     respectively.
 #'     See examples.
 #'
@@ -61,7 +61,7 @@
 #'   `enframe()` to convert a named vector into a tibble. Name repair is
 #'   detailed in [vctrs::vec_as_names()].
 #'   See [quasiquotation] for more details on tidy dots semantics,
-#'   i.e. exactly how  the `...` argument is processed.
+#'   i.e. exactly how the `...` argument is processed.
 #' @export
 #' @examples
 #' # Unnamed arguments are named with their expression:

--- a/R/tribble.R
+++ b/R/tribble.R
@@ -13,7 +13,7 @@
 #' @return A [tibble].
 #' @seealso
 #'   See [quasiquotation] for more details on tidy dots semantics,
-#'   i.e. exactly how  the `...` argument is processed.
+#'   i.e. exactly how the `...` argument is processed.
 #' @export
 #' @examples
 #' tribble(
@@ -62,7 +62,7 @@ tribble <- function(...) {
 #' @return A [matrix].
 #' @seealso
 #'   See [quasiquotation] for more details on tidy dots semantics,
-#'   i.e. exactly how  the `...` argument is processed.
+#'   i.e. exactly how the `...` argument is processed.
 #' @export
 #' @examples
 #' frame_matrix(

--- a/man/add_row.Rd
+++ b/man/add_row.Rd
@@ -20,7 +20,7 @@ default: after last row.}
 }
 \description{
 This is a convenient way to add one or more rows of data to an existing data
-frame. See \code{\link[=tribble]{tribble()}} for an easy way to create an complete
+frame. See \code{\link[=tribble]{tribble()}} for an easy way to create a complete
 data frame row-by-row. Use \code{\link[=tibble_row]{tibble_row()}} to ensure that the new data
 has only one row.
 

--- a/man/frame_matrix.Rd
+++ b/man/frame_matrix.Rd
@@ -31,5 +31,5 @@ frame_matrix(
 }
 \seealso{
 See \link[rlang:quasiquotation]{quasiquotation} for more details on tidy dots semantics,
-i.e. exactly how  the \code{...} argument is processed.
+i.e. exactly how the \code{...} argument is processed.
 }

--- a/man/new_tibble.Rd
+++ b/man/new_tibble.Rd
@@ -22,7 +22,7 @@ validate_tibble(x)
 }
 \description{
 Creates or validates a subclass of a tibble.
-These function is mostly useful for package authors that implement subclasses
+This function is mostly useful for package authors that implement subclasses
 of a tibble, like \pkg{sf} or \pkg{tsibble}.
 
 \code{new_tibble()} creates a new object as a subclass of \code{tbl_df}, \code{tbl} and \code{data.frame}.

--- a/man/rownames.Rd
+++ b/man/rownames.Rd
@@ -37,7 +37,7 @@ to a tibble.
 Generally, it is best to avoid row names, because they are basically a
 character column with different semantics than every other column.
 
-These functions allow to you detect if a data frame has row names
+These functions allow you to detect if a data frame has row names
 (\code{has_rownames()}), remove them (\code{remove_rownames()}), or convert
 them back-and-forth between an explicit column (\code{rownames_to_column()}
 and \code{column_to_rownames()}).

--- a/man/tbl_df-class.Rd
+++ b/man/tbl_df-class.Rd
@@ -53,7 +53,7 @@ Read more in \code{\link[vctrs:vec_recycle]{vctrs::vec_recycle()}}.
 Empty and duplicated column names are strongly discouraged, but the user
 must indicate how to resolve. Read more in \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}}.
 \item Row names are not added and are strongly discouraged, in favor of storing
-that info as a column. Read about in \link{rownames}.
+that info as a column. Read more in \link{rownames}.
 \item \code{df[, j]} returns a tibble; it does not automatically extract the column
 inside. \code{df[, j, drop = FALSE]} is the default. Read more in \link{subsetting}.
 \item There is no partial matching when \code{$} is used to index by name. \code{df$name}

--- a/man/tibble.Rd
+++ b/man/tibble.Rd
@@ -77,7 +77,7 @@ transforming the user's input.
 refer to columns created earlier in the call. Only columns of length one
 are recycled.
 \item If a column evaluates to a data frame or tibble, it is nested or spliced.
-If it evaluates to a matrix or a array, it remains a matrix or array,
+If it evaluates to a matrix or an array, it remains a matrix or array,
 respectively.
 See examples.
 }
@@ -189,5 +189,5 @@ Use \code{\link[=as_tibble]{as_tibble()}} to turn an existing object into a tibb
 \code{enframe()} to convert a named vector into a tibble. Name repair is
 detailed in \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}}.
 See \link[rlang:quasiquotation]{quasiquotation} for more details on tidy dots semantics,
-i.e. exactly how  the \code{...} argument is processed.
+i.e. exactly how the \code{...} argument is processed.
 }

--- a/man/tribble.Rd
+++ b/man/tribble.Rd
@@ -51,5 +51,5 @@ tribble(
 }
 \seealso{
 See \link[rlang:quasiquotation]{quasiquotation} for more details on tidy dots semantics,
-i.e. exactly how  the \code{...} argument is processed.
+i.e. exactly how the \code{...} argument is processed.
 }


### PR DESCRIPTION
## Summary

Fixes several typos and grammar errors in tibble's roxygen documentation:

| File | Issue | Fix |
|------|-------|-----|
| R/add.R | Wrong article | "an complete" -> "a complete" |
| R/tibble.R | Wrong article | "a array" -> "an array" |
| R/tibble.R | Double space | "how  the" -> "how the" |
| R/tribble.R | Double space (x2) | "how  the" -> "how the" |
| R/tbl_df.R | Incomplete phrase | "Read about in" -> "Read more in" |
| R/rownames.R | Swapped words | "allow to you" -> "allow you to" |
| R/new.R | Subject-verb agreement | "These function is" -> "This function is" |

## Validation

- tools::checkRd() passes on all 7 modified .Rd files
- R CMD check --no-manual --no-tests --no-vignettes --no-examples passes (Status: OK)
- Man pages regenerated with roxygen2::roxygenise()
